### PR TITLE
fix(scripts): fix binlog.index not found (#22)

### DIFF
--- a/install_scripts/install.sh
+++ b/install_scripts/install.sh
@@ -1,5 +1,5 @@
 mkdir -p data/innodb
-#mkdir binlog
+mkdir binlog
 mkdir log
 mkdir tmp
 


### PR DESCRIPTION
## Summary
fix binlog.index not found during install.

## Changelog
- Bug Fix
