### PR TITLE
upgrade(index): Add the code for upgrading rocksdb-4.13 to rocksdb-6.12.6.(#10)

### DIFF
--- a/storage/stonedb/index/kv_store.cpp
+++ b/storage/stonedb/index/kv_store.cpp
@@ -45,12 +45,11 @@ void KVStore::Init() {
   db_option.statistics = rocksdb::CreateDBStatistics();
   // get column family names from manfest file
   rocksdb::Status status = rocksdb::DB::ListColumnFamilies(db_option, rocksdb_datadir, &cf_names);
- //if (!status.ok() && status.subcode() == rocksdb::Status::kNone) {
- if (!status.ok() && ((status.subcode() == rocksdb::Status::kNone) || (status.subcode() == rocksdb::Status::kPathNotFound)) )
- {
-    STONEDB_LOG(LogCtl_Level::INFO, "First init rocksdb, create default cloum family");
-    cf_names.push_back(DEFAULT_CF_NAME);
- }
+  if (!status.ok() && ((status.subcode() == rocksdb::Status::kNone) || (status.subcode() == rocksdb::Status::kPathNotFound)) )
+  {
+      STONEDB_LOG(LogCtl_Level::INFO, "First init rocksdb, create default cloum family");
+      cf_names.push_back(DEFAULT_CF_NAME);
+  }
 
   rocksdb::ColumnFamilyOptions rs_cf_option(options);
   rocksdb::ColumnFamilyOptions index_cf_option(options);

--- a/storage/stonedb/index/kv_store.cpp
+++ b/storage/stonedb/index/kv_store.cpp
@@ -45,10 +45,12 @@ void KVStore::Init() {
   db_option.statistics = rocksdb::CreateDBStatistics();
   // get column family names from manfest file
   rocksdb::Status status = rocksdb::DB::ListColumnFamilies(db_option, rocksdb_datadir, &cf_names);
-  if (!status.ok() && status.subcode() == rocksdb::Status::kNone) {
+ //if (!status.ok() && status.subcode() == rocksdb::Status::kNone) {
+ if (!status.ok() && ((status.subcode() == rocksdb::Status::kNone) || (status.subcode() == rocksdb::Status::kPathNotFound)) )
+ {
     STONEDB_LOG(LogCtl_Level::INFO, "First init rocksdb, create default cloum family");
     cf_names.push_back(DEFAULT_CF_NAME);
-  }
+ }
 
   rocksdb::ColumnFamilyOptions rs_cf_option(options);
   rocksdb::ColumnFamilyOptions index_cf_option(options);


### PR DESCRIPTION
<!--

Thank you for contributing to StoneDB!

PR Title Format: <type>(<scope>): description to this pr (#issue_id)
e.g.
fix(util): fix sth..... (#1)

-->
upgrade(index): Add the code for upgrading rocksdb-4.13 to rocksdb-6.12.6(#10 )

   During initialization, the MANIFEST file of rocksdb is checked to obtain the column family name, but the CURENT file that stores the MANIFEST log in the initial state does not exist, and the error code of IOERROR is returned. The corresponding subcode of IOERROR returned by rocksdb4.13 is kNone, rocksdb6.12.6 Version IOERROR adds a subcode of kPathNotFound.
Stonedb judged that there is only kNone, so it did not go through the process of creating the default column family, resulting in "Default column family not specified" and subsequent errors. 
including:
            1: Add the "rocksdb::Status::kPathNotFound" judgment process of subcode to create a default column family file to solve the problem of initialization failure.
## Summary about this PR
<!--

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".
e.g.:
Issue: close #1

-->

Issue Number: close #10 


## Tests Check List
<!-- At least one of next options must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code

## Changelog
<!-- At least one of next options must be included. -->

- [ ] New Feature
- [x] Bug Fix
- [ ] Improvement
- [ ] Performance Improvement
- [ ] Build/Testing/CI/CD
- [ ] Documentation
- [ ] Not for changelog (changelog entry is not required)

## Documentation
<!-- At least one of next options must be included. -->

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
