### PR TITLE
feat(innodb): To support compiling innodb as C++ 17(#374)

### DIFF
--- a/storage/innobase/include/univ.i
+++ b/storage/innobase/include/univ.i
@@ -415,7 +415,7 @@ mysql_com.h if you are to use this macro. */
 */
 
 /* Note that inside MySQL 'byte' is defined as char on Linux! */
-#define byte			unsigned char
+using byte = unsigned char;
 
 /* Another basic type we use is unsigned long integer which should be equal to
 the word size of the machine, that is on a 32-bit platform 32 bits, and on a

--- a/storage/innobase/include/ut0new.h
+++ b/storage/innobase/include/ut0new.h
@@ -898,7 +898,7 @@ ut_delete_array(
 		ptr, n_bytes, __FILE__))
 
 #define ut_free(ptr)	ut_allocator<byte>(PSI_NOT_INSTRUMENTED).deallocate( \
-	reinterpret_cast<byte*>(ptr))
+	reinterpret_cast<::byte*>(ptr))
 
 #else /* UNIV_PFS_MEMORY */
 


### PR DESCRIPTION
To support innodb is compiled as C++ 17. For now, tianmu is compiling as C++17,
and C++17 has became mainstream of C++ standard. Therefore, now, we star to support
to compile Innodb as C++17 in stonedb.

This is backport from MySQL, which commit id is: 1a8a111d8f855a31d0aeffc8f02309b2b82dd410 and bug# is #32907274

<!--

Thank you for contributing to StoneDB!

PR Title Format: <type>(<scope>): description to this pr (#issue_id)
e.g.
fix(util): fix sth..... (#1)

-->

## Summary about this PR
<!--

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".
e.g.:
Issue: close #1

-->

Issue Number: close #374


## Tests Check List
<!-- At least one of next options must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

## Changelog
<!-- At least one of next options must be included. -->

- [ ] New Feature
- [ ] Bug Fix
- [ ] Improvement
- [ ] Performance Improvement
- [ ] Build/Testing/CI/CD
- [ ] Documentation
- [ ] Not for changelog (changelog entry is not required)

## Documentation
<!-- At least one of next options must be included. -->

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
