### PR TITLE
feat(stonedb8.0:load binlog): support mysql load binlog. (#530)

### DIFF
--- a/sql/sql_load.h
+++ b/sql/sql_load.h
@@ -118,7 +118,7 @@ class Sql_cmd_load_table final : public Sql_cmd {
 
   bool read_xml_field(THD *thd, COPY_INFO &info, TABLE_LIST *table_list,
                       READ_INFO &read_info, ulong skip_lines);
-
+public: // stonedb8
   bool write_execute_load_query_log_event(
       THD *thd, const char *db, const char *table_name, bool is_concurrent,
       enum enum_duplicates duplicates, bool transactional_table, int errocode);

--- a/storage/tianmu/handler/ha_rcengine.cpp
+++ b/storage/tianmu/handler/ha_rcengine.cpp
@@ -28,7 +28,7 @@ namespace dbhandler {
 enum class TIANMUEngineReturnValues { LD_Successed = 100, LD_Failed = 101, LD_Continue = 102 };
 
 void TIANMU_UpdateAndStoreColumnComment(TABLE *table, int field_id, Field *source_field, int source_field_id,
-                                     CHARSET_INFO *cs) {
+                                        CHARSET_INFO *cs) {
   try {
     ha_rcengine_->UpdateAndStoreColumnComment(table, field_id, source_field, source_field_id, cs);
   } catch (std::exception &e) {
@@ -72,14 +72,14 @@ bool TIANMU_SetStatementAllowed(THD *thd, LEX *lex) {
 }
 
 int TIANMU_HandleSelect(THD *thd, LEX *lex, Query_result *&result, ulong setup_tables_done_option, int &res,
-                     int &optimize_after_tianmu, int &tianmu_free_join, int with_insert=false) {
+                        int &optimize_after_tianmu, int &tianmu_free_join, int with_insert ) {
   int ret = RCBASE_QUERY_ROUTE;
   try {
     // handle_select_ret is introduced here because in case of some exceptions
     // (e.g. thrown from ForbiddenMySQLQueryPath) we want to return
     // RCBASE_QUERY_ROUTE
-    int handle_select_ret = ha_rcengine_->HandleSelect(thd, lex, result, setup_tables_done_option, res, optimize_after_tianmu,
-                                                tianmu_free_join, with_insert);
+    int handle_select_ret = ha_rcengine_->HandleSelect(thd, lex, result, setup_tables_done_option, res,
+                                                       optimize_after_tianmu, tianmu_free_join, with_insert);
     if (handle_select_ret == RETURN_QUERY_TO_MYSQL_ROUTE && AtLeastOneTIANMUTableInvolved(lex) &&
         ForbiddenMySQLQueryPath(lex)) {
       my_message(static_cast<int>(common::ErrorCode::UNKNOWN_ERROR),
@@ -99,7 +99,8 @@ Either restructure the query with supported syntax, or enable the MySQL core::Qu
   return ret;
 }
 
-int TIANMU_LoadData(THD *thd, sql_exchange *ex, TABLE_LIST *table_list, void *arg, char *errmsg, int len, int &errcode) {
+int TIANMU_LoadData(THD *thd, sql_exchange *ex, TABLE_LIST *table_list, void *arg, char *errmsg, int len,
+                    int &errcode) {
   common::TIANMUError tianmu_error;
   int ret = static_cast<int>(TIANMUEngineReturnValues::LD_Failed);
 
@@ -129,7 +130,8 @@ int TIANMU_LoadData(THD *thd, sql_exchange *ex, TABLE_LIST *table_list, void *ar
 bool tianmu_load(THD *thd, sql_exchange *ex, TABLE_LIST *table_list, void *arg) {
   char tianmumsg[256];
   int tianmu_errcode;
-  switch (static_cast<TIANMUEngineReturnValues>(TIANMU_LoadData(thd, ex, table_list, arg, tianmumsg, 256, tianmu_errcode))) {
+  switch (static_cast<TIANMUEngineReturnValues>(
+      TIANMU_LoadData(thd, ex, table_list, arg, tianmumsg, 256, tianmu_errcode))) {
     case TIANMUEngineReturnValues::LD_Continue:
       return true;
     case TIANMUEngineReturnValues::LD_Failed:


### PR DESCRIPTION
* use Sql_cmd_load_table::write_execute_load_query_log_event function to write mysql log binlog.

<!--

Thank you for contributing to StoneDB!

PR Title Format: <type>(<scope>): description to this pr (#issue_id)
e.g.
fix(util): fix sth..... (#1)

-->

## Summary about this PR
<!--

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".
e.g.:
Issue: close #1

-->

Issue Number: close #530

mysql load sql is executed, the binary log shoud be written to the binary log file.

the binlog format is the same with the noraml, it is better to use the wrapper function "write_execute_load_query_log_event".
the function is a private memeber of Sql_cmd_load_table, change the private to public, and use the function in tianmu's RCTable::binlog_load_query_log_event.

## Tests Check List
<!-- At least one of next options must be included. -->

- [ ] Unit test
- [ ] Integration test
- [X] Manual test (add detailed scripts or steps below)
- [ ] No code

## Changelog
<!-- At least one of next options must be included. -->

- [X] New Feature
- [ ] Bug Fix
- [ ] Improvement
- [ ] Performance Improvement
- [ ] Build/Testing/CI/CD
- [ ] Documentation
- [ ] Not for changelog (changelog entry is not required)

## Documentation
<!-- At least one of next options must be included. -->

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
