### PR TITLE
feat(stonedb8.0): mysql load sql with set clause should report warning. (#551)

### DIFF
--- a/storage/tianmu/core/engine.cpp
+++ b/storage/tianmu/core/engine.cpp
@@ -1729,19 +1729,25 @@ common::TIANMUError Engine::GetRejectFileIOParameters(THD &thd, std::unique_ptr<
 }
 
 common::TIANMUError Engine::GetIOP(std::unique_ptr<system::IOParameters> &io_params, THD &thd, sql_exchange &ex,
-                                TABLE *table, void *arg, bool for_exporter) {
+                                   TABLE *table, void *arg, bool for_exporter) {
   const CHARSET_INFO *cs = ex.cs;
-  bool local_load = false; // for_exporter ? false : (bool)(thd.lex)->local_file; // stonedb8 TODO: mysql_load
-  uint value_list_elements = 0; // (thd.lex)->load_value_list.elements; // stonedb8 TODO: mysql_load
-  // thr_lock_type lock_option = (thd.lex)->lock_option;
+  // stonedb8 start
+  bool local_load = false;
+  uint value_list_elements = 0;
 
+  if (!for_exporter) {
+    auto cmd = down_cast<Sql_cmd_load_table *>(thd.lex->m_sql_cmd);
+    local_load = cmd->m_is_local_file;
+    value_list_elements = cmd->m_opt_set_exprs.size();
+  }
+  // stonedb8 end
   int io_mode = -1;
-  char name[FN_REFLEN];
-  char *tdb = 0;
+  char name[FN_REFLEN] = {0};
+  char *tdb = nullptr;
   if (table) {
-    tdb = table->s->db.str ? (char*)table->s->db.str : (char*)thd.db().str;
+    tdb = table->s->db.str ? const_cast<char*>(table->s->db.str) : const_cast<char*>(thd.db().str);
   } else
-    tdb = (char*)thd.db().str;
+    tdb = const_cast<char*>(thd.db().str);
 
   io_params = CreateIOParameters(&thd, table, arg);
   short sign, minutes;


### PR DESCRIPTION
<!--

Thank you for contributing to StoneDB!

PR Title Format: <type>(<scope>): description to this pr (#issue_id)
e.g.
fix(util): fix sth..... (#1)

-->

## Summary about this PR
<!--

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".
e.g.:
Issue: close #1

-->

Issue Number: close #551
warns when execute the sql as below:
`LOAD DATA INFILE '/data/1.txt' Into TABLE tmp_loaddata2 FIELDS TERMINATED BY ','(id,name) set id2 =3 ;`

## Tests Check List
<!-- At least one of next options must be included. -->

- [ ] Unit test
- [ ] Integration test
- [X] Manual test (add detailed scripts or steps below)
- [ ] No code

## Changelog
<!-- At least one of next options must be included. -->

- [X] New Feature
- [ ] Bug Fix
- [ ] Improvement
- [ ] Performance Improvement
- [ ] Build/Testing/CI/CD
- [ ] Documentation
- [ ] Not for changelog (changelog entry is not required)

## Documentation
<!-- At least one of next options must be included. -->

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
