### PR TITLE
fix(mergify): fix incorrect lable name PR-Docs to PR-docs #564

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -7,7 +7,7 @@ pull_request_rules:
   - name: automatic merge of hotfix (high priority)
     conditions:
       - "#approved-reviews-by>=2"
-      - label=A-bug
+      - label=PR-bug
       - label!=PR-docs
       - check-success=stonedb-build
     actions:
@@ -18,8 +18,8 @@ pull_request_rules:
   - name: put other pr to merge queue
     conditions:
       - "#approved-reviews-by>=2"
-      - label!=A-bug
-      - label!=PR-Docs
+      - label!=PR-bug
+      - label!=PR-docs
       - check-success=stonedb-build
     actions:
       queue:
@@ -29,7 +29,7 @@ pull_request_rules:
   - name: put docs to merge queue
     conditions:
       - "#approved-reviews-by>=2"
-      - label=PR-Docs
+      - label=PR-docs
     actions:
       queue:
         name: shared_queue

--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -8,7 +8,7 @@ pull_request_rules:
     conditions:
       - "#approved-reviews-by>=2"
       - label=A-bug
-      - label!=PR-Docs
+      - label!=PR-docs
       - check-success=stonedb-build
     actions:
       queue:


### PR DESCRIPTION
<!--

Thank you for contributing to StoneDB!

PR Title Format: <type>(<scope>): description to this pr (#issue_id)
e.g.
fix(util): fix sth..... (#1)

-->

## Summary about this PR
<!--

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".
e.g.:
Issue: close #1

-->
In mergify.yml, the lable name is not correct, fix `PR-Docs` ---> `PR-docs`.
Also, we use pr lable ,not issue lable.

Issue Number: close #564


## Tests Check List
<!-- At least one of next options must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code

## Changelog
<!-- At least one of next options must be included. -->

- [ ] New Feature
- [x] Bug Fix
- [ ] Improvement
- [ ] Performance Improvement
- [ ] Build/Testing/CI/CD
- [ ] Documentation
- [ ] Not for changelog (changelog entry is not required)

## Documentation
<!-- At least one of next options must be included. -->

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
