### PR TITLE
feat(StoneDB 8.0): parent_lex->result is nullptr in "select ... from" clause without "into outfile/dumpfile". (#557)

### DIFF
--- a/storage/tianmu/core/engine.cpp
+++ b/storage/tianmu/core/engine.cpp
@@ -1609,23 +1609,19 @@ const char *Engine::GetFilename(Query_block *selects_list, int &is_dumpfile) {  
   // maybe 'select into DUMPFILE' if the function returns NULL it was a regular
   // 'select' don't look into is_dumpfile in this case
 
-  // stonedb8 start
+  if(selects_list->parent_lex->result == nullptr) {
+    return nullptr;
+  }
+
   auto exchange =
       static_cast<Query_result_to_file *>(selects_list->parent_lex->result)->get_sql_exchange();
+
   if (exchange) {
     is_dumpfile = exchange->dumpfile;
     return exchange->file_name;
   }
 
-  /* MySQL 5.7.36
-  if (selects_list->parent_lex->exchange) {
-    is_dumpfile = selects_list->parent_lex->exchange->dumpfile;
-    return selects_list->parent_lex->exchange->file_name;
-  }
-   */
-  // stonedb8 end
-
-  return 0;
+  return nullptr;
 }
 
 std::unique_ptr<system::IOParameters> Engine::CreateIOParameters(const std::string &path, void *arg) {


### PR DESCRIPTION
[summary]
1 "SELECT ... INTO OUTFILE/DUMPFILE",parent_lex->result is not nullptr;
 2 "SELECT ... FORM ",normal clause,parent_lex->result is nullptr; 
3 parent_lex->result can be used to check the dumpfile,just to check null value;

<!--

Thank you for contributing to StoneDB!

PR Title Format: <type>(<scope>): description to this pr (#issue_id)
e.g.
fix(util): fix sth..... (#1)

-->

## Summary about this PR
<!--

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".
e.g.:
Issue: close #1

-->

Issue Number: close #557
```
 auto exchange =
      static_cast<Query_result_to_file *>(selects_list->parent_lex->result)->get_sql_exchange();
  if (exchange) {
    is_dumpfile = exchange->dumpfile;
    return exchange->file_name;
  }
```
1 "SELECT ... INTO OUTFILE/DUMPFILE",parent_lex->result is not nullptr;
 2 "SELECT ... FORM ",normal clause,parent_lex->result is nullptr; 
3 parent_lex->result can be used to check the dumpfile,just to check null value;

## Tests Check List
<!-- At least one of next options must be included. -->

- [ ] Unit test
- [ ] Integration test
- [X] Manual test (add detailed scripts or steps below)
- [ ] No code

## Changelog
<!-- At least one of next options must be included. -->

- [X] New Feature
- [ ] Bug Fix
- [ ] Improvement
- [ ] Performance Improvement
- [ ] Build/Testing/CI/CD
- [ ] Documentation
- [ ] Not for changelog (changelog entry is not required)

## Documentation
<!-- At least one of next options must be included. -->

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
