### PR TITLE
    fix(tianmu): The current version does not enable multithreaded aggregation optimization (#567)

### DIFF
--- a/storage/tianmu/core/aggregation_algorithm.cpp
+++ b/storage/tianmu/core/aggregation_algorithm.cpp
@@ -194,7 +194,7 @@ void AggregationAlgorithm::Aggregate(bool just_distinct, int64_t &limit, int64_t
     }
   } else {
     int64_t local_limit = limit == -1 ? upper_approx_of_groups : limit;
-    MultiDimensionalGroupByScan(gbw, local_limit, offset, sender, limit_less_than_no_groups, true);
+    MultiDimensionalGroupByScan(gbw, local_limit, offset, sender, limit_less_than_no_groups, false);
     if (limit != -1) limit = local_limit;
   }
   t->ClearMultiIndexP();  // cleanup (i.e. regarded as materialized,


### PR DESCRIPTION
    The current version does not enable multithreaded aggregation optimization,
    Here's why:
    Currently, for multi-thread parallel,
    it is not completely carried out to the physical layer,
    for DPN and PACK data structure,
    because the underlying physical block processing for multi-thread from the data structure support is missing,
    when a multi-thread switch occurs,
    the data that has been read out is reset.
    More time is needed to support parallel read IO across multiple threads from the underlying data structures,
    which is not available in the current version,
    so we plan to start the second phase of the multi-thread read IO process completely.

<!--

Thank you for contributing to StoneDB!

PR Title Format: <type>(<scope>): description to this pr (#issue_id)
e.g.
fix(util): fix sth..... (#1)

-->

## Summary about this PR
<!--

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".
e.g.:
Issue: close #1

-->

Issue Number: close #567 


## Tests Check List
<!-- At least one of next options must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

## Changelog
<!-- At least one of next options must be included. -->

- [ ] New Feature
- [ ] Bug Fix
- [x] Improvement
- [ ] Performance Improvement
- [ ] Build/Testing/CI/CD
- [ ] Documentation
- [ ] Not for changelog (changelog entry is not required)

## Documentation
<!-- At least one of next options must be included. -->

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
