### PR TITLE
feat(StoneDB 8.0): thd->no_errors no_errors is deleted. (#574)

### DIFF
--- a/storage/tianmu/handler/tianmu_handler_com.cpp
+++ b/storage/tianmu/handler/tianmu_handler_com.cpp
@@ -122,7 +122,7 @@ int rcbase_commit([[maybe_unused]] handlerton *hton, THD *thd, bool all) {
   int ret = 1;
   std::string error_message;
 
-  if (!( /*thd->no_errors != 0 || */ thd->killed || thd->transaction_rollback_request)) { // stonedb8 TODO: no_errors is deleted
+  if (!( thd->is_error() || thd->killed || thd->transaction_rollback_request)) {
     try {
       ha_rcengine_->CommitTx(thd, all);
       ret = 0;


### PR DESCRIPTION
[summary]
1 no_erros is used little in mysql5.7，eg in Item::update_null_value and so on. 
2 code is refacted in 8.0,and use push_warning or my_error function to mark errors in is_error function.

Reference: https://github.com/mysql/mysql-server/commit/9fce6b0f909b09645d308912001c4234e06eaf3a
      in the mysql commit, we can see that is_errors is deleted directly almost. But check the code, like the
      the items related function, push_warning|my_error is used to mark errors. So use is_error is a better solution.

<!--

Thank you for contributing to StoneDB!

PR Title Format: <type>(<scope>): description to this pr (#issue_id)
e.g.
fix(util): fix sth..... (#1)

-->

## Summary about this PR
<!--

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".
e.g.:
Issue: close #1

-->

Issue Number: close #574 
fix: thd->no_errors no_errors is deleted.
the no_erros is used little in mysql5.7，eg in Item::update_null_value and so on. In mysql8.0,
the code is refacted,and is used push_warning or my_error function to mark erros in is_error function.
The solution is to use is_erro instead no_errors.


## Tests Check List
<!-- At least one of next options must be included. -->

- [ ] Unit test
- [ ] Integration test
- [X] Manual test (add detailed scripts or steps below)
- [ ] No code

## Changelog
<!-- At least one of next options must be included. -->

- [X] New Feature
- [ ] Bug Fix
- [ ] Improvement
- [ ] Performance Improvement
- [ ] Build/Testing/CI/CD
- [ ] Documentation
- [ ] Not for changelog (changelog entry is not required)

## Documentation
<!-- At least one of next options must be included. -->

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
