### PR TITLE
feat(StoneDB 8.0): refactor ConditionNumberFromMultipleEquality function. (#583)

### DIFF
--- a/storage/tianmu/core/query.cpp
+++ b/storage/tianmu/core/query.cpp
@@ -1107,21 +1107,18 @@ int Query::Item2CQTerm(Item *an_arg, CQTerm &term, const TabID &tmp_table, CondT
 CondID Query::ConditionNumberFromMultipleEquality(Item_equal *conds, const TabID &tmp_table, CondType filter_type,
                                                   CondID *and_me_filter, bool is_or_subtree) {
   CQTerm zero_term, first_term, next_term;
-  // stonedb8 start
-  List_STL_Iterator<Item_field> ifield;
-  List_STL_Iterator<Item_field> li;
-  li = conds->get_fields().begin();
-  // stonedb8 end
+  Item_field *ifield{nullptr};
+  auto li = conds->get_fields().begin();
 
   Item *const_item = conds->get_const();
   if (const_item) {
     if (!Item2CQTerm(const_item, zero_term, tmp_table, filter_type)) return CondID(-1);
   } else {
-    ifield = li++;
-    if (!Item2CQTerm(&*ifield, zero_term, tmp_table, filter_type)) return CondID(-1); // stonedb8 TODO
+    ifield = &*(li++);
+    if (!Item2CQTerm(ifield, zero_term, tmp_table, filter_type)) return CondID(-1);
   }
-  ifield = li++;
-  if (!Item2CQTerm(&*ifield, first_term, tmp_table, filter_type)) return CondID(-1); // stonedb8 TODO
+  ifield = &*(li++);
+  if (!Item2CQTerm(ifield, first_term, tmp_table, filter_type)) return CondID(-1);
   CondID filter;
   if (!and_me_filter)
     cq->CreateConds(filter, tmp_table, first_term, common::Operator::O_EQ, zero_term, CQTerm(),
@@ -1132,8 +1129,9 @@ CondID Query::ConditionNumberFromMultipleEquality(Item_equal *conds, const TabID
     else
       cq->And(*and_me_filter, tmp_table, first_term, common::Operator::O_EQ, zero_term);
   }
-  while ((ifield = li++) != conds->get_fields().end()) {  // stonedb8
-    if (!Item2CQTerm(&*ifield, next_term, tmp_table, filter_type)) return CondID(-1); // stonedb8 TODO
+  while (li != conds->get_fields().end()) {
+    ifield = &*(li++);
+    if (!Item2CQTerm(ifield, next_term, tmp_table, filter_type)) return CondID(-1);
     if (!and_me_filter) {
       if (is_or_subtree)
         cq->Or(filter, tmp_table, next_term, common::Operator::O_EQ, zero_term);


### PR DESCRIPTION

[summary]
1 improve the function's readability;
2 remove "stonedb8" comments;

<!--

Thank you for contributing to StoneDB!

PR Title Format: <type>(<scope>): description to this pr (#issue_id)
e.g.
fix(util): fix sth..... (#1)

-->

## Summary about this PR
<!--

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".
e.g.:
Issue: close #1

-->

Issue Number: close #583

[summary]
function ConditionNumberFromMultipleEquality in the file storage/tianmu/core/query.cpp
the reason for the 8.0 adaptor for this function is  :Item_equal_iterator is deleted from mysql8.0.
Reference:https://github.com/mysql/mysql-server/commit/908666ca5aa957de291544a2f757bdf9b2884d03
```
  List_STL_Iterator<Item_field> ifield;
  List_STL_Iterator<Item_field> li;
  li = conds->get_fields().begin();
```
the logic is correct, but code can be cleaner.

1 improve the function's readability;
2 remove "stonedb8" comments;
## Tests Check List
<!-- At least one of next options must be included. -->

- [ ] Unit test
- [ ] Integration test
- [X] Manual test (add detailed scripts or steps below)
- [ ] No code

## Changelog
<!-- At least one of next options must be included. -->

- [X] New Feature
- [ ] Bug Fix
- [X] Improvement
- [ ] Performance Improvement
- [ ] Build/Testing/CI/CD
- [ ] Documentation
- [ ] Not for changelog (changelog entry is not required)

## Documentation
<!-- At least one of next options must be included. -->

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
