### PR TITLE
feat(StoneDB 8.0): unify the boost directory of mysql8.0 and tianmu. …

### DIFF
--- a/cmake/boost.cmake
+++ b/cmake/boost.cmake
@@ -170,7 +170,7 @@ IF (WITH_BOOST)
            )
   ## Did we get a path name to an unzippped version?
   FIND_PATH(LOCAL_BOOST_DIR
-            NAMES "boost/version.hpp"
+            NAMES "include/boost/version.hpp"
             PATHS ${WITH_BOOST}
             NO_DEFAULT_PATH
            )
@@ -196,7 +196,7 @@ ENDIF()
 # There is a similar option in unittest/gunit.
 # But the boost tarball is much bigger, so we have a separate option.
 OPTION(DOWNLOAD_BOOST "Download boost from sourceforge." OFF)
-SET(DOWNLOAD_BOOST_TIMEOUT 600 CACHE STRING
+SET(DOWNLOAD_BOOST_TIMEOUT 6000 CACHE STRING
   "Timeout in seconds when downloading boost.")
 
 # If we could not find it, then maybe download it.
@@ -260,7 +260,7 @@ ENDIF()
 
 # Search for the version file, first in LOCAL_BOOST_DIR or WITH_BOOST
 FIND_PATH(BOOST_INCLUDE_DIR
-  NAMES boost/version.hpp
+  NAMES include/boost/version.hpp
   NO_DEFAULT_PATH
   PATHS ${LOCAL_BOOST_DIR}
         ${LOCAL_BOOST_DIR}/${BOOST_PACKAGE_NAME}
@@ -268,15 +268,15 @@ FIND_PATH(BOOST_INCLUDE_DIR
 )
 # Then search in standard places (if not found above).
 FIND_PATH(BOOST_INCLUDE_DIR
-  NAMES boost/version.hpp
+  NAMES include/boost/version.hpp
 )
 
 IF(NOT BOOST_INCLUDE_DIR)
   MESSAGE(STATUS
-    "Looked for boost/version.hpp in ${LOCAL_BOOST_DIR} and ${WITH_BOOST}")
+    "Looked for include/boost/version.hpp in ${LOCAL_BOOST_DIR} and ${WITH_BOOST}")
   COULD_NOT_FIND_BOOST()
 ELSE()
-  MESSAGE(STATUS "Found ${BOOST_INCLUDE_DIR}/boost/version.hpp ")
+  MESSAGE(STATUS "Found ${BOOST_INCLUDE_DIR}/include/boost/version.hpp ")
 ENDIF()
 
 # Verify version number. Version information looks like:
@@ -284,7 +284,7 @@ ENDIF()
 # //  BOOST_VERSION / 100 % 1000 is the minor version
 # //  BOOST_VERSION / 100000 is the major version
 # #define BOOST_VERSION 107700
-FILE(STRINGS "${BOOST_INCLUDE_DIR}/boost/version.hpp"
+FILE(STRINGS "${BOOST_INCLUDE_DIR}/include/boost/version.hpp"
   BOOST_VERSION_NUMBER
   REGEX "^#define[\t ]+BOOST_VERSION[\t ][0-9]+.*"
 )


### PR DESCRIPTION
…(#584)

[summary]
1 change mysql8.0 boost version.hpp directory from /boost/version.hpp to include/boost/version.hpp ; 2 the boost directory of mysql8.0 and tianmu becomes the same one;

<!--

Thank you for contributing to StoneDB!

PR Title Format: <type>(<scope>): description to this pr (#issue_id)
e.g.
fix(util): fix sth..... (#1)

-->

## Summary about this PR
<!--

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".
e.g.:
Issue: close #584 

-->

Issue Number: close #584


## Tests Check List
<!-- At least one of next options must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code

## Changelog
<!-- At least one of next options must be included. -->

- [x] New Feature
- [ ] Bug Fix
- [ ] Improvement
- [ ] Performance Improvement
- [ ] Build/Testing/CI/CD
- [ ] Documentation
- [ ] Not for changelog (changelog entry is not required)

## Documentation
<!-- At least one of next options must be included. -->

- [x] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
