### PR TITLE
fix(tianmu): Switches are added to support controlling whether multithreading is used to nested loops (#578)

### DIFF
--- a/storage/tianmu/core/aggregation_algorithm.cpp
+++ b/storage/tianmu/core/aggregation_algorithm.cpp
@@ -194,7 +194,7 @@ void AggregationAlgorithm::Aggregate(bool just_distinct, int64_t &limit, int64_t
     }
   } else {
     int64_t local_limit = limit == -1 ? upper_approx_of_groups : limit;
-    MultiDimensionalGroupByScan(gbw, local_limit, offset, sender, limit_less_than_no_groups, true);
+    MultiDimensionalGroupByScan(gbw, local_limit, offset, sender, limit_less_than_no_groups, false);
     if (limit != -1) limit = local_limit;
   }
   t->ClearMultiIndexP();  // cleanup (i.e. regarded as materialized,

--- a/storage/tianmu/core/joiner.h
+++ b/storage/tianmu/core/joiner.h
@@ -100,9 +100,16 @@ class JoinerGeneral : public TwoDimensionalJoiner {
   // Instead of the original inner Join function block, 
   // as the top-level call of inner Join, 
   // internal split multiple threads to separate different subsets for processing
-  void ExecuteInnerJoinLoop(MIIterator &mit, Condition &cond, MINewContents &new_mind, DimensionVector &all_dims,
+  void ExecuteInnerJoinLoopMultiThread(MIIterator &mit, Condition &cond, MINewContents &new_mind,
+                                          DimensionVector &all_dims,
                             std::vector<bool> &pack_desc_locked, int64_t &tuples_in_output, int64_t limit,
                             bool count_only);
+
+  // A single thread handles nested loop. 
+  // The purpose of this function is to provide an option that can be handled by a single thread
+  void ExecuteInnerJoinLoopSingleThread(MIIterator &mit, Condition &cond, MINewContents &new_mind,
+                                          DimensionVector &all_dims, std::vector<bool> &pack_desc_locked,
+                                          int64_t &tuples_in_output, int64_t limit, bool count_only);
 
   // Handles each row in the Pack that the current iterator points to
   // TODO: Keep in mind that internal Pack reads will have cache invalidation during multithread switching, 


### PR DESCRIPTION

## Summary about this PR

    The nested loop now enforces multithreading. 
    Switches are added to support controlling whether multithreading is used to nested loops
    
    The reason for adding a parameter to control whether to enable multithreaded nested loop is that

    1. Provides parameters for fast execution of single-threaded versus multithreaded comparisons
    2. At present, the physical layer is placed in the second stage because 
    the multi-threaded transformation of Nested loop has not been thoroughly carried out during the development period. 
    The argument that controls turning on multithreading is also needed for easy code rollback

    TODO: There is no time to continue to optimize this parameter, 
    later need to provide a configurable parameter to
    control whether to enable multithreading


Note that the single-threaded processing function in the Nested loop is the original logic. It is only a function wrapper to be used in parallel with the multithreaded processing. The purpose is to facilitate the second phase of optimization and performance test data comparison

 

Issue Number: close #578 


## Tests Check List
<!-- At least one of next options must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

## Changelog
<!-- At least one of next options must be included. -->

- [ ] New Feature
- [ ] Bug Fix
- [x] Improvement
- [ ] Performance Improvement
- [ ] Build/Testing/CI/CD
- [ ] Documentation
- [ ] Not for changelog (changelog entry is not required)

## Documentation
<!-- At least one of next options must be included. -->

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
