### PR TITLE
feat(StoneDB 8.0): Fix up the compiling extra-semi warnings. (#547)

### DIFF
--- a/storage/tianmu/base/core/execution_stage.h
+++ b/storage/tianmu/base/core/execution_stage.h
@@ -170,7 +170,7 @@ class execution_stage {
     }));
     _flush_scheduled = true;
     return true;
-  };
+  }
 
   /// Checks whether there are pending operations.
   ///

--- a/storage/tianmu/base/core/expiring_fifo.h
+++ b/storage/tianmu/base/core/expiring_fifo.h
@@ -37,12 +37,12 @@ namespace base {
 
 template <typename T>
 struct dummy_expiry {
-  void operator()(T &) noexcept {};
+  void operator()(T &) noexcept {}
 };
 
 template <typename... T>
 struct promise_expiry {
-  void operator()(promise<T...> &pr) noexcept { pr.set_exception(std::make_exception_ptr(timed_out_error())); };
+  void operator()(promise<T...> &pr) noexcept { pr.set_exception(std::make_exception_ptr(timed_out_error())); }
 };
 
 /// Container for elements with support for expiration of entries.

--- a/storage/tianmu/base/core/future.h
+++ b/storage/tianmu/base/core/future.h
@@ -976,7 +976,7 @@ class future {
       } catch (...) {
         return result.rethrow_with_nested();
       }
-    };
+    }
   };
 
   /// \brief Terminate the program if this future fails.

--- a/storage/tianmu/base/core/reactor.h
+++ b/storage/tianmu/base/core/reactor.h
@@ -349,7 +349,7 @@ class smp_message_queue {
 // OSv-specific file-descriptor-less mechanisms (reactor_backend_osv).
 class reactor_backend {
  public:
-  virtual ~reactor_backend(){};
+  virtual ~reactor_backend(){}
   // wait_and_process() waits for some events to become available, and
   // processes one or more of them. If block==false, it doesn't wait,
   // and just processes events that have already happened, if any.

--- a/storage/tianmu/base/net/api.h
+++ b/storage/tianmu/base/net/api.h
@@ -92,7 +92,7 @@ class get_impl;
 
 class udp_datagram_impl {
  public:
-  virtual ~udp_datagram_impl(){};
+  virtual ~udp_datagram_impl(){}
   virtual ipv4_addr get_src() = 0;
   virtual ipv4_addr get_dst() = 0;
   virtual uint16_t get_dst_port() = 0;
@@ -104,7 +104,7 @@ class udp_datagram final {
   std::unique_ptr<udp_datagram_impl> _impl;
 
  public:
-  udp_datagram(std::unique_ptr<udp_datagram_impl> &&impl) : _impl(std::move(impl)){};
+  udp_datagram(std::unique_ptr<udp_datagram_impl> &&impl) : _impl(std::move(impl)){}
   ipv4_addr get_src() { return _impl->get_src(); }
   ipv4_addr get_dst() { return _impl->get_dst(); }
   uint16_t get_dst_port() { return _impl->get_dst_port(); }

--- a/storage/tianmu/base/net/posix_stack.cpp
+++ b/storage/tianmu/base/net/posix_stack.cpp
@@ -428,7 +428,7 @@ class posix_udp_channel : public udp_channel_impl {
   }
   virtual ~posix_udp_channel() {
     if (!_closed) close();
-  };
+  }
   virtual future<udp_datagram> receive() override;
   future<> send(ipv4_addr dst, const char *msg) override;
   future<> send(ipv4_addr dst, packet p) override;

--- a/storage/tianmu/base/net/posix_stack.h
+++ b/storage/tianmu/base/net/posix_stack.h
@@ -176,7 +176,7 @@ class posix_network_stack : public network_stack {
   static future<std::unique_ptr<network_stack>> create() {
     return make_ready_future<std::unique_ptr<network_stack>>(std::unique_ptr<network_stack>(new posix_network_stack()));
   }
-  virtual bool has_per_core_namespace() override { return _reuseport; };
+  virtual bool has_per_core_namespace() override { return _reuseport; }
 };
 
 class posix_ap_network_stack : public posix_network_stack {

--- a/storage/tianmu/base/net/stack.h
+++ b/storage/tianmu/base/net/stack.h
@@ -66,7 +66,7 @@ class server_socket_impl {
 
 class udp_channel_impl {
  public:
-  virtual ~udp_channel_impl(){};
+  virtual ~udp_channel_impl(){}
   virtual future<udp_datagram> receive() = 0;
   virtual future<> send(ipv4_addr dst, const char *msg) = 0;
   virtual future<> send(ipv4_addr dst, packet p) = 0;

--- a/storage/tianmu/core/bloom_block.h
+++ b/storage/tianmu/core/bloom_block.h
@@ -108,7 +108,7 @@ inline int Slice::compare(const Slice &b) const {
 
 class FilterPolicy {
  public:
-  virtual ~FilterPolicy(){};
+  virtual ~FilterPolicy(){}
 
   // Return the name of this policy.  Note that if the filter encoding
   // changes in an incompatible way, the name returned by this method

--- a/storage/tianmu/core/column_type.h
+++ b/storage/tianmu/core/column_type.h
@@ -93,7 +93,7 @@ struct ColumnType {
   uint GetInternalSize() const { return internal_size; }
   // Use in cases where actual string length is less then declared, before
   // materialization of Attr
-  void OverrideInternalSize(uint size) { internal_size = size; };
+  void OverrideInternalSize(uint size) { internal_size = size; }
   int GetDisplaySize() const { return display_size; }
   bool IsLookup() const { return fmt == common::PackFmt::LOOKUP; }
   ColumnType RemovedLookup() const;
@@ -112,9 +112,9 @@ struct ColumnType {
     }
   }
 
-  bool IsKnown() const { return type != common::CT::UNK; };
-  bool IsFixed() const { return ATI::IsFixedNumericType(type); };
-  bool IsFloat() const { return ATI::IsRealType(type); };
+  bool IsKnown() const { return type != common::CT::UNK; }
+  bool IsFixed() const { return ATI::IsFixedNumericType(type); }
+  bool IsFloat() const { return ATI::IsRealType(type); }
   bool IsInt() const { return IsFixed() && scale == 0; }
   bool IsString() const { return ATI::IsStringType(type); }
   bool IsDateTime() const { return ATI::IsDateTimeType(type); }

--- a/storage/tianmu/core/compiled_query.h
+++ b/storage/tianmu/core/compiled_query.h
@@ -100,7 +100,7 @@ class CompiledQuery final {
           alias(NULL),
           n1(common::NULL_VALUE_64),
           n2(common::NULL_VALUE_64),
-          si(){};
+          si(){}
 
     CQStep(const CQStep &);
 

--- a/storage/tianmu/core/descriptor.h
+++ b/storage/tianmu/core/descriptor.h
@@ -192,7 +192,7 @@ class SortDescriptor {
  public:
   vcolumn::VirtualColumn *vc;
   int dir;  // ordering direction: 0 - ascending, 1 - descending
-  SortDescriptor() : vc(NULL), dir(0){};
+  SortDescriptor() : vc(NULL), dir(0){}
   int operator==(const SortDescriptor &sec) { return (dir == sec.dir) && (vc == sec.vc); }
 };
 

--- a/storage/tianmu/core/dimension_group.h
+++ b/storage/tianmu/core/dimension_group.h
@@ -71,7 +71,7 @@ class DimensionGroup {
     // note: retrieving a value depends on DimensionGroup type
     Iterator() { valid = false; }
     Iterator(const Iterator &sec) { valid = sec.valid; }
-    virtual ~Iterator(){};
+    virtual ~Iterator(){}
 
     virtual void operator++() = 0;
     virtual void Rewind() = 0;

--- a/storage/tianmu/core/dimension_vector.h
+++ b/storage/tianmu/core/dimension_vector.h
@@ -27,7 +27,7 @@ namespace core {
 class DimensionVector {
  public:
   DimensionVector() = default;
-  DimensionVector(int no_dims) : v(no_dims){};
+  DimensionVector(int no_dims) : v(no_dims){}
   DimensionVector(const DimensionVector &sec) = default;
   ~DimensionVector() = default;
 

--- a/storage/tianmu/core/filter.h
+++ b/storage/tianmu/core/filter.h
@@ -60,7 +60,7 @@ class Filter final : public mm::TraceableObject {
   // original), but it ok as the copy uses pools and mutexes from the original
   static Filter *ShallowCopy(Filter &f);
 
-  mm::TO_TYPE TraceableType() const override { return mm::TO_TYPE::TO_FILTER; };
+  mm::TO_TYPE TraceableType() const override { return mm::TO_TYPE::TO_FILTER; }
   // Copying operation
   std::unique_ptr<Filter> Clone() const;
 
@@ -152,7 +152,7 @@ class Filter final : public mm::TraceableObject {
                         // nonempty block.
   // Otherwise it is an average number of ones in nonempty blocks.
 
-  boost::pool<HeapAllocator> *GetBitBlockPool() { return bit_block_pool; };
+  boost::pool<HeapAllocator> *GetBitBlockPool() { return bit_block_pool; }
   friend class FilterOnesIterator;
   friend class FilterOnesIteratorOrdered;
 
@@ -161,12 +161,12 @@ class Filter final : public mm::TraceableObject {
   Block *GetBlock(size_t b) const {
     DEBUG_ASSERT(b < no_blocks);
     return blocks[b];
-  };
+  }
   uchar GetBlockStatus(size_t i) {
     DEBUG_ASSERT(i < no_blocks);
     return block_status[i];
-  };
-  uint32_t GetPower() { return no_power; };
+  }
+  uint32_t GetPower() { return no_power; }
   bool GetBlockChangeStatus(uint32_t n) const {
     DEBUG_ASSERT(n < no_blocks);
     return block_changed[n];

--- a/storage/tianmu/core/joiner_mapped.h
+++ b/storage/tianmu/core/joiner_mapped.h
@@ -62,7 +62,7 @@ class JoinerMapped : public TwoDimensionalJoiner {
 
 class JoinerParallelMapped : public JoinerMapped {
  public:
-  JoinerParallelMapped(MultiIndex *_mind, TempTable *_table, JoinTips &_tips) : JoinerMapped(_mind, _table, _tips){};
+  JoinerParallelMapped(MultiIndex *_mind, TempTable *_table, JoinTips &_tips) : JoinerMapped(_mind, _table, _tips){}
 
   void ExecuteJoinConditions(Condition &cond) override;
 
@@ -126,7 +126,7 @@ class OffsetMapFunction : public JoinerMapFunction {
 class MultiMapsFunction : public JoinerMapFunction {
  public:
   MultiMapsFunction(Transaction *_m_conn) : JoinerMapFunction(_m_conn) {}
-  ~MultiMapsFunction(){};
+  ~MultiMapsFunction(){}
 
   bool Init(vcolumn::VirtualColumn *vc, MIIterator &mit);
 

--- a/storage/tianmu/core/just_a_table.h
+++ b/storage/tianmu/core/just_a_table.h
@@ -61,7 +61,7 @@ class JustATable : public std::enable_shared_from_this<JustATable> {
   //! Returns column value in the form required by complex expressions
   ValueOrNull GetComplexValue(const int64_t obj, const int attr);
 
-  virtual ~JustATable(){};
+  virtual ~JustATable(){}
 };
 
 }  // namespace core

--- a/storage/tianmu/core/pack_orderer.h
+++ b/storage/tianmu/core/pack_orderer.h
@@ -40,7 +40,7 @@ class PackOrderer {
   enum class State { INIT_VAL = -1, END = -2 };
 
   struct OrderStat {
-    OrderStat(int n, int o) : neutral(n), ordered(o){};
+    OrderStat(int n, int o) : neutral(n), ordered(o){}
     int neutral;
     int ordered;
   };

--- a/storage/tianmu/core/query.h
+++ b/storage/tianmu/core/query.h
@@ -49,7 +49,7 @@ class Query final {
    */
   void RemoveFromManagedList(const std::shared_ptr<RCTable> tab);
 
-  int NumOfTabs() const { return t.size(); };
+  int NumOfTabs() const { return t.size(); }
   std::shared_ptr<RCTable> Table(size_t table_num) const {
     ASSERT(table_num < t.size(), "table_num out of range: " + std::to_string(table_num));
     return t[table_num];

--- a/storage/tianmu/core/rc_attr.h
+++ b/storage/tianmu/core/rc_attr.h
@@ -160,7 +160,7 @@ class RCAttr final : public mm::TraceableObject, public PhysicalColumn, public P
       return true;
     }
     return true;
-  };
+  }
 
   /*! \brief Get a non null-terminated String from a column
    *
@@ -198,7 +198,7 @@ class RCAttr final : public mm::TraceableObject, public PhysicalColumn, public P
   size_t ComputeNaturalSize();  // natural size of data (i.e. without any compression)
   // the compressed size of the attribute (for e.g. calculating compression
   // ratio); may be slightly approximated
-  int64_t CompressedSize() const { return hdr.compressed_size; };
+  int64_t CompressedSize() const { return hdr.compressed_size; }
   uint32_t ValueOfPackPower() const { return pss; }
   uint64_t NumOfObj() const { return hdr.nr; }
   uint64_t NumOfNulls() const { return hdr.nn; }
@@ -294,7 +294,7 @@ class RCAttr final : public mm::TraceableObject, public PhysicalColumn, public P
   void LoadData(loader::ValueCache *nvs, Transaction *conn_info = NULL);
   void LoadPackInfo(Transaction *trans_ = current_txn_);
   void LoadProcessedData([[maybe_unused]] std::unique_ptr<system::Stream> &s,
-                         [[maybe_unused]] size_t no_rows){/* TODO */};
+                         [[maybe_unused]] size_t no_rows){/* TODO */}
   void PreparePackForLoad();
 
   bool SaveVersion();  // return true iff there was any change

--- a/storage/tianmu/core/rough_multi_index.h
+++ b/storage/tianmu/core/rough_multi_index.h
@@ -31,12 +31,12 @@ class RoughMultiIndex {
   RoughMultiIndex(const RoughMultiIndex &);
   ~RoughMultiIndex();
 
-  common::RSValue GetPackStatus(int dim, int pack) { return rf[dim][pack]; };
-  void SetPackStatus(int dim, int pack, common::RSValue v) { rf[dim][pack] = v; };
+  common::RSValue GetPackStatus(int dim, int pack) { return rf[dim][pack]; }
+  void SetPackStatus(int dim, int pack, common::RSValue v) { rf[dim][pack] = v; }
 
-  int NumOfDimensions() { return no_dims; };
-  int NoPacks(int dim) { return no_packs[dim]; };
-  int NoConditions(int dim) { return int(local_desc[dim].size()); };
+  int NumOfDimensions() { return no_dims; }
+  int NoPacks(int dim) { return no_packs[dim]; }
+  int NoConditions(int dim) { return int(local_desc[dim].size()); }
   int GlobalDescNum(int dim, int local_desc_num) { return (local_desc[dim])[local_desc_num]->desc_num; }
   /*
           Example of query processing steps:
@@ -47,7 +47,7 @@ class RoughMultiIndex {
      optimize access for next conditions.
   */
 
-  common::RSValue *GetRSValueTable(int dim) { return rf[dim]; };
+  common::RSValue *GetRSValueTable(int dim) { return rf[dim]; }
   common::RSValue *GetLocalDescFilter(int dim, int desc_num, bool read_only = false);
   // if not exists, create one (unless read_only is set)
   void ClearLocalDescFilters();  // clear all desc info, for reusing the rough

--- a/storage/tianmu/core/rsi_histogram.h
+++ b/storage/tianmu/core/rsi_histogram.h
@@ -57,7 +57,7 @@ class RSIndex_Hist final : public RSIndex {
 
   void SaveToFile(common::TX_ID ver) override;
 
-  bool Fixed() { return hdr.fixed == 1; };
+  bool Fixed() { return hdr.fixed == 1; }
 
  private:
   void AppendKNs(unsigned int no_kns_to_add);  // append new KNs

--- a/storage/tianmu/core/sorter3.h
+++ b/storage/tianmu/core/sorter3.h
@@ -32,7 +32,7 @@ namespace core {
 class Sorter3 : public mm::TraceableObject {
  public:
   Sorter3(uint _size, uint _key_bytes, uint _total_bytes)
-      : conn(current_txn_), key_bytes(_key_bytes), total_bytes(_total_bytes), size(_size){};
+      : conn(current_txn_), key_bytes(_key_bytes), total_bytes(_total_bytes), size(_size){}
 
   static Sorter3 *CreateSorter(int64_t size, uint key_bytes, uint total_bytes, int64_t limit = -1,
                                int mem_modifier = 0);

--- a/storage/tianmu/core/temp_table.h
+++ b/storage/tianmu/core/temp_table.h
@@ -504,7 +504,7 @@ class TempTable : public JustATable {
 class TempTableForSubquery : public TempTable {
  public:
   TempTableForSubquery(JustATable *const t, int alias, Query *q)
-      : TempTable(t, alias, q), template_filter(0), is_attr_for_rough(false), rough_materialized(false){};
+      : TempTable(t, alias, q), template_filter(0), is_attr_for_rough(false), rough_materialized(false){}
   ~TempTableForSubquery();
 
   void CreateTemplateIfNotExists();

--- a/storage/tianmu/core/transaction.h
+++ b/storage/tianmu/core/transaction.h
@@ -70,8 +70,8 @@ class Transaction final {
   std::shared_ptr<RCTable> GetTableByPathIfExists(const std::string &table_path);
   std::shared_ptr<RCTable> GetTableByPath(const std::string &table_path);
 
-  void ExplicitLockTables() { m_explicit_lock_tables = true; };
-  void ExplicitUnlockTables() { m_explicit_lock_tables = false; };
+  void ExplicitLockTables() { m_explicit_lock_tables = true; }
+  void ExplicitUnlockTables() { m_explicit_lock_tables = false; }
   void AddTableRD(std::shared_ptr<TableShare> &share);
   void AddTableWR(std::shared_ptr<TableShare> &share);
   void AddTableWRIfNeeded(std::shared_ptr<TableShare> &share);

--- a/storage/tianmu/exporter/export2file.h
+++ b/storage/tianmu/exporter/export2file.h
@@ -28,12 +28,12 @@ class select_tianmu_export : public Query_result_export {
  public:
   // select_tianmu_export(sql_exchange *ex);
   select_tianmu_export(Query_result_export *se);
-  ~select_tianmu_export(){};
+  ~select_tianmu_export(){}
   int prepare(List<Item> &list, Query_expression *u) /*override*/;
   void SetRowCount(ha_rows x);
   void SendOk(THD *thd);
   sql_exchange *SqlExchange();
-  bool IsPrepared() const { return prepared; };
+  bool IsPrepared() const { return prepared; }
   bool send_data(THD *thd, mem_root_deque<Item *> &items) /*override*/; // stonedb8
 
  private:

--- a/storage/tianmu/index/kv_store.h
+++ b/storage/tianmu/index/kv_store.h
@@ -42,7 +42,7 @@ class KVStore final {
  public:
   KVStore(const KVStore &) = delete;
   //mysql_real_data_home, pls refer to the system params.
-  KVStore() : kv_data_dir_(mysql_real_data_home){};
+  KVStore() : kv_data_dir_(mysql_real_data_home){}
 
   KVStore &operator=(const KVStore &) = delete;
   virtual ~KVStore() { UnInit(); }

--- a/storage/tianmu/index/rc_table_index.h
+++ b/storage/tianmu/index/rc_table_index.h
@@ -68,8 +68,8 @@ class RCTableIndex final {
 class KeyIterator final {
  public:
   KeyIterator() = delete;
-  KeyIterator(const KeyIterator &sec) : valid(sec.valid), iter_(sec.iter_), rdbkey_(sec.rdbkey_){};
-  KeyIterator(KVTransaction *tx) : trans_(tx){};
+  KeyIterator(const KeyIterator &sec) : valid(sec.valid), iter_(sec.iter_), rdbkey_(sec.rdbkey_){}
+  KeyIterator(KVTransaction *tx) : trans_(tx){}
   void ScanToKey(std::shared_ptr<RCTableIndex> tab, std::vector<std::string_view> &fields, common::Operator op);
   void ScanToEdge(std::shared_ptr<RCTableIndex> tab, bool forward);
   common::ErrorCode GetCurKV(std::vector<std::string> &keys, uint64_t &row);

--- a/storage/tianmu/index/rdb_meta_manager.h
+++ b/storage/tianmu/index/rdb_meta_manager.h
@@ -242,7 +242,7 @@ class DICTManager {
   bool init(rocksdb::DB *const rdb_dict, CFManager *const cf_manager_);
   inline void lock() { m_mutex.lock(); }
   inline void unlock() { m_mutex.unlock(); }
-  void cleanup(){};
+  void cleanup(){}
   inline rocksdb::ColumnFamilyHandle *get_system_cf() const { return m_system_cfh; }
   std::unique_ptr<rocksdb::WriteBatch> begin() const;
   bool commit(rocksdb::WriteBatch *const batch, const bool &sync = true) const;

--- a/storage/tianmu/system/channel.h
+++ b/storage/tianmu/system/channel.h
@@ -33,9 +33,9 @@ class Channel {
   ~Channel();
 
   void addOutput(ChannelOut *output);
-  void setOn() { enabled_ = true; };
-  void setOff() { enabled_ = false; };
-  void setTimeStamp(bool _on = true) { time_stamp_at_lock_ = _on; };
+  void setOn() { enabled_ = true; }
+  void setOff() { enabled_ = false; }
+  void setTimeStamp(bool _on = true) { time_stamp_at_lock_ = _on; }
   bool isOn();
 
   Channel &lock(uint optional_sess_id = 0xFFFFFFFF);
@@ -62,7 +62,7 @@ class Channel {
   Channel &operator<<(const std::string &str);
 
   Channel &operator<<(const std::exception &exc);
-  Channel &operator<<(Channel &(*_Pfn)(Channel &)) { return _Pfn(*this); };
+  Channel &operator<<(Channel &(*_Pfn)(Channel &)) { return _Pfn(*this); }
   Channel &flush();
 
  private:

--- a/storage/tianmu/system/channel_out.h
+++ b/storage/tianmu/system/channel_out.h
@@ -56,7 +56,7 @@ class ChannelOut {
   ChannelOut &operator<<(const std::exception &exc) {
     (*this) << exc.what();
     return *this;
-  };
+  }
 
   virtual void setf(std::ios_base::fmtflags _Mask) = 0;
   virtual void precision(std::streamsize prec) = 0;
@@ -66,7 +66,7 @@ class ChannelOut {
   virtual void close() = 0;
 
   virtual ChannelOut &operator<<(ChannelOut &(*_Pfn)(ChannelOut &)) = 0;
-  virtual ~ChannelOut(){};
+  virtual ~ChannelOut(){}
 };
 
 inline ChannelOut &endl(ChannelOut &inout) {

--- a/storage/tianmu/system/file_out.h
+++ b/storage/tianmu/system/file_out.h
@@ -38,96 +38,96 @@ class FileOut : public ChannelOut {
   ChannelOut &operator<<(short value) override {
     out_stream_ << value;
     return *this;
-  };
+  }
 
   ChannelOut &operator<<(int value) override {
     out_stream_ << value;
     return *this;
-  };
+  }
 
   ChannelOut &operator<<(long value) override {
     out_stream_ << value;
     return *this;
-  };
+  }
 
   ChannelOut &operator<<(float value) override {
     out_stream_ << value;
     return *this;
-  };
+  }
 
   ChannelOut &operator<<(double value) override {
     out_stream_ << value;
     return *this;
-  };
+  }
 
   ChannelOut &operator<<(long double value) override {
     out_stream_ << value;
     return *this;
-  };
+  }
 
   ChannelOut &operator<<(unsigned short value) override {
     out_stream_ << value;
     return *this;
-  };
+  }
 
   ChannelOut &operator<<(unsigned int value) override {
     out_stream_ << value;
     return *this;
-  };
+  }
 
   ChannelOut &operator<<(unsigned long value) override {
     out_stream_ << value;
     return *this;
-  };
+  }
 
   ChannelOut &operator<<(int long long value) override {
     out_stream_ << value;
     return *this;
-  };
+  }
 
   ChannelOut &operator<<(int long long unsigned value) override {
     out_stream_ << value;
     return *this;
-  };
+  }
 
   ChannelOut &operator<<(char c) override {
     out_stream_ << c;
     return *this;
-  };
+  }
 
   ChannelOut &operator<<(const char *buffer) override {
     out_stream_ << buffer;
     return *this;
-  };
+  }
 
   ChannelOut &operator<<(const wchar_t *buffer) override {
     out_stream_ << buffer;
     return *this;
-  };
+  }
 
   ChannelOut &operator<<(const std::string &str) override {
     out_stream_ << str.c_str();
     return *this;
-  };
+  }
 
-  void setf(std::ios_base::fmtflags _Mask) override { out_stream_.setf(_Mask); };
-  void precision(std::streamsize prec) override { out_stream_.precision(prec); };
+  void setf(std::ios_base::fmtflags _Mask) override { out_stream_.setf(_Mask); }
+  void precision(std::streamsize prec) override { out_stream_.precision(prec); }
 
   ChannelOut &flush() override {
     out_stream_.flush();
     return *this;
-  };
+  }
 
   ChannelOut &fixed() override {
     out_stream_.setf(std::ios_base::fixed, std::ios_base::floatfield);
     return *this;
-  };
+  }
 
   void close() override {
     if (out_stream_.is_open()) out_stream_.close();
-  };
+  }
 
-  ChannelOut &operator<<(ChannelOut &(*_Pfn)(ChannelOut &)) override { return _Pfn(*this); };
+  ChannelOut &operator<<(ChannelOut &(*_Pfn)(ChannelOut &)) override { return _Pfn(*this); }
 
  private:
   std::ofstream out_stream_;

--- a/storage/tianmu/types/rc_data_types.h
+++ b/storage/tianmu/types/rc_data_types.h
@@ -169,7 +169,7 @@ template <typename T>
 class ValueBasic : public RCDataType {
  public:
   ValueTypeEnum GetValueType() const override { return T::value_type; }
-  std::unique_ptr<RCDataType> Clone() const override { return std::unique_ptr<RCDataType>(new T((T &)*this)); };
+  std::unique_ptr<RCDataType> Clone() const override { return std::unique_ptr<RCDataType>(new T((T &)*this)); }
   static T null_value;
   static T &NullValue() { return T::null_value; }
   using RCDataType::operator=;
@@ -306,7 +306,7 @@ class RCDateTime : public ValueBasic<RCDateTime> {
   bool GetInt64(int64_t &value) const {
     value = GetInt64();
     return true;
-  };
+  }
 
   /** Convert RCDateTime to 64 bit integer in the following format:
    * YEAR: 				YYYY
@@ -441,14 +441,14 @@ class rc_hash_compare {
   using Key = T;
 
  public:
-  size_t operator()(const Key k) const { return k->GetHashCode() & 1048575; };
+  size_t operator()(const Key k) const { return k->GetHashCode() & 1048575; }
   bool operator()(const Key &k1, const Key &k2) const {
     if (dynamic_cast<RCNum *>(k1)) {
       if (dynamic_cast<RCNum *>(k2)) return *k1 == *k2;
     } else if (AreComparable(k1->Type(), k2->Type()))
       return *k1 == *k2;
     return false;
-  };
+  }
 };
 
 /*! \brief Converts BString according to a given collation to the binary form

--- a/storage/tianmu/types/rc_item_types.h
+++ b/storage/tianmu/types/rc_item_types.h
@@ -55,7 +55,7 @@ class Item_sum_int_rcbase : public Item_sum_num {
   void clear() override;
   bool add() override;
   void update_field() override;
-  const char *func_name() const override { return "count("; };
+  const char *func_name() const override { return "count("; }
 
 public:
   int64_t count_;

--- a/storage/tianmu/types/value_parser4txt.h
+++ b/storage/tianmu/types/value_parser4txt.h
@@ -27,8 +27,8 @@ namespace Tianmu {
 namespace types {
 class ValueParserForText {
  public:
-  ValueParserForText(){};
-  virtual ~ValueParserForText(){};
+  ValueParserForText(){}
+  virtual ~ValueParserForText(){}
 
   static auto GetParsingFuntion(const core::AttributeTypeInfo &at)
       -> std::function<common::ErrorCode(BString const &, int64_t &)> {

--- a/storage/tianmu/vc/virtual_column_base.h
+++ b/storage/tianmu/vc/virtual_column_base.h
@@ -72,7 +72,7 @@ class VirtualColumnBase : public core::Column {
 
   enum class single_col_t { SC_NOT = 0, SC_ATTR, SC_RCATTR };
 
-  virtual ~VirtualColumnBase(){};
+  virtual ~VirtualColumnBase(){}
 
   /////////////// Data access //////////////////////
 
@@ -321,7 +321,7 @@ class VirtualColumnBase : public core::Column {
   //! \brief Assign a value to a parameter
   //! It is up the to column user to set values of all the parameters before
   //! requesting any value from the column
-  virtual void SetParamTypes([[maybe_unused]] core::MysqlExpression::TypOfVars *types){};
+  virtual void SetParamTypes([[maybe_unused]] core::MysqlExpression::TypOfVars *types){}
 
   /*! Mark as true each dimension used as source for variables in this
    * VirtualColumn


### PR DESCRIPTION
<!--

Thank you for contributing to StoneDB!

PR Title Format: <type>(<scope>): description to this pr (#issue_id)
e.g.
fix(util): fix sth..... (#1)

-->

## Summary about this PR
<!--

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".
e.g.:
Issue: close #1

-->

Issue Number: ref #547
Fix up the compiling extra-semi warnings like this：
`warning: extra ‘;’ after in-class function definition [-Wextra-semi]`
```
step1:
make -j32 &> tianmu_build.log
step2:
grep "\-Wextra-semi"  tianmu_build.log| \
grep "function definition" | \
sort| \
uniq| \
awk -F ":"  '{printf("sed -i \"%ss#\\\;[ \\t]*\$##g\"  %s\n",$2,$1)}'  > fix-extra-semi.sh
step3:
sh fix-extra-semi.sh

```
## Tests Check List
<!-- At least one of next options must be included. -->

- [ ] Unit test
- [ ] Integration test
- [X] Manual test (add detailed scripts or steps below)
- [ ] No code

## Changelog
<!-- At least one of next options must be included. -->

- [X] New Feature
- [ ] Bug Fix
- [ ] Improvement
- [ ] Performance Improvement
- [ ] Build/Testing/CI/CD
- [ ] Documentation
- [ ] Not for changelog (changelog entry is not required)

## Documentation
<!-- At least one of next options must be included. -->

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
