### PR TITLE
feat(StoneDB 8.0):  Query_block->braces is deleted by MySQL 8.0 (#593)

### DIFF
--- a/storage/tianmu/core/engine_execute.cpp
+++ b/storage/tianmu/core/engine_execute.cpp
@@ -581,7 +581,7 @@ int Query_expression::optimize_for_tianmu(THD *thd) {
                 // When using braces, SQL_CALC_FOUND_ROWS affects the whole query:
                 // we don't calculate found_rows() per union part.
                 // Otherwise, SQL_CALC_FOUND_ROWS should be done on all sub parts.
-                sl->join->select_options = (select_limit_cnt == HA_POS_ERROR /*|| sl->braces*/) // stonedb8 TODO
+                sl->join->select_options = (select_limit_cnt == HA_POS_ERROR || thd->lex->unit->is_union())
                                                ? sl->active_options() & ~OPTION_FOUND_ROWS
                                                : sl->active_options() | found_rows_for_union;
                 saved_error = sl->join->optimize(1);


### PR DESCRIPTION
<!--

Thank you for contributing to StoneDB!

PR Title Format: <type>(<scope>): description to this pr (#issue_id)
e.g.
fix(util): fix sth..... (#1)

-->

## Summary about this PR
<!--

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".
e.g.:
Issue: close #1

-->
1 SELECT_LEX->braces is used in MySQL5.7, at optimize part, but deleted in MySQL 8.0 
2 in MySQL 8.0, use Query_expression->is_union() instead of SELECT_LEX->braces

Issue Number: close #593 


## Tests Check List
<!-- At least one of next options must be included. -->

- [] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

## Changelog
<!-- At least one of next options must be included. -->

- [x] New Feature
- [ ] Bug Fix
- [ ] Improvement
- [ ] Performance Improvement
- [ ] Build/Testing/CI/CD
- [ ] Documentation
- [ ] Not for changelog (changelog entry is not required)

## Documentation
<!-- At least one of next options must be included. -->

- [ ] Affects user behaviors
- [x] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
