### PR TITLE
feat(StoneDB 8.0): st_select_lex::set_join is deleted in mysql8.0. (#598)

### DIFF
--- a/sql/sql_lex.cc
+++ b/sql/sql_lex.cc
@@ -4398,22 +4398,12 @@ void Query_block::include_chain_in_global(Query_block **start) {
   *start = this;
 }
 
-// stonedb8 start TODO: a better way.
-//
-// follows: from MySQL 5.7.36
-//void st_select_lex::set_join(JOIN *join_arg)
-//{
-//  master_unit()->thd->lock_query_plan();
-//  join= join_arg;
-//  master_unit()->thd->unlock_query_plan();
-//}
-//
-void Query_block::set_join(JOIN *join_arg)
+void Query_block::set_join(THD *thd, JOIN *join_arg)
 {
+  thd->lock_query_plan();
   join= join_arg;
+  thd->unlock_query_plan();
 }
-
-// stonedb8 end
 
 /**
    Helper function which handles the "ON conditions" part of

--- a/sql/sql_lex.h
+++ b/sql/sql_lex.h
@@ -1797,7 +1797,7 @@ class Query_block {
    The function sets the pointer only after acquiring THD::LOCK_query_plan
    mutex. This is needed to avoid races when EXPLAIN FOR CONNECTION is used.
 */
-  void set_join(JOIN *join_arg);
+  void set_join(THD *thd, JOIN *join_arg);
 
   /**
     Does permanent transformations which are local to a query block (which do

--- a/storage/tianmu/core/engine_execute.cpp
+++ b/storage/tianmu/core/engine_execute.cpp
@@ -361,7 +361,7 @@ int optimize_select(THD *thd, ulong select_options, Query_result *result,
         }       
         if (!(join = new JOIN(thd, select_lex)))
             return true; /* purecov: inspected */
-        select_lex->set_join(join); // stonedb8 TODO
+        select_lex->set_join(thd, join);
         
 	}
     join->best_rowcount = 2;
@@ -564,7 +564,7 @@ int Query_expression::optimize_for_tianmu(THD *thd) {
                     cleanup(thd, 0); // stonedb8
                     return true;
                 }
-                sl->set_join(join);
+                sl->set_join(thd, join);
             }           
             if (is_optimized())
                 sl->join->reset();
@@ -651,7 +651,7 @@ int Query_expression::optimize_after_tianmu(THD *thd)
                 cleanup(thd, 0);  // stonedb8
                 return true;
             }
-            sl->set_join(join);
+            sl->set_join(thd, join);
         }           
         int res = sl->join->optimize(2);
         if (res) {


### PR DESCRIPTION
<!--

Thank you for contributing to StoneDB!

PR Title Format: <type>(<scope>): description to this pr (#issue_id)
e.g.
fix(util): fix sth..... (#1)

-->

## Summary about this PR
<!--

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".
e.g.:
Issue: close #1

-->

Issue Number: close #598

1 in the commit(commit1) below, st_select_lex::set_join is renamed as SELECT_LEX::set_join
https://github.com/mysql/mysql-server/commit/74f720bd786c6899411429ea8886cfe2f5ce76d5
2 in the commit(commit2) below, SELECT_LEX::set_join is deleted:
https://github.com/mysql/mysql-server/commit/03b579fca6a9fc5024fd16b818e0f41efa88f935
3 in commit2, it is given the reference to implement the set_join:
<table>
<tr>
<th> old version</th>
<th> new version  </th>
</tr>
<tr>
<td>

```c++
set_join(join_local); 
```
</td>
<td>

```c++
  thd->lock_query_plan();
  join = join_local;
  thd->unlock_query_plan();
```

</td>
</tr>
</table>

4 by the way,  comment of variable Query_block::join is like this:
```
  /**
    After optimization it is pointer to corresponding JOIN. This member
    should be changed only when THD::LOCK_query_plan mutex is taken.
  */
  JOIN *join{nullptr};
```
5  So, use LOCK_query_plan mutex to implement set_join is a proper way.

## Tests Check List
<!-- At least one of next options must be included. -->

- [ ] Unit test
- [ ] Integration test
- [X] Manual test (add detailed scripts or steps below)
- [ ] No code

## Changelog
<!-- At least one of next options must be included. -->

- [X] New Feature
- [ ] Bug Fix
- [ ] Improvement
- [ ] Performance Improvement
- [ ] Build/Testing/CI/CD
- [ ] Documentation
- [ ] Not for changelog (changelog entry is not required)

## Documentation
<!-- At least one of next options must be included. -->

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features


















