### PR TITLE
    fix(tianmu): In Tianmu engine conversion syntax tree code style collation (#11)

### DIFF
--- a/storage/tianmu/core/mysql_expression.cpp
+++ b/storage/tianmu/core/mysql_expression.cpp
@@ -80,9 +80,15 @@ bool MysqlExpression::HandledFieldType(Item_result type) {
 bool MysqlExpression::SanityAggregationCheck(Item *item, std::set<Item *> &fields, bool toplevel /*= true*/,
                                              bool *has_aggregation /*= NULL*/) {
   // printItemTree(item);
-  if (!item) return false;
-  if (toplevel && !HandledResultType(item)) return false;
-  if (toplevel && has_aggregation) *has_aggregation = false;
+  if (!item) {
+    return false;
+  }
+  if (toplevel && !HandledResultType(item)) {
+    return false;
+  }
+  if (toplevel && has_aggregation) {
+    *has_aggregation = false;
+  }
 
   /*
    * *FIXME*
@@ -105,16 +111,22 @@ bool MysqlExpression::SanityAggregationCheck(Item *item, std::set<Item *> &field
       fields.insert(((Item_tianmufield *)item)->OriginalItem());
       return true;
     case Item::FIELD_ITEM:
-      if (((Item_field *)item)->field && !HandledFieldType(item->result_type())) return false;
+      if (((Item_field *)item)->field && !HandledFieldType(item->result_type())) {
+        return false;
+      }
       fields.insert(item);
       return true;
     case Item::FUNC_ITEM: {
-      if (dynamic_cast<Item_func_trig_cond *>(item) != NULL) return false;
+      if (dynamic_cast<Item_func_trig_cond *>(item) != NULL) {
+        return false;
+      }
 
       // currently stored procedures not supported
       if (dynamic_cast<Item_func_sp *>(item) != NULL) {
         Item_func_sp *ifunc = dynamic_cast<Item_func_sp *>(item);
-        if (ifunc->argument_count() != 0) return false;
+        if (ifunc->argument_count() != 0) {
+          return false;
+        }
         return true;
       }
 
@@ -140,14 +152,18 @@ bool MysqlExpression::SanityAggregationCheck(Item *item, std::set<Item *> &field
       return correct;
     }
     case Item::SUM_FUNC_ITEM: {
-      if (!HandledFieldType(item->result_type())) return false;
+      if (!HandledFieldType(item->result_type())) {
+        return false;
+      }
       if (has_aggregation) *has_aggregation = true;
       fields.insert(item);
       return true;
     }
     case Item::REF_ITEM: {
       Item_ref *iref = dynamic_cast<Item_ref *>(item);
-      if (!iref->ref) return false;
+      if (!iref->ref) {
+        return false;
+      }
       Item *arg = *(iref->ref);
       return SanityAggregationCheck(arg, fields, toplevel, has_aggregation);
     }


### PR DESCRIPTION
    In Tianmu engine conversion syntax tree code style collation

    In the code logic of Tianmu engine conversion syntax tree,
    a large number of if judgment returns to the same line as if, which has the following problems:

    1. During debugging,
        it is not possible to break the point directly at the position where the logic returns,
        so it must be tracked step by step,
        which is unfavorable for fast positioning logic problems

    2. When reading the code,
        I could not quickly understand the relevant logic.
        I wrote the if and return logic on the same line,
        which apparently saved the number of lines of code,
        but increased the effort needed to understand the context

<!--

Thank you for contributing to StoneDB!

PR Title Format: <type>(<scope>): description to this pr (#issue_id)
e.g.
fix(util): fix sth..... (#1)

-->

## Summary about this PR
<!--

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".
e.g.:
Issue: close #11 

-->

Issue Number: close #issue_number_you_created


## Tests Check List
<!-- At least one of next options must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

## Changelog
<!-- At least one of next options must be included. -->

- [ ] New Feature
- [ ] Bug Fix
- [x] Improvement
- [ ] Performance Improvement
- [ ] Build/Testing/CI/CD
- [ ] Documentation
- [ ] Not for changelog (changelog entry is not required)

## Documentation
<!-- At least one of next options must be included. -->

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
