### PR TITLE
feat(StoneDB 8.0): 'bool partitioned' parameter is added by MySQL 8.0 in handlerton->create function. (#596)

### DIFF
--- a/storage/tianmu/handler/tianmu_handler.cpp
+++ b/storage/tianmu/handler/tianmu_handler.cpp
@@ -154,7 +154,8 @@ static core::Value GetValueFromField(Field *f) {
   return v;
 }
 
-TianmuHandler::TianmuHandler(handlerton *hton, TABLE_SHARE *table_arg) : handler(hton, table_arg) {
+TianmuHandler::TianmuHandler(handlerton *hton, TABLE_SHARE *table_arg, bool partitioned)
+    : handler(hton, table_arg), m_partitioned(partitioned) {
   ref_length = sizeof(uint64_t);
 }
 

--- a/storage/tianmu/handler/tianmu_handler.h
+++ b/storage/tianmu/handler/tianmu_handler.h
@@ -27,7 +27,7 @@ namespace dbhandler {
 // Class definition for the storage engine
 class TianmuHandler final : public handler {
  public:
-  TianmuHandler(handlerton *hton, TABLE_SHARE *table_arg);
+  TianmuHandler(handlerton *hton, TABLE_SHARE *table_arg, bool partitioned);
   virtual ~TianmuHandler() = default;
   /* The name that will be used for display purposes */
   const char *table_type() const override { return "TIANMU"; }
@@ -188,6 +188,7 @@ class TianmuHandler final : public handler {
   std::unique_ptr<core::CompiledQuery> m_cq;
   bool m_result = false;
   std::vector<std::vector<uchar>> blob_buffers;
+  bool m_partitioned = false;
 };
 
 }  // namespace dbhandler

--- a/storage/tianmu/handler/tianmu_handler_com.cpp
+++ b/storage/tianmu/handler/tianmu_handler_com.cpp
@@ -63,9 +63,8 @@ static int rcbase_done_func([[maybe_unused]] void *p) {
   DBUG_RETURN(0);
 }
 
-handler *rcbase_create_handler(handlerton *hton, TABLE_SHARE *table, bool partitioned,
-                               MEM_ROOT *mem_root) {  // stonedb8 TODO
-  return new (mem_root) TianmuHandler(hton, table);
+handler *rcbase_create_handler(handlerton *hton, TABLE_SHARE *table, bool partitioned, MEM_ROOT *mem_root) {
+  return new (mem_root) TianmuHandler(hton, table, partitioned);
 }
 
 int rcbase_panic_func([[maybe_unused]] handlerton *hton, enum ha_panic_function flag) {


### PR DESCRIPTION
<!--

Thank you for contributing to StoneDB!

PR Title Format: <type>(<scope>): description to this pr (#issue_id)
e.g.
fix(util): fix sth..... (#1)

-->

## Summary about this PR
<!--

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".
e.g.:
Issue: close #1

-->

Issue Number: close #596

handlerton->create function function add "bool partitioned" parameter, in tianmu as below:
`handler *rcbase_create_handler(handlerton *hton, TABLE_SHARE *table, bool partitioned, MEM_ROOT *mem_root) `

From the create functions of storage engines, we can see that the partitioned value is only used by innodb, others ignore the partitioned argument.
* innodb is row_based, and support partition feature to split rows into partitions;
* tianmu is column_based, now unsupport partition feature. Maybe we can support it in some day,eg, split rows in partitions,
and columns of row belongs to different partitions should not be stored together in one DPN,etc.

Solution: Add 'bool m_partioned' in tianmu engine's handler to indicate the parameter;

## Tests Check List
<!-- At least one of next options must be included. -->

- [ ] Unit test
- [ ] Integration test
- [X] Manual test (add detailed scripts or steps below)
- [ ] No code

## Changelog
<!-- At least one of next options must be included. -->

- [X] New Feature
- [ ] Bug Fix
- [ ] Improvement
- [ ] Performance Improvement
- [ ] Build/Testing/CI/CD
- [ ] Documentation
- [ ] Not for changelog (changelog entry is not required)

## Documentation
<!-- At least one of next options must be included. -->

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
