### PR TITLE
feat(StoneDB 8.0): format tianmu engine's code according to clang-format file. (#618)

### DIFF
--- a/storage/tianmu/async_tests/main.cc
+++ b/storage/tianmu/async_tests/main.cc
@@ -100,11 +100,11 @@ Tianmu::base::future<stdexp::optional<bool>> Recurse(std::shared_ptr<int> counte
 
   int count = (*counter)--;
   return Tianmu::base::smp::submit_to(thd,
-                                       [count, thd] {
-                                         // std::this_thread::sleep_for(1000ms);
-                                         Tianmu::base::print("Calling on : %d thread counter: %d\n", thd, count);
-                                         test_pool(50000, false);
-                                       })
+                                      [count, thd] {
+                                        // std::this_thread::sleep_for(1000ms);
+                                        Tianmu::base::print("Calling on : %d thread counter: %d\n", thd, count);
+                                        test_pool(50000, false);
+                                      })
       .then([thd]() {
         Tianmu::base::print("Called completed on : %d thread \n", thd);
         return stdexp::optional<bool>(stdexp::nullopt);

--- a/storage/tianmu/base/core/checked_ptr.h
+++ b/storage/tianmu/base/core/checked_ptr.h
@@ -93,8 +93,8 @@ inline T *checked_ptr_do_get(T *ptr) noexcept {
 template <typename Ptr, typename NullDerefAction = default_null_deref_action>
 /// \cond GCC6_CONCEPT_DOC
 GCC6_CONCEPT(requires std::is_default_constructible<NullDerefAction>::value &&requires(NullDerefAction action) {
-                                                                                NullDerefAction();
-                                                                              })
+  NullDerefAction();
+})
     /// \endcond
     class checked_ptr {
  public:

--- a/storage/tianmu/base/core/chunked_fifo.h
+++ b/storage/tianmu/base/core/chunked_fifo.h
@@ -138,7 +138,7 @@ class chunked_fifo {
   T &back();
   const T &back() const;
   template <typename... A>
-  inline void emplace_back(A &&...args);
+  inline void emplace_back(A &&... args);
   inline T &front() const noexcept;
   inline void pop_front() noexcept;
   inline bool empty() const noexcept;
@@ -328,7 +328,7 @@ void chunked_fifo<T, items_per_chunk>::undo_room_back() {
 
 template <typename T, size_t items_per_chunk>
 template <typename... Args>
-inline void chunked_fifo<T, items_per_chunk>::emplace_back(Args &&...args) {
+inline void chunked_fifo<T, items_per_chunk>::emplace_back(Args &&... args) {
   ensure_room_back();
   auto p = &_back_chunk->items[mask(_back_chunk->end)].data;
   try {

--- a/storage/tianmu/base/core/circular_buffer.h
+++ b/storage/tianmu/base/core/circular_buffer.h
@@ -71,11 +71,11 @@ class circular_buffer {
   void push_front(const T &data);
   void push_front(T &&data);
   template <typename... A>
-  void emplace_front(A &&...args);
+  void emplace_front(A &&... args);
   void push_back(const T &data);
   void push_back(T &&data);
   template <typename... A>
-  void emplace_back(A &&...args);
+  void emplace_back(A &&... args);
   T &front();
   T &back();
   void pop_front();
@@ -281,7 +281,7 @@ inline void circular_buffer<T, Alloc>::push_front(T &&data) {
 
 template <typename T, typename Alloc>
 template <typename... Args>
-inline void circular_buffer<T, Alloc>::emplace_front(Args &&...args) {
+inline void circular_buffer<T, Alloc>::emplace_front(Args &&... args) {
   maybe_expand();
   auto p = &_impl.storage[mask(_impl.begin - 1)];
   _impl.construct(p, std::forward<Args>(args)...);
@@ -306,7 +306,7 @@ inline void circular_buffer<T, Alloc>::push_back(T &&data) {
 
 template <typename T, typename Alloc>
 template <typename... Args>
-inline void circular_buffer<T, Alloc>::emplace_back(Args &&...args) {
+inline void circular_buffer<T, Alloc>::emplace_back(Args &&... args) {
   maybe_expand();
   auto p = &_impl.storage[mask(_impl.end)];
   _impl.construct(p, std::forward<Args>(args)...);

--- a/storage/tianmu/base/core/circular_buffer_fixed_capacity.h
+++ b/storage/tianmu/base/core/circular_buffer_fixed_capacity.h
@@ -152,11 +152,11 @@ class circular_buffer_fixed_capacity {
   void push_front(const T &data);
   void push_front(T &&data);
   template <typename... A>
-  T &emplace_front(A &&...args);
+  T &emplace_front(A &&... args);
   void push_back(const T &data);
   void push_back(T &&data);
   template <typename... A>
-  T &emplace_back(A &&...args);
+  T &emplace_back(A &&... args);
   T &front();
   T &back();
   void pop_front();
@@ -230,7 +230,7 @@ inline void circular_buffer_fixed_capacity<T, Capacity>::push_front(T &&data) {
 
 template <typename T, size_t Capacity>
 template <typename... Args>
-inline T &circular_buffer_fixed_capacity<T, Capacity>::emplace_front(Args &&...args) {
+inline T &circular_buffer_fixed_capacity<T, Capacity>::emplace_front(Args &&... args) {
   auto p = new (obj(_begin - 1)) T(std::forward<Args>(args)...);
   --_begin;
   return *p;
@@ -250,7 +250,7 @@ inline void circular_buffer_fixed_capacity<T, Capacity>::push_back(T &&data) {
 
 template <typename T, size_t Capacity>
 template <typename... Args>
-inline T &circular_buffer_fixed_capacity<T, Capacity>::emplace_back(Args &&...args) {
+inline T &circular_buffer_fixed_capacity<T, Capacity>::emplace_back(Args &&... args) {
   auto p = new (obj(_end)) T(std::forward<Args>(args)...);
   ++_end;
   return *p;

--- a/storage/tianmu/base/core/do_with.h
+++ b/storage/tianmu/base/core/do_with.h
@@ -92,7 +92,7 @@ inline auto with_lock(Lock &lock, Func &&func) {
 /// \c f executes.  \c f will be called with all arguments as
 /// reference parameters.
 template <typename T1, typename T2, typename T3_or_F, typename... More>
-inline auto do_with(T1 &&rv1, T2 &&rv2, T3_or_F &&rv3, More &&...more) {
+inline auto do_with(T1 &&rv1, T2 &&rv2, T3_or_F &&rv3, More &&... more) {
   auto all = std::forward_as_tuple(std::forward<T1>(rv1), std::forward<T2>(rv2), std::forward<T3_or_F>(rv3),
                                    std::forward<More>(more)...);
   constexpr size_t nr = std::tuple_size<decltype(all)>::value - 1;

--- a/storage/tianmu/base/core/execution_stage.h
+++ b/storage/tianmu/base/core/execution_stage.h
@@ -266,7 +266,7 @@ class concrete_execution_stage final : public execution_stage {
     promise_type _ready;
 
     template <typename... Args>
-    work_item(Args &&...args) : _in(std::forward<Args>(args)...) {}
+    work_item(Args &&... args) : _in(std::forward<Args>(args)...) {}
 
     work_item(work_item &&other) = delete;
     work_item(const work_item &) = delete;
@@ -330,7 +330,7 @@ class concrete_execution_stage final : public execution_stage {
   /// \return future containing the result of the call to the stage's function
   template <typename... Args>
   GCC6_CONCEPT(requires std::is_constructible<input_type, Args...>::value)
-  return_type operator()(Args &&...args) {
+  return_type operator()(Args &&... args) {
     _queue.emplace_back(std::forward<Args>(args)...);
     _empty = false;
     _stats.function_calls_enqueued++;

--- a/storage/tianmu/base/core/future.h
+++ b/storage/tianmu/base/core/future.h
@@ -88,7 +88,7 @@ class shared_future;
 /// to perform a computation (for example, because the data is cached
 /// in some buffer).
 template <typename... T, typename... A>
-future<T...> make_ready_future(A &&...value);
+future<T...> make_ready_future(A &&... value);
 
 /// \brief Creates a \ref future in an available, failed state.
 ///
@@ -203,7 +203,7 @@ struct future_state {
     _state = state::result;
   }
   template <typename... A>
-  void set(A &&...a) {
+  void set(A &&... a) {
     assert(_state == state::future);
     new (&_u.value) std::tuple<T...>(std::forward<A>(a)...);
     _state = state::result;
@@ -454,7 +454,7 @@ class promise {
   /// Forwards the arguments and makes them available to the associated
   /// future.  May be called either before or after \c get_future().
   template <typename... A>
-  void set_value(A &&...a) noexcept {
+  void set_value(A &&... a) noexcept {
     assert(_state);
     _state->set(std::forward<A>(a)...);
     make_ready<urgent::no>();
@@ -569,7 +569,7 @@ struct futurize {
   /// Apply a function to an argument list
   /// and return the result, as a future (if it wasn't already).
   template <typename Func, typename... FuncArgs>
-  static inline type apply(Func &&func, FuncArgs &&...args) noexcept;
+  static inline type apply(Func &&func, FuncArgs &&... args) noexcept;
 
   /// Convert a value or a future to a future
   static inline type convert(T &&value) { return make_ready_future<T>(std::move(value)); }
@@ -596,7 +596,7 @@ struct futurize<void> {
   static inline type apply(Func &&func, std::tuple<FuncArgs...> &&args) noexcept;
 
   template <typename Func, typename... FuncArgs>
-  static inline type apply(Func &&func, FuncArgs &&...args) noexcept;
+  static inline type apply(Func &&func, FuncArgs &&... args) noexcept;
 
   static inline type from_tuple(value_type &&value);
   static inline type from_tuple(const value_type &value);
@@ -614,9 +614,9 @@ struct futurize<future<Args...>> {
   static inline type apply(Func &&func, std::tuple<FuncArgs...> &&args) noexcept;
 
   template <typename Func, typename... FuncArgs>
-  static inline type apply(Func &&func, FuncArgs &&...args) noexcept;
+  static inline type apply(Func &&func, FuncArgs &&... args) noexcept;
 
-  static inline type convert(Args &&...values) { return make_ready_future<Args...>(std::move(values)...); }
+  static inline type convert(Args &&... values) { return make_ready_future<Args...>(std::move(values)...); }
   static inline type convert(type &&value) { return std::move(value); }
 
   template <typename Arg>
@@ -639,7 +639,8 @@ GCC6_CONCEPT(
 
     template <typename Func, typename Return, typename... T> concept bool ApplyReturns =
         requires(Func f, T... args) {
-          { f(std::forward<T>(args)...) } -> Return;
+          { f(std::forward<T>(args)...) }
+          ->Return;
         };
 
     template <typename Func, typename... T> concept bool ApplyReturnsAnyFuture =
@@ -672,7 +673,7 @@ class future {
  private:
   future(promise<T...> *pr) noexcept : _promise(pr) { _promise->_future = this; }
   template <typename... A>
-  future(ready_future_marker, A &&...a) : _promise(nullptr) {
+  future(ready_future_marker, A &&... a) : _promise(nullptr) {
     _local_state.set(std::forward<A>(a)...);
   }
   template <typename... A>
@@ -1070,7 +1071,7 @@ class future {
   template <typename... U>
   friend class promise;
   template <typename... U, typename... A>
-  friend future<U...> make_ready_future(A &&...value);
+  friend future<U...> make_ready_future(A &&... value);
   template <typename... U>
   friend future<U...> make_exception_future(std::exception_ptr ex) noexcept;
   template <typename... U, typename Exception>
@@ -1128,7 +1129,7 @@ inline void promise<T...>::abandoned() noexcept {
 }
 
 template <typename... T, typename... A>
-inline future<T...> make_ready_future(A &&...value) {
+inline future<T...> make_ready_future(A &&... value) {
   return future<T...>(ready_future_marker(), std::forward<A>(value)...);
 }
 
@@ -1164,7 +1165,7 @@ typename futurize<T>::type futurize<T>::apply(Func &&func, std::tuple<FuncArgs..
 
 template <typename T>
 template <typename Func, typename... FuncArgs>
-typename futurize<T>::type futurize<T>::apply(Func &&func, FuncArgs &&...args) noexcept {
+typename futurize<T>::type futurize<T>::apply(Func &&func, FuncArgs &&... args) noexcept {
   try {
     return convert(func(std::forward<FuncArgs>(args)...));
   } catch (...) {
@@ -1174,7 +1175,7 @@ typename futurize<T>::type futurize<T>::apply(Func &&func, FuncArgs &&...args) n
 
 template <typename Func, typename... FuncArgs>
 inline std::enable_if_t<!is_future<std::result_of_t<Func(FuncArgs &&...)>>::value, future<>> do_void_futurize_apply(
-    Func &&func, FuncArgs &&...args) noexcept {
+    Func &&func, FuncArgs &&... args) noexcept {
   try {
     func(std::forward<FuncArgs>(args)...);
     return make_ready_future<>();
@@ -1185,7 +1186,7 @@ inline std::enable_if_t<!is_future<std::result_of_t<Func(FuncArgs &&...)>>::valu
 
 template <typename Func, typename... FuncArgs>
 inline std::enable_if_t<is_future<std::result_of_t<Func(FuncArgs &&...)>>::value, future<>> do_void_futurize_apply(
-    Func &&func, FuncArgs &&...args) noexcept {
+    Func &&func, FuncArgs &&... args) noexcept {
   try {
     return func(std::forward<FuncArgs>(args)...);
   } catch (...) {
@@ -1220,7 +1221,7 @@ typename futurize<void>::type futurize<void>::apply(Func &&func, std::tuple<Func
 }
 
 template <typename Func, typename... FuncArgs>
-typename futurize<void>::type futurize<void>::apply(Func &&func, FuncArgs &&...args) noexcept {
+typename futurize<void>::type futurize<void>::apply(Func &&func, FuncArgs &&... args) noexcept {
   return do_void_futurize_apply(std::forward<Func>(func), std::forward<FuncArgs>(args)...);
 }
 
@@ -1237,7 +1238,7 @@ typename futurize<future<Args...>>::type futurize<future<Args...>>::apply(Func &
 
 template <typename... Args>
 template <typename Func, typename... FuncArgs>
-typename futurize<future<Args...>>::type futurize<future<Args...>>::apply(Func &&func, FuncArgs &&...args) noexcept {
+typename futurize<future<Args...>>::type futurize<future<Args...>>::apply(Func &&func, FuncArgs &&... args) noexcept {
   try {
     return func(std::forward<FuncArgs>(args)...);
   } catch (...) {
@@ -1277,7 +1278,7 @@ inline future<> futurize<void>::from_tuple([[maybe_unused]] std::tuple<> &&value
 inline future<> futurize<void>::from_tuple([[maybe_unused]] const std::tuple<> &value) { return make_ready_future<>(); }
 
 template <typename Func, typename... Args>
-auto futurize_apply(Func &&func, Args &&...args) {
+auto futurize_apply(Func &&func, Args &&... args) {
   using futurator = futurize<std::result_of_t<Func(Args && ...)>>;
   return futurator::apply(std::forward<Func>(func), std::forward<Args>(args)...);
 }

--- a/storage/tianmu/base/core/print.h
+++ b/storage/tianmu/base/core/print.h
@@ -40,25 +40,25 @@ namespace Tianmu {
 namespace base {
 
 template <typename... A>
-std::ostream &fprint(std::ostream &os, const char *fmt, A &&...a) {
+std::ostream &fprint(std::ostream &os, const char *fmt, A &&... a) {
   Tianmu::fmt::fprintf(os, fmt, std::forward<A>(a)...);
   return os;
 }
 
 template <typename... A>
-void print(const char *fmt, A &&...a) {
+void print(const char *fmt, A &&... a) {
   Tianmu::fmt::printf(fmt, std::forward<A>(a)...);
 }
 
 template <typename... A>
-std::string sprint(const char *fmt, A &&...a) {
+std::string sprint(const char *fmt, A &&... a) {
   std::ostringstream os;
   Tianmu::fmt::fprintf(os, fmt, std::forward<A>(a)...);
   return os.str();
 }
 
 template <typename... A>
-std::string sprint(const sstring &fmt, A &&...a) {
+std::string sprint(const sstring &fmt, A &&... a) {
   std::ostringstream os;
   Tianmu::fmt::fprintf(os, fmt.c_str(), std::forward<A>(a)...);
   return os.str();
@@ -98,7 +98,7 @@ std::ostream &operator<<(std::ostream &os,
 }
 
 template <typename... A>
-void log(A &&...a) {
+void log(A &&... a) {
   std::cout << usecfmt(std::chrono::high_resolution_clock::now()) << " ";
   print(std::forward<A>(a)...);
 }
@@ -113,7 +113,7 @@ void log(A &&...a) {
  *         parameters on a given format string.
  */
 template <typename... A>
-sstring format(const char *fmt, A &&...a) {
+sstring format(const char *fmt, A &&... a) {
   fmt::MemoryWriter out;
   out.write(fmt, std::forward<A>(a)...);
   return sstring{out.data(), out.size()};

--- a/storage/tianmu/base/core/reactor.cpp
+++ b/storage/tianmu/base/core/reactor.cpp
@@ -103,7 +103,7 @@ constexpr std::chrono::milliseconds lowres_clock_impl::_granularity;
 static bool sched_debug() { return false; }
 
 template <typename... Args>
-void sched_print(const char *fmt, Args &&...args) {
+void sched_print(const char *fmt, Args &&... args) {
   if (sched_debug()) {
     sched_logger.trace(fmt, std::forward<Args>(args)...);
   }

--- a/storage/tianmu/base/core/reactor.h
+++ b/storage/tianmu/base/core/reactor.h
@@ -349,7 +349,7 @@ class smp_message_queue {
 // OSv-specific file-descriptor-less mechanisms (reactor_backend_osv).
 class reactor_backend {
  public:
-  virtual ~reactor_backend(){}
+  virtual ~reactor_backend() {}
   // wait_and_process() waits for some events to become available, and
   // processes one or more of them. If block==false, it doesn't wait,
   // and just processes events that have already happened, if any.

--- a/storage/tianmu/base/core/scollectd.h
+++ b/storage/tianmu/base/core/scollectd.h
@@ -435,10 +435,10 @@ struct typed_value {
    * Used to group types into a plugin_instance_metrics
    */
   template <typename... Args>
-  typed_value(const type_id &tid, const scollectd::type_instance &ti, description, Args &&...args);
+  typed_value(const type_id &tid, const scollectd::type_instance &ti, description, Args &&... args);
 
   template <typename... Args>
-  typed_value(const type_id &tid, const scollectd::type_instance &ti, Args &&...args)
+  typed_value(const type_id &tid, const scollectd::type_instance &ti, Args &&... args)
       : typed_value(tid, ti, description(), std::forward<Args>(args)...) {}
 
   const scollectd::type_instance &type_instance() const { return _type_instance; }
@@ -454,7 +454,7 @@ struct typed_value {
 class plugin_instance_metrics {
  public:
   template <typename... TypedValues>
-  plugin_instance_metrics(const plugin_id &p, const plugin_instance_id &pi, TypedValues &&...values)
+  plugin_instance_metrics(const plugin_id &p, const plugin_instance_id &pi, TypedValues &&... values)
       : _plugin_id(p), _plugin_instance(pi), _registrations({add_impl(values)...}) {}
   std::vector<type_instance_id> bound_ids() const;
   void add(const typed_value &);
@@ -474,7 +474,7 @@ class plugin_instance_metrics {
 class percpu_plugin_instance_metrics : public plugin_instance_metrics {
  public:
   template <typename... TypedValues>
-  percpu_plugin_instance_metrics(const plugin_id &p, TypedValues &&...values)
+  percpu_plugin_instance_metrics(const plugin_id &p, TypedValues &&... values)
       : plugin_instance_metrics(p, per_cpu_plugin_instance, std::forward<TypedValues>(values)...) {}
 };
 
@@ -485,14 +485,14 @@ class percpu_plugin_instance_metrics : public plugin_instance_metrics {
 template <known_type Type>
 struct typed_value_impl : public typed_value {
   template <typename... Args>
-  typed_value_impl(const scollectd::type_instance &ti, Args &&...args)
+  typed_value_impl(const scollectd::type_instance &ti, Args &&... args)
       : typed_value(type_id_for(Type), ti, std::forward<Args>(args)...) {}
 
   template <typename... Args>
-  typed_value_impl(scollectd::type_instance ti, description d, Args &&...args)
+  typed_value_impl(scollectd::type_instance ti, description d, Args &&... args)
       : typed_value(type_id_for(Type), std::move(ti), std::move(d), std::forward<Args>(args)...) {}
   template <typename... Args>
-  typed_value_impl(description d, Args &&...args)
+  typed_value_impl(description d, Args &&... args)
       : typed_value(type_id_for(Type), scollectd::type_instance(), std::move(d), std::forward<Args>(args)...) {}
 };
 
@@ -647,7 +647,7 @@ class values_impl : public value_list {
  public:
   static const size_t num_values = sizeof...(Args);
 
-  values_impl(description d, Args &&...args) : value_list(std::move(d)), _values(std::forward<Args>(args)...) {}
+  values_impl(description d, Args &&... args) : value_list(std::move(d)), _values(std::forward<Args>(args)...) {}
 
   values_impl(values_impl<Args...> &&a) = default;
   values_impl(const values_impl<Args...> &a) = default;
@@ -684,7 +684,7 @@ void add_polled(const type_instance_id &, const shared_ptr<value_list> &, bool e
 
 using notify_function = std::function<void()>;
 template <typename... _Args>
-static auto make_type_instance(description d, _Args &&...args)
+static auto make_type_instance(description d, _Args &&... args)
     -> values_impl<decltype(value<_Args>(std::forward<_Args>(args)))...> {
   return values_impl<decltype(value<_Args>(std::forward<_Args>(args)))...>(std::move(d),
                                                                            value<_Args>(std::forward<_Args>(args))...);
@@ -696,7 +696,7 @@ static auto make_type_instance(description d, _Args &&...args)
 template <typename... _Args>
 [[deprecated("Use the metrics layer")]] static type_instance_id add_polled_metric(
     const plugin_id &plugin, const plugin_instance_id &plugin_instance, const type_id &type,
-    const scollectd::type_instance &type_instance, _Args &&...args) {
+    const scollectd::type_instance &type_instance, _Args &&... args) {
   return add_polled_metric(plugin, plugin_instance, type, type_instance, description(), std::forward<_Args>(args)...);
 }
 /*!
@@ -706,21 +706,21 @@ template <typename... _Args>
 template <typename... _Args>
 [[deprecated("Use the metrics layer")]] static type_instance_id add_polled_metric(
     const plugin_id &plugin, const plugin_instance_id &plugin_instance, const type_id &type,
-    const scollectd::type_instance &type_instance, description d, _Args &&...args) {
+    const scollectd::type_instance &type_instance, description d, _Args &&... args) {
   return add_polled_metric(type_instance_id(plugin, plugin_instance, type, type_instance), std::move(d),
                            std::forward<_Args>(args)...);
 }
 template <typename... _Args>
 static future<> send_explicit_metric(const plugin_id &plugin, const plugin_instance_id &plugin_instance,
                                      const type_id &type, const scollectd::type_instance &type_instance,
-                                     _Args &&...args) {
+                                     _Args &&... args) {
   return send_explicit_metric(type_instance_id(plugin, plugin_instance, type, type_instance),
                               std::forward<_Args>(args)...);
 }
 template <typename... _Args>
 static notify_function create_explicit_metric(const plugin_id &plugin, const plugin_instance_id &plugin_instance,
                                               const type_id &type, const scollectd::type_instance &type_instance,
-                                              _Args &&...args) {
+                                              _Args &&... args) {
   return create_explicit_metric(type_instance_id(plugin, plugin_instance, type, type_instance),
                                 std::forward<_Args>(args)...);
 }
@@ -766,24 +766,24 @@ static type_instance_id add_disabled_polled_metric(const type_instance_id &id, A
 }
 
 template <typename... Args>
-static type_instance_id add_disabled_polled_metric(const type_instance_id &id, Args &&...args) {
+static type_instance_id add_disabled_polled_metric(const type_instance_id &id, Args &&... args) {
   return add_disabled_polled_metric(id, description(), std::forward<Args>(args)...);
 }
 
 // "Explicit" metric sends. Sends a single value list as a message.
 // Obviously not super efficient either. But maybe someone needs it sometime.
 template <typename... _Args>
-static future<> send_explicit_metric(const type_instance_id &id, _Args &&...args) {
+static future<> send_explicit_metric(const type_instance_id &id, _Args &&... args) {
   return send_metric(id, make_type_instance(std::forward<_Args>(args)...));
 }
 template <typename... _Args>
-static notify_function create_explicit_metric(const type_instance_id &id, _Args &&...args) {
+static notify_function create_explicit_metric(const type_instance_id &id, _Args &&... args) {
   auto list = make_type_instance(std::forward<_Args>(args)...);
   return [id, list = std::move(list)]() { send_metric(id, list); };
 }
 
 template <typename... Args>
-typed_value::typed_value(const type_id &tid, const scollectd::type_instance &ti, description d, Args &&...args)
+typed_value::typed_value(const type_id &tid, const scollectd::type_instance &ti, description d, Args &&... args)
     : _type_id(tid),
       _type_instance(ti),
       _values(base::make_shared<decltype(make_type_instance(std::move(d), std::forward<Args>(args)...))>(

--- a/storage/tianmu/base/core/sharded.h
+++ b/storage/tianmu/base/core/sharded.h
@@ -147,7 +147,7 @@ class sharded {
   /// \return a \ref future<> that becomes ready when all instances have been
   ///         constructed.
   template <typename... Args>
-  future<> start(Args &&...args);
+  future<> start(Args &&... args);
 
   /// Starts \c Service by constructing an instance on a single logical core
   /// with a copy of \c args passed to the constructor.
@@ -156,7 +156,7 @@ class sharded {
   /// \return a \ref future<> that becomes ready when the instance has been
   ///         constructed.
   template <typename... Args>
-  future<> start_single(Args &&...args);
+  future<> start_single(Args &&... args);
 
   /// Stops all started instances and destroys them.
   ///
@@ -196,14 +196,14 @@ class sharded {
   /// \see map_reduce(Iterator begin, Iterator end, Mapper&& mapper, Reducer&&
   /// r)
   template <typename Reducer, typename Ret, typename... FuncArgs, typename... Args>
-  inline auto map_reduce(Reducer &&r, Ret (Service::*func)(FuncArgs...), Args &&...args) ->
+  inline auto map_reduce(Reducer &&r, Ret (Service::*func)(FuncArgs...), Args &&... args) ->
       typename reducer_traits<Reducer>::future_type {
     return base::map_reduce(
         boost::make_counting_iterator<unsigned>(0), boost::make_counting_iterator<unsigned>(_instances.size()),
         [this, func, args = std::make_tuple(std::forward<Args>(args)...)](unsigned c) mutable {
           return smp::submit_to(c, [this, func, args]() mutable {
             return apply(
-                [this, func](Args &&...args) mutable {
+                [this, func](Args &&... args) mutable {
                   auto inst = _instances[engine().cpu_id()].service;
                   if (inst) {
                     return ((*inst).*func)(std::forward<Args>(args)...);
@@ -299,7 +299,7 @@ class sharded {
   /// \param args arguments to be passed to `func`
   /// \return result of calling `func(args)` on the designated instance
   template <typename Ret, typename... FuncArgs, typename... Args, typename FutureRet = futurize_t<Ret>>
-  FutureRet invoke_on(unsigned id, Ret (Service::*func)(FuncArgs...), Args &&...args) {
+  FutureRet invoke_on(unsigned id, Ret (Service::*func)(FuncArgs...), Args &&... args) {
     using futurator = futurize<Ret>;
     return smp::submit_to(id, [this, func, args = std::make_tuple(std::forward<Args>(args)...)]() mutable {
       auto inst = get_local_service();
@@ -341,7 +341,7 @@ class sharded {
   }
 
   template <typename... Args>
-  shared_ptr<Service> create_local_service(Args &&...args) {
+  shared_ptr<Service> create_local_service(Args &&... args) {
     auto s = base::make_shared<Service>(std::forward<Args>(args)...);
     set_container(*s);
     track_deletion(s, std::is_base_of<async_sharded_service<Service>, Service>());
@@ -393,7 +393,7 @@ sharded<Service>::sharded(sharded &&x) noexcept : _instances(std::move(x._instan
 
 template <typename Service>
 template <typename... Args>
-future<> sharded<Service>::start(Args &&...args) {
+future<> sharded<Service>::start(Args &&... args) {
   _instances.resize(smp::count);
   return parallel_for_each(
              boost::irange<unsigned>(0, _instances.size()),
@@ -418,7 +418,7 @@ future<> sharded<Service>::start(Args &&...args) {
 
 template <typename Service>
 template <typename... Args>
-future<> sharded<Service>::start_single(Args &&...args) {
+future<> sharded<Service>::start_single(Args &&... args) {
   assert(_instances.empty());
   _instances.resize(1);
   return smp::submit_to(0,

--- a/storage/tianmu/base/core/shared_future.h
+++ b/storage/tianmu/base/core/shared_future.h
@@ -254,7 +254,7 @@ class shared_promise {
 
   /// \brief Sets the shared_promise's value (variadic), same as normal promise
   template <typename... A>
-  void set_value(A &&...a) noexcept {
+  void set_value(A &&... a) noexcept {
     _promise.set_value(std::forward<A>(a)...);
   }
 

--- a/storage/tianmu/base/core/shared_ptr.h
+++ b/storage/tianmu/base/core/shared_ptr.h
@@ -73,7 +73,7 @@ template <typename T>
 class enable_shared_from_this;
 
 template <typename T, typename... A>
-lw_shared_ptr<T> make_lw_shared(A &&...a);
+lw_shared_ptr<T> make_lw_shared(A &&... a);
 
 template <typename T>
 lw_shared_ptr<T> make_lw_shared(T &&a);
@@ -82,7 +82,7 @@ template <typename T>
 lw_shared_ptr<T> make_lw_shared(T &a);
 
 template <typename T, typename... A>
-shared_ptr<T> make_shared(A &&...a);
+shared_ptr<T> make_shared(A &&... a);
 
 template <typename T>
 shared_ptr<T> make_shared(T &&a);
@@ -160,7 +160,7 @@ struct shared_ptr_no_esft : private lw_shared_ptr_counter_base {
   shared_ptr_no_esft(const T &x) : _value(x) {}
   shared_ptr_no_esft(T &&x) : _value(std::move(x)) {}
   template <typename... A>
-  shared_ptr_no_esft(A &&...a) : _value(std::forward<A>(a)...) {}
+  shared_ptr_no_esft(A &&... a) : _value(std::forward<A>(a)...) {}
 
   template <typename X>
   friend class lw_shared_ptr;
@@ -243,7 +243,7 @@ class lw_shared_ptr {
     }
   }
   template <typename... A>
-  static lw_shared_ptr make(A &&...a) {
+  static lw_shared_ptr make(A &&... a) {
     auto p = new concrete_type(std::forward<A>(a)...);
     accessors::instantiate_to_value(p);
     return lw_shared_ptr(p);
@@ -339,7 +339,7 @@ class lw_shared_ptr {
 };
 
 template <typename T, typename... A>
-inline lw_shared_ptr<T> make_lw_shared(A &&...a) {
+inline lw_shared_ptr<T> make_lw_shared(A &&... a) {
   return lw_shared_ptr<T>::make(std::forward<A>(a)...);
 }
 
@@ -383,7 +383,7 @@ template <typename T>
 struct shared_ptr_count_for : shared_ptr_count_base {
   T data;
   template <typename... A>
-  shared_ptr_count_for(A &&...a) : data(std::forward<A>(a)...) {}
+  shared_ptr_count_for(A &&... a) : data(std::forward<A>(a)...) {}
 };
 
 template <typename T>
@@ -494,7 +494,7 @@ class shared_ptr {
   struct make_helper;
 
   template <typename U, typename... A>
-  friend shared_ptr<U> make_shared(A &&...a);
+  friend shared_ptr<U> make_shared(A &&... a);
 
   template <typename U>
   friend shared_ptr<U> make_shared(U &&a);
@@ -509,7 +509,7 @@ class shared_ptr {
   friend shared_ptr<V> const_pointer_cast(const shared_ptr<U> &p);
 
   template <bool esft, typename... A>
-  static shared_ptr make(A &&...a);
+  static shared_ptr make(A &&... a);
 
   template <typename U>
   friend class enable_shared_from_this;
@@ -527,7 +527,7 @@ struct shared_ptr_make_helper;
 template <typename T>
 struct shared_ptr_make_helper<T, false> {
   template <typename... A>
-  static shared_ptr<T> make(A &&...a) {
+  static shared_ptr<T> make(A &&... a) {
     return shared_ptr<T>(new shared_ptr_count_for<T>(std::forward<A>(a)...));
   }
 };
@@ -535,14 +535,14 @@ struct shared_ptr_make_helper<T, false> {
 template <typename T>
 struct shared_ptr_make_helper<T, true> {
   template <typename... A>
-  static shared_ptr<T> make(A &&...a) {
+  static shared_ptr<T> make(A &&... a) {
     auto p = new T(std::forward<A>(a)...);
     return shared_ptr<T>(p, p);
   }
 };
 
 template <typename T, typename... A>
-inline shared_ptr<T> make_shared(A &&...a) {
+inline shared_ptr<T> make_shared(A &&... a) {
   using helper = shared_ptr_make_helper<T, std::is_base_of<shared_ptr_count_base, T>::value>;
   return helper::make(std::forward<A>(a)...);
 }

--- a/storage/tianmu/base/core/sstring.h
+++ b/storage/tianmu/base/core/sstring.h
@@ -599,7 +599,7 @@ static inline size_type str_len(const basic_sstring<char_type, size_type, max_si
 }
 
 template <typename First, typename Second, typename... Tail>
-static inline size_t str_len(const First &first, const Second &second, const Tail &...tail) {
+static inline size_t str_len(const First &first, const Second &second, const Tail &... tail) {
   return str_len(first) + str_len(second, tail...);
 }
 
@@ -642,12 +642,12 @@ namespace base {
 static inline char *copy_str_to(char *dst) { return dst; }
 
 template <typename Head, typename... Tail>
-static inline char *copy_str_to(char *dst, const Head &head, const Tail &...tail) {
+static inline char *copy_str_to(char *dst, const Head &head, const Tail &... tail) {
   return copy_str_to(std::copy(str_begin(head), str_end(head), dst), tail...);
 }
 
 template <typename String = sstring, typename... Args>
-static String make_sstring(Args &&...args) {
+static String make_sstring(Args &&... args) {
   String ret(sstring::initialized_later(), str_len(args...));
   copy_str_to(ret.begin(), args...);
   return ret;

--- a/storage/tianmu/base/core/thread.h
+++ b/storage/tianmu/base/core/thread.h
@@ -302,7 +302,7 @@ inline future<> thread::join() {
 /// \endcode
 template <typename Func, typename... Args>
 inline futurize_t<std::result_of_t<std::decay_t<Func>(std::decay_t<Args>...)>> async(thread_attributes attr,
-                                                                                     Func &&func, Args &&...args) {
+                                                                                     Func &&func, Args &&... args) {
   using return_type = std::result_of_t<std::decay_t<Func>(std::decay_t<Args>...)>;
   struct work {
     thread_attributes attr;
@@ -331,7 +331,7 @@ inline futurize_t<std::result_of_t<std::decay_t<Func>(std::decay_t<Args>...)>> a
 /// \param args a parameter pack to be forwarded to \c func.
 /// \return whatever \c func returns, as a future.
 template <typename Func, typename... Args>
-inline futurize_t<std::result_of_t<std::decay_t<Func>(std::decay_t<Args>...)>> async(Func &&func, Args &&...args) {
+inline futurize_t<std::result_of_t<std::decay_t<Func>(std::decay_t<Args>...)>> async(Func &&func, Args &&... args) {
   return async(thread_attributes{}, std::forward<Func>(func), std::forward<Args>(args)...);
 }
 

--- a/storage/tianmu/base/fmt/format.h
+++ b/storage/tianmu/base/fmt/format.h
@@ -276,8 +276,7 @@ using intmax_t = __int64;
 #define FMT_USE_EXTERN_TEMPLATES \
   ((__clang__ && FMT_USE_VARIADIC_TEMPLATES) || (FMT_GCC_VERSION >= 303 && FMT_HAS_GXX_CXX11))
 #else
-#define FMT_USE_EXTERN_TEMPLATES \
-  ((0 && FMT_USE_VARIADIC_TEMPLATES) || (FMT_GCC_VERSION >= 303 && FMT_HAS_GXX_CXX11))
+#define FMT_USE_EXTERN_TEMPLATES ((0 && FMT_USE_VARIADIC_TEMPLATES) || (FMT_GCC_VERSION >= 303 && FMT_HAS_GXX_CXX11))
 #endif
 #endif
 
@@ -2188,7 +2187,7 @@ struct ArgArray<N, false /*IsPacked*/> {
 
 #if FMT_USE_VARIADIC_TEMPLATES
 template <typename Arg, typename... Args>
-inline uint64_t make_type(const Arg &first, const Args &...tail) {
+inline uint64_t make_type(const Arg &first, const Args &... tail) {
   return make_type(first) | (make_type(tail...) << 4);
 }
 
@@ -2223,7 +2222,7 @@ inline uint64_t make_type(FMT_GEN15(FMT_ARG_TYPE_DEFAULT)) {
 // Defines a variadic function returning void.
 #define FMT_VARIADIC_VOID(func, arg_type)                                                       \
   template <typename... Args>                                                                   \
-  void func(arg_type arg0, const Args &...args) {                                               \
+  void func(arg_type arg0, const Args &... args) {                                              \
     typedef fmt::internal::ArgArray<sizeof...(Args)> ArgArray;                                  \
     typename ArgArray::Type array{ArgArray::template make<fmt::BasicFormatter<Char>>(args)...}; \
     func(arg0, fmt::ArgList(fmt::internal::make_type(args...), array));                         \
@@ -2232,7 +2231,7 @@ inline uint64_t make_type(FMT_GEN15(FMT_ARG_TYPE_DEFAULT)) {
 // Defines a variadic constructor.
 #define FMT_VARIADIC_CTOR(ctor, func, arg0_type, arg1_type)                                     \
   template <typename... Args>                                                                   \
-  ctor(arg0_type arg0, arg1_type arg1, const Args &...args) {                                   \
+  ctor(arg0_type arg0, arg1_type arg1, const Args &... args) {                                  \
     typedef fmt::internal::ArgArray<sizeof...(Args)> ArgArray;                                  \
     typename ArgArray::Type array{ArgArray::template make<fmt::BasicFormatter<Char>>(args)...}; \
     func(arg0, arg1, fmt::ArgList(fmt::internal::make_type(args...), array));                   \
@@ -3364,7 +3363,7 @@ void arg(WStringRef, const internal::NamedArg<Char> &) FMT_DELETED_OR_UNDEFINED;
 #if FMT_USE_VARIADIC_TEMPLATES
 #define FMT_VARIADIC_(Char, ReturnType, func, call, ...)                                                       \
   template <typename... Args>                                                                                  \
-  ReturnType func(FMT_FOR_EACH(FMT_ADD_ARG_NAME, __VA_ARGS__), const Args &...args) {                          \
+  ReturnType func(FMT_FOR_EACH(FMT_ADD_ARG_NAME, __VA_ARGS__), const Args &... args) {                         \
     typedef fmt::internal::ArgArray<sizeof...(Args)> ArgArray;                                                 \
     typename ArgArray::Type array{ArgArray::template make<fmt::BasicFormatter<Char>>(args)...};                \
     call(FMT_FOR_EACH(FMT_GET_ARG_NAME, __VA_ARGS__), fmt::ArgList(fmt::internal::make_type(args...), array)); \
@@ -3782,7 +3781,7 @@ struct UdlFormat {
   const Char *str;
 
   template <typename... Args>
-  auto operator()(Args &&...args) const -> decltype(format(str, std::forward<Args>(args)...)) {
+  auto operator()(Args &&... args) const -> decltype(format(str, std::forward<Args>(args)...)) {
     return format(str, std::forward<Args>(args)...);
   }
 };

--- a/storage/tianmu/base/net/api.h
+++ b/storage/tianmu/base/net/api.h
@@ -92,7 +92,7 @@ class get_impl;
 
 class udp_datagram_impl {
  public:
-  virtual ~udp_datagram_impl(){}
+  virtual ~udp_datagram_impl() {}
   virtual ipv4_addr get_src() = 0;
   virtual ipv4_addr get_dst() = 0;
   virtual uint16_t get_dst_port() = 0;
@@ -104,7 +104,7 @@ class udp_datagram final {
   std::unique_ptr<udp_datagram_impl> _impl;
 
  public:
-  udp_datagram(std::unique_ptr<udp_datagram_impl> &&impl) : _impl(std::move(impl)){}
+  udp_datagram(std::unique_ptr<udp_datagram_impl> &&impl) : _impl(std::move(impl)) {}
   ipv4_addr get_src() { return _impl->get_src(); }
   ipv4_addr get_dst() { return _impl->get_dst(); }
   uint16_t get_dst_port() { return _impl->get_dst_port(); }

--- a/storage/tianmu/base/net/byteorder.h
+++ b/storage/tianmu/base/net/byteorder.h
@@ -97,13 +97,13 @@ inline void ntoh_inplace() {}
 inline void hton_inplace(){};
 
 template <typename First, typename... Rest>
-inline void ntoh_inplace(First &first, Rest &...rest) {
+inline void ntoh_inplace(First &first, Rest &... rest) {
   first = ntoh(first);
   ntoh_inplace(std::forward<Rest &>(rest)...);
 }
 
 template <typename First, typename... Rest>
-inline void hton_inplace(First &first, Rest &...rest) {
+inline void hton_inplace(First &first, Rest &... rest) {
   first = hton(first);
   hton_inplace(std::forward<Rest &>(rest)...);
 }
@@ -111,14 +111,14 @@ inline void hton_inplace(First &first, Rest &...rest) {
 template <class T>
 inline T ntoh(const T &x) {
   T tmp = x;
-  tmp.adjust_endianness([](auto &&...what) { ntoh_inplace(std::forward<decltype(what) &>(what)...); });
+  tmp.adjust_endianness([](auto &&... what) { ntoh_inplace(std::forward<decltype(what) &>(what)...); });
   return tmp;
 }
 
 template <class T>
 inline T hton(const T &x) {
   T tmp = x;
-  tmp.adjust_endianness([](auto &&...what) { hton_inplace(std::forward<decltype(what) &>(what)...); });
+  tmp.adjust_endianness([](auto &&... what) { hton_inplace(std::forward<decltype(what) &>(what)...); });
   return tmp;
 }
 

--- a/storage/tianmu/base/net/packet.h
+++ b/storage/tianmu/base/net/packet.h
@@ -298,8 +298,12 @@ class packet final {
   bool allocate_headroom(size_t size);
 
  public:
-  class offload_info offload_info() const { return _impl->_offload_info; }
-  class offload_info &offload_info_ref() { return _impl->_offload_info; }
+  class offload_info offload_info() const {
+    return _impl->_offload_info;
+  }
+  class offload_info &offload_info_ref() {
+    return _impl->_offload_info;
+  }
   void set_offload_info(class offload_info oi) { _impl->_offload_info = oi; }
 };
 

--- a/storage/tianmu/base/net/stack.h
+++ b/storage/tianmu/base/net/stack.h
@@ -66,7 +66,7 @@ class server_socket_impl {
 
 class udp_channel_impl {
  public:
-  virtual ~udp_channel_impl(){}
+  virtual ~udp_channel_impl() {}
   virtual future<udp_datagram> receive() = 0;
   virtual future<> send(ipv4_addr dst, const char *msg) = 0;
   virtual future<> send(ipv4_addr dst, packet p) = 0;

--- a/storage/tianmu/base/util/log.h
+++ b/storage/tianmu/base/util/log.h
@@ -99,7 +99,7 @@ class logger {
     virtual void append(std::ostream &os) override { os << arg; }
   };
   template <typename... Args>
-  void do_log(log_level level, const char *fmt, Args &&...args);
+  void do_log(log_level level, const char *fmt, Args &&... args);
   void really_do_log(log_level level, const char *fmt, stringer **stringers, size_t n);
   void failed_to_log(std::exception_ptr ex);
 
@@ -122,7 +122,7 @@ class logger {
   /// \param args - args to print string
   ///
   template <typename... Args>
-  void log(log_level level, const char *fmt, Args &&...args) {
+  void log(log_level level, const char *fmt, Args &&... args) {
     if (is_enabled(level)) {
       try {
         do_log(level, fmt, std::forward<Args>(args)...);
@@ -139,7 +139,7 @@ class logger {
   /// \param args - args to print string
   ///
   template <typename... Args>
-  void error(const char *fmt, Args &&...args) {
+  void error(const char *fmt, Args &&... args) {
     log(log_level::error, fmt, std::forward<Args>(args)...);
   }
   /// Log with warning tag:
@@ -149,7 +149,7 @@ class logger {
   /// \param args - args to print string
   ///
   template <typename... Args>
-  void warn(const char *fmt, Args &&...args) {
+  void warn(const char *fmt, Args &&... args) {
     log(log_level::warn, fmt, std::forward<Args>(args)...);
   }
   /// Log with info tag:
@@ -159,7 +159,7 @@ class logger {
   /// \param args - args to print string
   ///
   template <typename... Args>
-  void info(const char *fmt, Args &&...args) {
+  void info(const char *fmt, Args &&... args) {
     log(log_level::info, fmt, std::forward<Args>(args)...);
   }
   /// Log with info tag on shard zero only:
@@ -169,7 +169,7 @@ class logger {
   /// \param args - args to print string
   ///
   template <typename... Args>
-  void info0(const char *fmt, Args &&...args) {
+  void info0(const char *fmt, Args &&... args) {
     if (is_shard_zero()) {
       log(log_level::info, fmt, std::forward<Args>(args)...);
     }
@@ -181,7 +181,7 @@ class logger {
   /// \param args - args to print string
   ///
   template <typename... Args>
-  void debug(const char *fmt, Args &&...args) {
+  void debug(const char *fmt, Args &&... args) {
     log(log_level::debug, fmt, std::forward<Args>(args)...);
   }
   /// Log with trace tag:
@@ -191,7 +191,7 @@ class logger {
   /// \param args - args to print string
   ///
   template <typename... Args>
-  void trace(const char *fmt, Args &&...args) {
+  void trace(const char *fmt, Args &&... args) {
     log(log_level::trace, fmt, std::forward<Args>(args)...);
   }
 
@@ -305,8 +305,8 @@ class logger_for : public logger {
 };
 
 template <typename... Args>
-void logger::do_log(log_level level, const char *fmt, Args &&...args) {
-  [&](auto &&...stringers) {
+void logger::do_log(log_level level, const char *fmt, Args &&... args) {
+  [&](auto &&... stringers) {
     stringer *s[sizeof...(stringers)] = {&stringers...};
     this->really_do_log(level, fmt, s, sizeof...(stringers));
   }(stringer_for<Args>(std::forward<Args>(args))...);

--- a/storage/tianmu/common/exception.h
+++ b/storage/tianmu/common/exception.h
@@ -185,7 +185,8 @@ class DataTypeConversionException : public Exception {
 class UnsupportedDataTypeException : public Exception {
  public:
   UnsupportedDataTypeException(std::string const &msg) : Exception(msg) {}
-  UnsupportedDataTypeException(TIANMUError tianmu_error = ErrorCode::UNSUPPORTED_DATATYPE) : Exception(tianmu_error.Message()) {}
+  UnsupportedDataTypeException(TIANMUError tianmu_error = ErrorCode::UNSUPPORTED_DATATYPE)
+      : Exception(tianmu_error.Message()) {}
 };
 
 class NetStreamException : public Exception {

--- a/storage/tianmu/common/mysql_gate.cpp
+++ b/storage/tianmu/common/mysql_gate.cpp
@@ -42,13 +42,13 @@ int wildcmp(const DTCollation &collation, const char *str, const char *str_end, 
 
 size_t strnxfrm(const DTCollation &collation, uchar *src, size_t src_len, const uchar *dest, size_t dest_len) {
   return collation.collation->coll->strnxfrm(collation.collation, src, src_len, src_len, dest, dest_len,
-                                             MY_STRXFRM_PAD_TO_MAXLEN); // stonedb8
+                                             MY_STRXFRM_PAD_TO_MAXLEN);  // stonedb8
 }
 
 // stonedb8 start
 void SetMySQLTHD(THD *thd) {
-  //my_thread_set_THR_THD(thd);
-  //my_thread_set_THR_MALLOC(&thd->mem_root);
+  // my_thread_set_THR_THD(thd);
+  // my_thread_set_THR_MALLOC(&thd->mem_root);
   mysql_thread_set_psi_THD(thd);
   THR_MALLOC = &thd->mem_root;
 }

--- a/storage/tianmu/common/mysql_gate.h
+++ b/storage/tianmu/common/mysql_gate.h
@@ -23,25 +23,24 @@
 
 #define MYSQL_SERVER 1
 
-
 #include "key.h"
 #include "lock.h"
 //#include "mysqld_suffix.h" // stonedb8 "mysqld_suffix.h" deleted by 8 about MYSQL_SERVER_SUFFIX
-#include "rpl_replica.h"
-#include "sp_rcontext.h"
 #include "item_strfunc.h"
 #include "item_sum.h"
+#include "rpl_replica.h"
+#include "sp_rcontext.h"
 #include "sql_array.h"
 #include "sql_base.h"
 #include "sql_class.h"
 #include "sql_load.h"
+#include "sql_optimizer.h"
 #include "sql_parse.h"
 #include "sql_plugin.h"
 #include "sql_select.h"
 #include "sql_show.h"
 #include "sql_time.h"
 #include "sql_tmp_table.h"
-#include "sql_optimizer.h"
 #include "transaction.h"
 #include "tztime.h"
 
@@ -51,14 +50,14 @@
 #include "mysql_com.h"
 //#include "probes_mysql.h" // stonedb8 deleted by MySQL 8.0
 // stonedb8 start
+#include "include/my_inttypes.h"
+#include "include/my_systime.h"
+#include "mysql/plugin.h"
+#include "sql/derror.h"
+#include "sql/mysqld.h"
 #include "sql/nested_join.h"
 #include "sql/protocol.h"
 #include "sql/sql_locale.h"
-#include "sql/derror.h"
-#include "mysql/plugin.h"
-#include "sql/mysqld.h"
-#include "include/my_inttypes.h"
-#include "include/my_systime.h"
 // stonedb8 end
 
 /* Putting macros named like `max', `min' or `test'

--- a/storage/tianmu/compress/inc_alloc.cpp
+++ b/storage/tianmu/compress/inc_alloc.cpp
@@ -36,7 +36,7 @@ void IncAlloc::clear() {
   blk = 0;
   used = 0;
   while (!blocks.empty()) {
-    delete[] (char *)(blocks.back().mem);
+    delete[](char *)(blocks.back().mem);
     blocks.pop_back();
   }
   clearfrag();

--- a/storage/tianmu/core/aggregation_algorithm.h
+++ b/storage/tianmu/core/aggregation_algorithm.h
@@ -47,7 +47,8 @@ class AggregationAlgorithm {
 
   // No parallel for subquery/join/distinct cases
   bool ParallelAllowed(GroupByWrapper &gbw) {
-    return (tianmu_sysvar_groupby_speedup && !t->HasTempTable() && (mind->NumOfDimensions() == 1) && gbw.MayBeParallel());
+    return (tianmu_sysvar_groupby_speedup && !t->HasTempTable() && (mind->NumOfDimensions() == 1) &&
+            gbw.MayBeParallel());
   }
   void TaskFillOutput(GroupByWrapper *gbw, Transaction *ci, int64_t offset, int64_t limit);
   void ParallelFillOutputWrapper(GroupByWrapper &gbw, int64_t offset, int64_t limit, MIIterator &mit);

--- a/storage/tianmu/core/aggregator_advanced.cpp
+++ b/storage/tianmu/core/aggregator_advanced.cpp
@@ -194,9 +194,9 @@ void AggregatorGroupConcat::PutAggregatedValue(unsigned char *buf, const types::
       it->second = it->second + copylen;             // update the length of the buffer
     } else {
       TIANMU_LOG(LogCtl_Level::ERROR,
-                  "Internal error for AggregatorGroupConcat: buffer length is "
-                  "%d, which beyond threshold %d.",
-                  pos, gconcat_maxlen);
+                 "Internal error for AggregatorGroupConcat: buffer length is "
+                 "%d, which beyond threshold %d.",
+                 pos, gconcat_maxlen);
     }
   }
 }
@@ -239,7 +239,7 @@ types::BString AggregatorGroupConcat::GetValueT(unsigned char *buf) {
     start_pos = pos + si.separator.length();
   }
 
-  if (si.order == ORDER_DESC) { // stonedb8
+  if (si.order == ORDER_DESC) {  // stonedb8
     if (ATI::IsStringType(attrtype))
       std::sort(vstr.begin(), vstr.end(), std::greater<std::string>());
     else  // numeric

--- a/storage/tianmu/core/aggregator_advanced.h
+++ b/storage/tianmu/core/aggregator_advanced.h
@@ -236,9 +236,9 @@ class AggregatorGroupConcat : public TIANMUAggregator {
   types::BString GetValueT(unsigned char *buf) override;
 
  private:
-  const SI si{",", ORDER_NOT_RELEVANT}; // stonedb8
-  const uint gconcat_maxlen = tianmu_group_concat_max_len; // stonedb8
-  std::map<unsigned char *, unsigned int> lenmap;  // store aggregation column length
+  const SI si{",", ORDER_NOT_RELEVANT};                     // stonedb8
+  const uint gconcat_maxlen = tianmu_group_concat_max_len;  // stonedb8
+  std::map<unsigned char *, unsigned int> lenmap;           // store aggregation column length
   common::CT attrtype = common::CT::STRING;
 };
 }  // namespace core

--- a/storage/tianmu/core/aggregator_basic.cpp
+++ b/storage/tianmu/core/aggregator_basic.cpp
@@ -15,8 +15,8 @@
    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1335 USA
 */
 
-#include <limits>
 #include "aggregator_basic.h"
+#include <limits>
 
 #include "core/transaction.h"
 #include "system/rc_system.h"
@@ -30,7 +30,7 @@ void AggregatorSum64::PutAggregatedValue(unsigned char *buf, int64_t v, int64_t 
     *p = 0;
   }
   double overflow_check = double(*p) + double(v) * factor;
-  if (overflow_check > std::numeric_limits<std::streamsize>::max() || 
+  if (overflow_check > std::numeric_limits<std::streamsize>::max() ||
       overflow_check < std::numeric_limits<std::streamsize>::min())
     throw common::NotImplementedException("Aggregation overflow.");
   *p += v * factor;
@@ -45,7 +45,7 @@ void AggregatorSum64::Merge(unsigned char *buf, unsigned char *src_buf) {
     *p = 0;
   }
   double overflow_check = double(*p) + double(*ps);
-  if (overflow_check > std::numeric_limits<std::streamsize>::max() || 
+  if (overflow_check > std::numeric_limits<std::streamsize>::max() ||
       overflow_check < std::numeric_limits<std::streamsize>::min())
     throw common::NotImplementedException("Aggregation overflow.");
   *p += *ps;
@@ -53,7 +53,7 @@ void AggregatorSum64::Merge(unsigned char *buf, unsigned char *src_buf) {
 
 void AggregatorSum64::SetAggregatePackSum(int64_t par1, int64_t factor) {
   double overflow_check = double(par1) * factor;
-  if (overflow_check > std::numeric_limits<std::streamsize>::max() || 
+  if (overflow_check > std::numeric_limits<std::streamsize>::max() ||
       overflow_check < std::numeric_limits<std::streamsize>::min())
     throw common::NotImplementedException("Aggregation overflow.");
   pack_sum = par1 * factor;
@@ -108,10 +108,9 @@ bool AggregatorSumD::AggregatePack(unsigned char *buf) {
 void AggregatorAvg64::PutAggregatedValue(unsigned char *buf, int64_t v, int64_t factor) {
   stats_updated = false;
   *((double *)buf) += double(v) * factor;
-  if (!warning_issued && (*((double *)buf) > std::numeric_limits<std::streamsize>::max() || 
-      *((double *)buf) < std::numeric_limits<std::streamsize>::min())) {
-    common::PushWarning(current_txn_->Thd(), Sql_condition::SL_NOTE, ER_UNKNOWN_ERROR,
-                        "Values rounded in average()");
+  if (!warning_issued && (*((double *)buf) > std::numeric_limits<std::streamsize>::max() ||
+                          *((double *)buf) < std::numeric_limits<std::streamsize>::min())) {
+    common::PushWarning(current_txn_->Thd(), Sql_condition::SL_NOTE, ER_UNKNOWN_ERROR, "Values rounded in average()");
     warning_issued = true;
   }
   *((int64_t *)(buf + sizeof(int64_t))) += factor;
@@ -121,10 +120,9 @@ void AggregatorAvg64::Merge(unsigned char *buf, unsigned char *src_buf) {
   if (*((int64_t *)(src_buf + sizeof(int64_t))) == 0) return;
   stats_updated = false;
   *((double *)buf) += *((double *)src_buf);
-  if (!warning_issued && (*((double *)buf) > std::numeric_limits<std::streamsize>::max() || 
-      *((double *)buf) < std::numeric_limits<std::streamsize>::min())) {
-    common::PushWarning(current_txn_->Thd(), Sql_condition::SL_NOTE, ER_UNKNOWN_ERROR,
-                        "Values rounded in average()");
+  if (!warning_issued && (*((double *)buf) > std::numeric_limits<std::streamsize>::max() ||
+                          *((double *)buf) < std::numeric_limits<std::streamsize>::min())) {
+    common::PushWarning(current_txn_->Thd(), Sql_condition::SL_NOTE, ER_UNKNOWN_ERROR, "Values rounded in average()");
     warning_issued = true;
   }
   *((int64_t *)(buf + sizeof(int64_t))) += *((int64_t *)(src_buf + sizeof(int64_t)));

--- a/storage/tianmu/core/blocked_mem_table.cpp
+++ b/storage/tianmu/core/blocked_mem_table.cpp
@@ -70,13 +70,13 @@ void MemBlockManager::FreeBlock(void *b) {
       } else
         free_blocks.push_back(b);
     } else
-      // often freed block are immediately required by other - keep some of them
-      // above the limit in the pool
-      if (current_size > size_limit + block_size * (no_threads + 1)) {
-        dealloc(b);
-        current_size -= block_size;
-      } else
-        free_blocks.push_back(b);
+        // often freed block are immediately required by other - keep some of them
+        // above the limit in the pool
+        if (current_size > size_limit + block_size * (no_threads + 1)) {
+      dealloc(b);
+      current_size -= block_size;
+    } else
+      free_blocks.push_back(b);
   }  // else not found (already erased)
 }
 

--- a/storage/tianmu/core/bloom_block.h
+++ b/storage/tianmu/core/bloom_block.h
@@ -108,7 +108,7 @@ inline int Slice::compare(const Slice &b) const {
 
 class FilterPolicy {
  public:
-  virtual ~FilterPolicy(){}
+  virtual ~FilterPolicy() {}
 
   // Return the name of this policy.  Note that if the filter encoding
   // changes in an incompatible way, the name returned by this method

--- a/storage/tianmu/core/column_bin_encoder.cpp
+++ b/storage/tianmu/core/column_bin_encoder.cpp
@@ -909,8 +909,9 @@ ColumnBinEncoder::EncoderText_UTF::~EncoderText_UTF() {}
 
 bool ColumnBinEncoder::EncoderText_UTF::SecondColumn(vcolumn::VirtualColumn *vc2) {
   if (vc_type.IsString() && vc2->Type().IsString() && collation.collation != vc2->GetCollation().collation) {
-    rc_control_.lock(vc2->ConnInfo()->GetThreadID()) << "Nontrivial comparison: " << collation.collation->m_coll_name << " with "
-                                                   << vc2->GetCollation().collation->m_coll_name << system::unlock; // stonedb8
+    rc_control_.lock(vc2->ConnInfo()->GetThreadID())
+        << "Nontrivial comparison: " << collation.collation->m_coll_name << " with "
+        << vc2->GetCollation().collation->m_coll_name << system::unlock;  // stonedb8
     return false;
   }
   size_t coded_len = types::CollationBufLen(collation, vc2->MaxStringSize());

--- a/storage/tianmu/core/column_share.h
+++ b/storage/tianmu/core/column_share.h
@@ -69,7 +69,7 @@ class ColumnShare final {
   ColumnShare(TableShare *owner, common::TX_ID ver, uint32_t i, const fs::path &p, const Field *f)
       : owner(owner), m_path(p), col_id(i) {
     ct.SetCollation({f->charset(), f->derivation()});
-    ct.SetAutoInc(f->all_flags() & AUTO_INCREMENT_FLAG); //stonedb8
+    ct.SetAutoInc(f->all_flags() & AUTO_INCREMENT_FLAG);  // stonedb8
     Init(ver);
   }
 

--- a/storage/tianmu/core/compilation_tools.cpp
+++ b/storage/tianmu/core/compilation_tools.cpp
@@ -116,8 +116,8 @@ int OperationUnmysterify(Item *item, common::ColOperation &oper, bool &distinct,
         case Item_sum::GROUP_CONCAT_FUNC:
           distinct = ((Item_func_group_concat *)item)->get_distinct();
           TIANMU_LOG(LogCtl_Level::DEBUG, "group_concat distinct %d, sepertator %s, direction %d", distinct,
-                      ((Item_func_group_concat *)item)->get_separator()->c_ptr(),
-                      ((Item_func_group_concat *)item)->direction());
+                     ((Item_func_group_concat *)item)->get_separator()->c_ptr(),
+                     ((Item_func_group_concat *)item)->direction());
           oper = common::ColOperation::GROUP_CONCAT;
           break;
         default:
@@ -196,7 +196,7 @@ void PrintItemTree(Item *item, int indent) {
       break;
   }
   std::fprintf(stderr, "%s %s @%p %s %s max_length=%d", name, item->full_name(), (void *)item,
-               FieldType(item->data_type()), result, item->max_length); // stonedb8 item::field_type()->data_type()
+               FieldType(item->data_type()), result, item->max_length);  // stonedb8 item::field_type()->data_type()
 
   if (item->result_type() == DECIMAL_RESULT)
     std::fprintf(stderr, " [prec=%d,dec=%d,int=%d]", item->decimal_precision(), (int)item->decimals,
@@ -239,7 +239,7 @@ void PrintItemTree(Item *item, int indent) {
 
       std::fprintf(stderr, "  %s\n", sumname);
 
-      uint args_count = sum_func->argument_count(); // stonedb8
+      uint args_count = sum_func->argument_count();  // stonedb8
       for (uint i = 0; i < args_count; i++) PrintItemTree(sum_func->get_arg(i), indent);
       return;
     }

--- a/storage/tianmu/core/compiled_query.h
+++ b/storage/tianmu/core/compiled_query.h
@@ -100,7 +100,7 @@ class CompiledQuery final {
           alias(NULL),
           n1(common::NULL_VALUE_64),
           n2(common::NULL_VALUE_64),
-          si(){}
+          si() {}
 
     CQStep(const CQStep &);
 

--- a/storage/tianmu/core/descriptor.cpp
+++ b/storage/tianmu/core/descriptor.cpp
@@ -1630,11 +1630,10 @@ void Descriptor::CoerceColumnType(vcolumn::VirtualColumn *&for_typecast) {
 
   if (tcc) {
     if (rc_control_.isOn())
-      rc_control_.lock(current_txn_->GetThreadID()) << "Type conversion for VC:"
-                                                << (for_typecast == val1.vc   ? val1.vc_id
-                                                    : for_typecast == val2.vc ? val2.vc_id
-                                                                              : val1.vc_id)
-                                                << system::unlock;
+      rc_control_.lock(current_txn_->GetThreadID())
+          << "Type conversion for VC:"
+          << (for_typecast == val1.vc ? val1.vc_id : for_typecast == val2.vc ? val2.vc_id : val1.vc_id)
+          << system::unlock;
     table->AddVirtColumn(tcc);
     if (!tstamp)
       for_typecast = tcc;

--- a/storage/tianmu/core/descriptor.h
+++ b/storage/tianmu/core/descriptor.h
@@ -192,7 +192,7 @@ class SortDescriptor {
  public:
   vcolumn::VirtualColumn *vc;
   int dir;  // ordering direction: 0 - ascending, 1 - descending
-  SortDescriptor() : vc(NULL), dir(0){}
+  SortDescriptor() : vc(NULL), dir(0) {}
   int operator==(const SortDescriptor &sec) { return (dir == sec.dir) && (vc == sec.vc); }
 };
 

--- a/storage/tianmu/core/dimension_group.h
+++ b/storage/tianmu/core/dimension_group.h
@@ -35,8 +35,8 @@ class DimensionGroup {
   virtual DimensionGroup *Clone(bool shallow) = 0;  // create a new group with the same (copied) contents
   virtual ~DimensionGroup() {}
   int64_t NumOfTuples() { return no_obj; }
-  virtual void UpdateNumOfTuples() {}          // may be not needed for some group types
-  DGType Type() { return dim_group_type; }     // type selector
+  virtual void UpdateNumOfTuples() {}       // may be not needed for some group types
+  DGType Type() { return dim_group_type; }  // type selector
   virtual Filter *GetFilter([[maybe_unused]] int dim) const {
     return NULL;
   }  // Get the pointer to a filter attached to a dimension. NOTE: will be NULL
@@ -71,7 +71,7 @@ class DimensionGroup {
     // note: retrieving a value depends on DimensionGroup type
     Iterator() { valid = false; }
     Iterator(const Iterator &sec) { valid = sec.valid; }
-    virtual ~Iterator(){}
+    virtual ~Iterator() {}
 
     virtual void operator++() = 0;
     virtual void Rewind() = 0;

--- a/storage/tianmu/core/dimension_group_multiple.cpp
+++ b/storage/tianmu/core/dimension_group_multiple.cpp
@@ -181,7 +181,8 @@ int MultiIndexTable::NumOfLocks() {
 //----------------------------DimensionGroupMultiMaterialized-------------------------------------------
 // The no_obj need to preset, because AddDimensionContent maybe not called on
 // uninvolved scenes.
-DimensionGroupMultiMaterialized::DimensionGroupMultiMaterialized(int64_t obj, DimensionVector &dims, uint32_t power, bool is_shallow_memory)
+DimensionGroupMultiMaterialized::DimensionGroupMultiMaterialized(int64_t obj, DimensionVector &dims, uint32_t power,
+                                                                 bool is_shallow_memory)
     : power_(power), dims_used_(dims), is_shallow_memory(is_shallow_memory) {
   dim_group_type = DGType::DG_INDEX_TABLE;
   no_obj = obj;

--- a/storage/tianmu/core/dimension_vector.h
+++ b/storage/tianmu/core/dimension_vector.h
@@ -27,7 +27,7 @@ namespace core {
 class DimensionVector {
  public:
   DimensionVector() = default;
-  DimensionVector(int no_dims) : v(no_dims){}
+  DimensionVector(int no_dims) : v(no_dims) {}
   DimensionVector(const DimensionVector &sec) = default;
   ~DimensionVector() = default;
 

--- a/storage/tianmu/core/engine.h
+++ b/storage/tianmu/core/engine.h
@@ -35,9 +35,9 @@
 #include "exporter/data_exporter.h"
 #include "exporter/export2file.h"
 #include "index/rc_table_index.h"
+#include "log.h"
 #include "system/io_parameters.h"
 #include "system/rc_system.h"
-#include "log.h"
 #include "util/fs.h"
 #include "util/mapped_circular_buffer.h"
 #include "util/thread_pool.h"
@@ -154,20 +154,20 @@ class Engine final {
   static void ComputeTimeZoneDiffInMinutes(THD *thd, short &sign, short &minutes);
   static std::string GetTablePath(TABLE *table);
   static common::TIANMUError GetIOP(std::unique_ptr<system::IOParameters> &io_params, THD &thd, sql_exchange &ex,
-                                 TABLE *table = 0, void *arg = NULL, bool for_exporter = false);
+                                    TABLE *table = 0, void *arg = NULL, bool for_exporter = false);
   static common::TIANMUError GetRejectFileIOParameters(THD &thd, std::unique_ptr<system::IOParameters> &io_params);
   static fs::path GetNextDataDir();
 
  private:
   void AddTx(Transaction *tx);
   void RemoveTx(Transaction *tx);
-  int Execute(THD *thd, LEX *lex, Query_result *result_output, Query_expression *unit_for_union = NULL); //stonedb8
+  int Execute(THD *thd, LEX *lex, Query_result *result_output, Query_expression *unit_for_union = NULL);  // stonedb8
   int SetUpCacheFolder(const std::string &cachefolder_path);
 
   static bool AreConvertible(types::RCDataType &rcitem, enum_field_types my_type, uint length = 0);
   static bool IsTIANMURoute(THD *thd, TABLE_LIST *table_list, Query_block *selects_list,
-                         int &in_case_of_failure_can_go_to_mysql, int with_insert); //stonedb8
-  static const char *GetFilename(Query_block *selects_list, int &is_dumpfile); //stonedb8
+                            int &in_case_of_failure_can_go_to_mysql, int with_insert);  // stonedb8
+  static const char *GetFilename(Query_block *selects_list, int &is_dumpfile);          // stonedb8
   static std::unique_ptr<system::IOParameters> CreateIOParameters(const std::string &path, void *arg);
   static std::unique_ptr<system::IOParameters> CreateIOParameters(THD *thd, TABLE *table, void *arg);
   void LogStat();
@@ -258,7 +258,7 @@ class Engine final {
 class ResultSender {
  public:
   // stonedb8 List -> mem_root_deque
-  ResultSender(THD *thd, Query_result *res, mem_root_deque<Item *> &fields); 
+  ResultSender(THD *thd, Query_result *res, mem_root_deque<Item *> &fields);
   virtual ~ResultSender();
 
   void Send(TempTable *t);
@@ -324,10 +324,10 @@ enum class tianmu_var_name {
 };
 
 static std::string tianmu_var_name_strings[] = {"TIANMU_LOAD_TIMEOUT",        "TIANMU_LOAD_DATAFORMAT",
-                                             "TIANMU_LOAD_PIPEMODE",       "TIANMU_LOAD_NULL",
-                                             "TIANMU_LOAD_THROTTLE",       "TIANMU_LOAD_TIANMUEXPRESSIONS",
-                                             "TIANMU_LOAD_PARALLEL_AGGR",  "TIANMU_LOAD_REJECT_FILE",
-                                             "TIANMU_LOAD_ABORT_ON_COUNT", "TIANMU_LOAD_ABORT_ON_THRESHOLD"};
+                                                "TIANMU_LOAD_PIPEMODE",       "TIANMU_LOAD_NULL",
+                                                "TIANMU_LOAD_THROTTLE",       "TIANMU_LOAD_TIANMUEXPRESSIONS",
+                                                "TIANMU_LOAD_PARALLEL_AGGR",  "TIANMU_LOAD_REJECT_FILE",
+                                                "TIANMU_LOAD_ABORT_ON_COUNT", "TIANMU_LOAD_ABORT_ON_THRESHOLD"};
 
 std::string get_parameter_name(enum tianmu_var_name vn);
 

--- a/storage/tianmu/core/engine_convert.cpp
+++ b/storage/tianmu/core/engine_convert.cpp
@@ -84,8 +84,7 @@ bool Engine::ConvertToField(Field *field, types::RCDataType &rcitem, std::vector
         Engine::Convert(is_null, &md, rcitem);
       }
       decimal_round(&md, &md, ((Field_new_decimal *)field)->decimals(), HALF_UP);
-      decimal2bin(&md, field_ptr, ((Field_new_decimal *)field)->precision,
-                  ((Field_new_decimal *)field)->decimals());
+      decimal2bin(&md, field_ptr, ((Field_new_decimal *)field)->precision, ((Field_new_decimal *)field)->decimals());
       break;
     }
     default:
@@ -100,16 +99,20 @@ bool Engine::ConvertToField(Field *field, types::RCDataType &rcitem, std::vector
         case common::CT::NUM:
           switch (field->type()) {
             case MYSQL_TYPE_TINY:
-              *(reinterpret_cast<char *>(field_ptr)) = static_cast<char>(static_cast<int64_t>(static_cast<types::RCNum &>(rcitem)));
+              *(reinterpret_cast<char *>(field_ptr)) =
+                  static_cast<char>(static_cast<int64_t>(static_cast<types::RCNum &>(rcitem)));
               break;
             case MYSQL_TYPE_SHORT:
-              *(reinterpret_cast<short *>(field_ptr)) = static_cast<short>(static_cast<int64_t>(static_cast<types::RCNum &>(rcitem)));
+              *(reinterpret_cast<short *>(field_ptr)) =
+                  static_cast<short>(static_cast<int64_t>(static_cast<types::RCNum &>(rcitem)));
               break;
             case MYSQL_TYPE_INT24:
-              int3store(reinterpret_cast<char *>(field_ptr), static_cast<int>(static_cast<int64_t>(static_cast<types::RCNum &>(rcitem))));
+              int3store(reinterpret_cast<char *>(field_ptr),
+                        static_cast<int>(static_cast<int64_t>(static_cast<types::RCNum &>(rcitem))));
               break;
             case MYSQL_TYPE_LONG:
-              *(reinterpret_cast<int *>(field_ptr)) = static_cast<int>(static_cast<int64_t>(static_cast<types::RCNum &>(rcitem)));
+              *(reinterpret_cast<int *>(field_ptr)) =
+                  static_cast<int>(static_cast<int64_t>(static_cast<types::RCNum &>(rcitem)));
               break;
             case MYSQL_TYPE_LONGLONG:
               *(reinterpret_cast<int64_t *>(field_ptr)) = static_cast<int64_t>(static_cast<types::RCNum &>(rcitem));
@@ -139,7 +142,8 @@ bool Engine::ConvertToField(Field *field, types::RCDataType &rcitem, std::vector
               break;
             }
             case MYSQL_TYPE_STRING:
-              ((types::BString &)rcitem).PutString(reinterpret_cast<char *&>(field_ptr), (ushort)field->field_length, false);
+              ((types::BString &)rcitem)
+                  .PutString(reinterpret_cast<char *&>(field_ptr), (ushort)field->field_length, false);
               break;
             case MYSQL_TYPE_BLOB: {
               Field_blob *blob = (Field_blob *)field;
@@ -184,7 +188,8 @@ bool Engine::ConvertToField(Field *field, types::RCDataType &rcitem, std::vector
               break;
             }
             default:
-              ((types::BString &)rcitem).PutString(reinterpret_cast<char *&>(field_ptr), (ushort)field->field_length, false);
+              ((types::BString &)rcitem)
+                  .PutString(reinterpret_cast<char *&>(field_ptr), (ushort)field->field_length, false);
               break;
           }
 
@@ -453,11 +458,11 @@ int Engine::Convert(int &is_null, String *value, types::RCDataType &rcitem, enum
         if (*rcdt != types::RC_TIMESTAMP_SPEC) {
           MYSQL_TIME local_time;
           my_time_t secs = tianmu_sec_since_epoch(rcdt->Year(), rcdt->Month(), rcdt->Day(), rcdt->Hour(),
-                                                   rcdt->Minute(), rcdt->Second());
+                                                  rcdt->Minute(), rcdt->Second());
           current_txn_->Thd()->variables.time_zone->gmt_sec_to_TIME(&local_time, secs);
           char buf[32];
           local_time.second_part = rcdt->MicroSecond();
-          my_datetime_to_str(local_time, buf, 0); // stonedb8
+          my_datetime_to_str(local_time, buf, 0);  // stonedb8
           value->set_ascii(buf, 19);
         } else {
           value->set_ascii("0000-00-00 00:00:00", 19);
@@ -496,8 +501,9 @@ bool Engine::AreConvertible(types::RCDataType &rcitem, enum_field_types my_type,
     case MYSQL_TYPE_TINY_BLOB:
     case MYSQL_TYPE_MEDIUM_BLOB:
     case MYSQL_TYPE_LONG_BLOB:
-      return (tianmu_type == common::CT::STRING || tianmu_type == common::CT::VARCHAR || tianmu_type == common::CT::BYTE ||
-              tianmu_type == common::CT::VARBYTE || tianmu_type == common::CT::LONGTEXT || tianmu_type == common::CT::BIN);
+      return (tianmu_type == common::CT::STRING || tianmu_type == common::CT::VARCHAR ||
+              tianmu_type == common::CT::BYTE || tianmu_type == common::CT::VARBYTE ||
+              tianmu_type == common::CT::LONGTEXT || tianmu_type == common::CT::BIN);
     case MYSQL_TYPE_YEAR:
       return tianmu_type == common::CT::YEAR;
     case MYSQL_TYPE_SHORT:

--- a/storage/tianmu/core/engine_results.cpp
+++ b/storage/tianmu/core/engine_results.cpp
@@ -35,7 +35,7 @@ void scan_fields(mem_root_deque<Item *> &fields, uint *&buf_lens, std::map<int, 
   Item::Type item_type;
   Item_sum::Sumfunctype sum_type;
 
-  buf_lens = new uint[CountVisibleFields(fields)]; // stonedb8
+  buf_lens = new uint[CountVisibleFields(fields)];  // stonedb8
   uint item_id = 0;
   uint field_length = 0;
   uint total_length = 0;
@@ -79,7 +79,7 @@ void scan_fields(mem_root_deque<Item *> &fields, uint *&buf_lens, std::map<int, 
         tmp->hybrid_field_type_ = item->data_type();
         tmp->collation.set(item->collation);
         tmp->value_.set_charset(item->collation.collation);
-        fields[item_id] = tmp; // stonedb8
+        fields[item_id] = tmp;  // stonedb8
         break;
       }
       case Item::SUM_FUNC_ITEM: {
@@ -98,7 +98,7 @@ void scan_fields(mem_root_deque<Item *> &fields, uint *&buf_lens, std::map<int, 
           isum_hybrid_rcbase->hybrid_field_type_ = is->data_type();
           isum_hybrid_rcbase->collation.set(is->collation);
           isum_hybrid_rcbase->value_.set_charset(is->collation.collation);
-          fields[item_id] = isum_hybrid_rcbase; // stonedb8
+          fields[item_id] = isum_hybrid_rcbase;  // stonedb8
           buf_lens[item_id] = 0;
           break;
         } else if (sum_type == Item_sum::COUNT_FUNC || sum_type == Item_sum::COUNT_DISTINCT_FUNC ||
@@ -106,7 +106,7 @@ void scan_fields(mem_root_deque<Item *> &fields, uint *&buf_lens, std::map<int, 
           isum_int_rcbase = new types::Item_sum_int_rcbase();
           isum_int_rcbase->unsigned_flag = is->unsigned_flag;
           items_backup[item_id] = item;
-          fields[item_id] = isum_int_rcbase; // stonedb8
+          fields[item_id] = isum_int_rcbase;  // stonedb8
           buf_lens[item_id] = 0;
           break;
           // we can use the same type for SUM,AVG and SUM DIST, AVG DIST
@@ -120,7 +120,7 @@ void scan_fields(mem_root_deque<Item *> &fields, uint *&buf_lens, std::map<int, 
           isum_sum_rcbase->decimals = is->decimals;
           isum_sum_rcbase->hybrid_type_ = is->result_type();
           isum_sum_rcbase->unsigned_flag = is->unsigned_flag;
-          fields[item_id] = isum_sum_rcbase; // stonedb8
+          fields[item_id] = isum_sum_rcbase;  // stonedb8
           buf_lens[item_id] = 0;
           break;
         } else {
@@ -165,10 +165,9 @@ void restore_fields(mem_root_deque<Item *> &fields, std::map<int, Item *> &items
 
   Item *item;
   int count = 0;
-  for (auto it = fields.begin(); it != fields.end(); ++it) { // stonedb8
+  for (auto it = fields.begin(); it != fields.end(); ++it) {  // stonedb8
     item = *it;
-    if (items_backup.find(count) != items_backup.end()) 
-      fields[count] = items_backup[count]; // stonedb8
+    if (items_backup.find(count) != items_backup.end()) fields[count] = items_backup[count];  // stonedb8
     count++;
   }
 }
@@ -277,7 +276,7 @@ void ResultSender::SendRecord(const std::vector<std::unique_ptr<types::RCDataTyp
   uint col_id = 0;
   int64_t value;
 
-  for (auto it = fields.begin(); it != fields.end(); ++it) { // stonedb8
+  for (auto it = fields.begin(); it != fields.end(); ++it) {  // stonedb8
     item = *it;
     int is_null = 0;
     types::RCDataType &rcdt(*r[col_id]);
@@ -378,10 +377,10 @@ void ResultSender::Finalize(TempTable *result_table) {
   auto &sctx = thd->m_main_security_ctx;
   if (rc_querylog_.isOn())
     rc_querylog_ << system::lock << "\tClientIp:" << (sctx.ip().length ? sctx.ip().str : "unkownn")
-               << "\tClientHostName:" << (sctx.host().length ? sctx.host().str : "unknown")
-               << "\tClientPort:" << thd->peer_port << "\tUser:" << sctx.user().str << global_serverinfo_
-               << "\tAffectRows:" << affect_rows << "\tResultRows:" << rows_sent << "\tDBName:" << thd->db().str
-               << "\tCosttime(ms):" << cost_time << "\tSQL:" << thd->query().str << system::unlock;
+                 << "\tClientHostName:" << (sctx.host().length ? sctx.host().str : "unknown")
+                 << "\tClientPort:" << thd->peer_port << "\tUser:" << sctx.user().str << global_serverinfo_
+                 << "\tAffectRows:" << affect_rows << "\tResultRows:" << rows_sent << "\tDBName:" << thd->db().str
+                 << "\tCosttime(ms):" << cost_time << "\tSQL:" << thd->query().str << system::unlock;
   TIANMU_LOG(LogCtl_Level::DEBUG, "Result: %" PRId64 " Costtime(ms): %" PRId64, rows_sent, cost_time);
 }
 
@@ -392,7 +391,7 @@ void ResultSender::SendEof() { res->send_eof(thd); }
 ResultSender::~ResultSender() { delete[] buf_lens; }
 
 // stonedb8 List -> mem_root_deque
-ResultExportSender::ResultExportSender(THD *thd, Query_result *result, mem_root_deque<Item *>  &fields)
+ResultExportSender::ResultExportSender(THD *thd, Query_result *result, mem_root_deque<Item *> &fields)
     : ResultSender(thd, result, fields) {
   export_res = dynamic_cast<exporter::select_tianmu_export *>(result);
   DEBUG_ASSERT(export_res);
@@ -411,7 +410,7 @@ void init_field_scan_helpers(THD *&thd, TABLE &tmp_table, TABLE_SHARE &share) {
 
   tmp_table.s->db_create_options = 0;
   tmp_table.s->db_low_byte_first = false; /* or true */
-  tmp_table.null_row = 0; // stonedb8 TABLE::maybe_null is deleted, and not use it
+  tmp_table.null_row = 0;                 // stonedb8 TABLE::maybe_null is deleted, and not use it
 }
 
 fields_t::value_type guest_field_type(THD *&thd, TABLE &tmp_table, Item *&item) {
@@ -424,7 +423,8 @@ fields_t::value_type guest_field_type(THD *&thd, TABLE &tmp_table, Item *&item) 
     else
       field = item->tmp_table_field_from_field_type(&tmp_table, 0);
   } else
-    field = create_tmp_field(thd, &tmp_table, item, item->type(), (Func_ptr_array*)0, &tmp_field, &def_field, 0, 0, 0, 0);
+    field =
+        create_tmp_field(thd, &tmp_table, item, item->type(), (Func_ptr_array *)0, &tmp_field, &def_field, 0, 0, 0, 0);
   fields_t::value_type f(MYSQL_TYPE_STRING);
   if (field) {
     f = field->type();
@@ -444,7 +444,8 @@ AttributeTypeInfo create_ati(THD *&thd, TABLE &tmp_table, Item *&item) {
     else
       field = item->tmp_table_field_from_field_type(&tmp_table, 0);
   } else
-    field = create_tmp_field(thd, &tmp_table, item, item->type(), (Func_ptr_array*)0, &tmp_field, &def_field, 0, 0, 0, 0);
+    field =
+        create_tmp_field(thd, &tmp_table, item, item->type(), (Func_ptr_array *)0, &tmp_field, &def_field, 0, 0, 0, 0);
   if (!field) throw common::DatabaseException("failed to guess item type");
   AttributeTypeInfo ati = Engine::GetCorrespondingATI(*field);
   delete field;
@@ -464,7 +465,8 @@ void ResultExportSender::Init(TempTable *t) {
 
   export_res->send_result_set_metadata(thd, fields, Protocol::SEND_NUM_ROWS | Protocol::SEND_EOF);
 
-  if ((tianmu_error = Engine::GetIOP(iop, *thd, *export_res->SqlExchange(), 0, NULL, true)) != common::ErrorCode::SUCCESS)
+  if ((tianmu_error = Engine::GetIOP(iop, *thd, *export_res->SqlExchange(), 0, NULL, true)) !=
+      common::ErrorCode::SUCCESS)
     throw common::Exception("Unable to get IOP");
 
   fields_t f;
@@ -476,7 +478,7 @@ void ResultExportSender::Init(TempTable *t) {
   std::vector<AttributeTypeInfo> deas = t->GetATIs(iop->GetEDF() != common::EDF::TRI_UNKNOWN);
   int i = 0;
 
-  for (auto it = fields.begin(); it != fields.end(); ++it) { // stonedb8
+  for (auto it = fields.begin(); it != fields.end(); ++it) {  // stonedb8
     item = *it;
     fields_t::value_type ft = guest_field_type(thd, tmp_table, item);
     f.push_back(ft);
@@ -495,7 +497,7 @@ void ResultExportSender::Init(TempTable *t) {
 void ResultExportSender::SendRecord(const std::vector<std::unique_ptr<types::RCDataType>> &r) {
   Item *l_item;
   uint o = 0;
-  for (auto it = fields.begin(); it != fields.end(); ++it) { // stonedb8
+  for (auto it = fields.begin(); it != fields.end(); ++it) {  // stonedb8
     l_item = *it;
     types::RCDataType &rcdt(*r[o]);
     if (rcdt.IsNull())

--- a/storage/tianmu/core/filter.h
+++ b/storage/tianmu/core/filter.h
@@ -141,11 +141,11 @@ class Filter final : public mm::TraceableObject {
 
   // Statistics etc.
   int64_t NumOfOnes() const;
-  uint NumOfOnes(int b);         // block b
+  uint NumOfOnes(int b);            // block b
   uint NumOfOnesUncommited(int b);  // with uncommitted Set/Reset
   int64_t NumOfOnesBetween(int64_t n1,
                            int64_t n2);  // no of 1 between n1 and n2, inclusively
-  int64_t NumOfObj() const;           // number of objects (table size)
+  int64_t NumOfObj() const;              // number of objects (table size)
   size_t NumOfBlocks() const { return no_blocks; }
   int NumOfAddBits() const;
   int DensityWeight();  // = 65537 for empty filter or a filter with only one

--- a/storage/tianmu/core/group_distinct_table.cpp
+++ b/storage/tianmu/core/group_distinct_table.cpp
@@ -137,8 +137,8 @@ void GroupDistinctTable::InitializeBuffers(int64_t max_no_rows)  // max_no_rows 
   t = (unsigned char *)alloc(total_width * no_rows, mm::BLOCK_TYPE::BLOCK_TEMPORARY);
   //	t = new BlockedRowMemStorage(total_width, &mem_mngr, no_rows);
   input_buffer = (unsigned char *)(new int[total_width / 4 + 1]);  // ensure proper memory alignment
-  rc_control_.lock(m_conn->GetThreadID()) << "GroupDistinctTable initialized as Hash(" << no_rows << "), " << group_bytes
-                                        << "+" << value_bytes << " bytes." << system::unlock;
+  rc_control_.lock(m_conn->GetThreadID()) << "GroupDistinctTable initialized as Hash(" << no_rows << "), "
+                                          << group_bytes << "+" << value_bytes << " bytes." << system::unlock;
   Clear();
 }
 

--- a/storage/tianmu/core/group_table.cpp
+++ b/storage/tianmu/core/group_table.cpp
@@ -181,102 +181,102 @@ void GroupTable::Initialize(int64_t max_no_groups, bool parallel_allowed) {
 
       } else  // SUM(...)				Note: strings are parsed
               // to double
-        if (desc.operation == GT_Aggregation::GT_SUM) {
-          if (ATI::IsRealType(desc.type) || ATI::IsStringType(desc.type))
-            aggregator[i] = new AggregatorSumD;
-          else
-            aggregator[i] = new AggregatorSum64;
+          if (desc.operation == GT_Aggregation::GT_SUM) {
+        if (ATI::IsRealType(desc.type) || ATI::IsStringType(desc.type))
+          aggregator[i] = new AggregatorSumD;
+        else
+          aggregator[i] = new AggregatorSum64;
 
-        } else  // AVG(...)				Note: strings are parsed
-                // to double
+      } else  // AVG(...)				Note: strings are parsed
+              // to double
           if (desc.operation == GT_Aggregation::GT_AVG) {
-            if (ATI::IsRealType(desc.type) || ATI::IsStringType(desc.type))
-              aggregator[i] = new AggregatorAvgD;
-            else if (desc.type == common::CT::YEAR)
-              aggregator[i] = new AggregatorAvgYear;
-            else
-              aggregator[i] = new AggregatorAvg64(desc.precision);
+        if (ATI::IsRealType(desc.type) || ATI::IsStringType(desc.type))
+          aggregator[i] = new AggregatorAvgD;
+        else if (desc.type == common::CT::YEAR)
+          aggregator[i] = new AggregatorAvgYear;
+        else
+          aggregator[i] = new AggregatorAvg64(desc.precision);
 
-          } else  // MIN(...)
-            if (desc.operation == GT_Aggregation::GT_MIN) {
-              if (ATI::IsStringType(desc.type)) {
-                if (types::RequiresUTFConversions(desc.collation))
-                  aggregator[i] = new AggregatorMinT_UTF(desc.size, desc.collation);
-                else
-                  aggregator[i] = new AggregatorMinT(desc.size);
-              } else if (ATI::IsRealType(desc.type))
-                aggregator[i] = new AggregatorMinD;
-              else if (desc.min < std::numeric_limits<int>::min() || desc.max > std::numeric_limits<int>::max())
-                aggregator[i] = new AggregatorMin64;
-              else
-                aggregator[i] = new AggregatorMin32;
+      } else  // MIN(...)
+          if (desc.operation == GT_Aggregation::GT_MIN) {
+        if (ATI::IsStringType(desc.type)) {
+          if (types::RequiresUTFConversions(desc.collation))
+            aggregator[i] = new AggregatorMinT_UTF(desc.size, desc.collation);
+          else
+            aggregator[i] = new AggregatorMinT(desc.size);
+        } else if (ATI::IsRealType(desc.type))
+          aggregator[i] = new AggregatorMinD;
+        else if (desc.min < std::numeric_limits<int>::min() || desc.max > std::numeric_limits<int>::max())
+          aggregator[i] = new AggregatorMin64;
+        else
+          aggregator[i] = new AggregatorMin32;
 
-            } else  // MAX(...)
-              if (desc.operation == GT_Aggregation::GT_MAX) {
-                if (ATI::IsStringType(desc.type)) {
-                  if (types::RequiresUTFConversions(desc.collation))
-                    aggregator[i] = new AggregatorMaxT_UTF(desc.size, desc.collation);
-                  else
-                    aggregator[i] = new AggregatorMaxT(desc.size);
-                } else if (ATI::IsRealType(desc.type))
-                  aggregator[i] = new AggregatorMaxD;
-                else if (desc.min < std::numeric_limits<int>::min() || desc.max > std::numeric_limits<int>::max())
-                  aggregator[i] = new AggregatorMax64;
-                else
-                  aggregator[i] = new AggregatorMax32;
-              } else  // LIST - just a first value found
-                if (desc.operation == GT_Aggregation::GT_LIST) {
-                  if (ATI::IsStringType(desc.type))
-                    aggregator[i] = new AggregatorListT(desc.size);
-                  else if (ATI::IsRealType(desc.type) || (desc.min < std::numeric_limits<int>::min() 
-                            || desc.max > std::numeric_limits<int>::max()))
-                    aggregator[i] = new AggregatorList64;
-                  else
-                    aggregator[i] = new AggregatorList32;
+      } else  // MAX(...)
+          if (desc.operation == GT_Aggregation::GT_MAX) {
+        if (ATI::IsStringType(desc.type)) {
+          if (types::RequiresUTFConversions(desc.collation))
+            aggregator[i] = new AggregatorMaxT_UTF(desc.size, desc.collation);
+          else
+            aggregator[i] = new AggregatorMaxT(desc.size);
+        } else if (ATI::IsRealType(desc.type))
+          aggregator[i] = new AggregatorMaxD;
+        else if (desc.min < std::numeric_limits<int>::min() || desc.max > std::numeric_limits<int>::max())
+          aggregator[i] = new AggregatorMax64;
+        else
+          aggregator[i] = new AggregatorMax32;
+      } else  // LIST - just a first value found
+          if (desc.operation == GT_Aggregation::GT_LIST) {
+        if (ATI::IsStringType(desc.type))
+          aggregator[i] = new AggregatorListT(desc.size);
+        else if (ATI::IsRealType(desc.type) ||
+                 (desc.min < std::numeric_limits<int>::min() || desc.max > std::numeric_limits<int>::max()))
+          aggregator[i] = new AggregatorList64;
+        else
+          aggregator[i] = new AggregatorList32;
 
-                } else  // VAR_POP(...)
-                  if (desc.operation == GT_Aggregation::GT_VAR_POP) {
-                    if (ATI::IsRealType(desc.type) || ATI::IsStringType(desc.type))
-                      aggregator[i] = new AggregatorVarPopD;
-                    else
-                      aggregator[i] = new AggregatorVarPop64(desc.precision);
+      } else  // VAR_POP(...)
+          if (desc.operation == GT_Aggregation::GT_VAR_POP) {
+        if (ATI::IsRealType(desc.type) || ATI::IsStringType(desc.type))
+          aggregator[i] = new AggregatorVarPopD;
+        else
+          aggregator[i] = new AggregatorVarPop64(desc.precision);
 
-                  } else  // VAR_SAMP(...)
-                    if (desc.operation == GT_Aggregation::GT_VAR_SAMP) {
-                      if (ATI::IsRealType(desc.type) || ATI::IsStringType(desc.type))
-                        aggregator[i] = new AggregatorVarSampD;
-                      else
-                        aggregator[i] = new AggregatorVarSamp64(desc.precision);
+      } else  // VAR_SAMP(...)
+          if (desc.operation == GT_Aggregation::GT_VAR_SAMP) {
+        if (ATI::IsRealType(desc.type) || ATI::IsStringType(desc.type))
+          aggregator[i] = new AggregatorVarSampD;
+        else
+          aggregator[i] = new AggregatorVarSamp64(desc.precision);
 
-                    } else  // STD_POP(...)
-                      if (desc.operation == GT_Aggregation::GT_STD_POP) {
-                        if (ATI::IsRealType(desc.type) || ATI::IsStringType(desc.type))
-                          aggregator[i] = new AggregatorStdPopD;
-                        else
-                          aggregator[i] = new AggregatorStdPop64(desc.precision);
+      } else  // STD_POP(...)
+          if (desc.operation == GT_Aggregation::GT_STD_POP) {
+        if (ATI::IsRealType(desc.type) || ATI::IsStringType(desc.type))
+          aggregator[i] = new AggregatorStdPopD;
+        else
+          aggregator[i] = new AggregatorStdPop64(desc.precision);
 
-                      } else  // STD_SAMP(...)
-                        if (desc.operation == GT_Aggregation::GT_STD_SAMP) {
-                          if (ATI::IsRealType(desc.type) || ATI::IsStringType(desc.type))
-                            aggregator[i] = new AggregatorStdSampD;
-                          else
-                            aggregator[i] = new AggregatorStdSamp64(desc.precision);
+      } else  // STD_SAMP(...)
+          if (desc.operation == GT_Aggregation::GT_STD_SAMP) {
+        if (ATI::IsRealType(desc.type) || ATI::IsStringType(desc.type))
+          aggregator[i] = new AggregatorStdSampD;
+        else
+          aggregator[i] = new AggregatorStdSamp64(desc.precision);
 
-                        } else  // BIT_AND(...)
-                          if (desc.operation == GT_Aggregation::GT_BIT_AND) {
-                            aggregator[i] = new AggregatorBitAnd;
+      } else  // BIT_AND(...)
+          if (desc.operation == GT_Aggregation::GT_BIT_AND) {
+        aggregator[i] = new AggregatorBitAnd;
 
-                          } else  // BIT_Or(...)
-                            if (desc.operation == GT_Aggregation::GT_BIT_OR) {
-                              aggregator[i] = new AggregatorBitOr;
+      } else  // BIT_Or(...)
+          if (desc.operation == GT_Aggregation::GT_BIT_OR) {
+        aggregator[i] = new AggregatorBitOr;
 
-                            } else  // BIT_XOR(...)
-                              if (desc.operation == GT_Aggregation::GT_BIT_XOR) {
-                                aggregator[i] = new AggregatorBitXor;
-                              } else  // GT_Aggregation::GT_GROUP_CONCAT(...)
-                                if (desc.operation == GT_Aggregation::GT_GROUP_CONCAT) {
-                                  aggregator[i] = new AggregatorGroupConcat(desc.si, desc.type);
-                                }
+      } else  // BIT_XOR(...)
+          if (desc.operation == GT_Aggregation::GT_BIT_XOR) {
+        aggregator[i] = new AggregatorBitXor;
+      } else  // GT_Aggregation::GT_GROUP_CONCAT(...)
+          if (desc.operation == GT_Aggregation::GT_GROUP_CONCAT) {
+        aggregator[i] = new AggregatorGroupConcat(desc.si, desc.type);
+      }
 
       if (aggregator[i]->IgnoreDistinct()) desc.distinct = false;
     }
@@ -370,10 +370,11 @@ void GroupTable::Initialize(int64_t max_no_groups, bool parallel_allowed) {
   Transaction *m_conn = current_txn_;
   double size_mb = (double)vm_tab->ByteSize();
   size_mb =
-      (size_mb > 1024 ? (size_mb > 1024 * 1024 ? int64_t(size_mb / 1024 * 1024) : int64_t(size_mb / 1024) / 1024.0) : 0.001);
-  rc_control_.lock(m_conn->GetThreadID()) << "GroupTable begin, initialized for up to " << max_no_groups << " groups, "
-                                        << grouping_buf_width << "+" << total_width - grouping_buf_width << " bytes ("
-                                        << size_mb << " MB)" << system::unlock;
+      (size_mb > 1024 ? (size_mb > 1024 * 1024 ? int64_t(size_mb / 1024 * 1024) : int64_t(size_mb / 1024) / 1024.0)
+                      : 0.001);
+  rc_control_.lock(m_conn->GetThreadID())
+      << "GroupTable begin, initialized for up to " << max_no_groups << " groups, " << grouping_buf_width << "+"
+      << total_width - grouping_buf_width << " bytes (" << size_mb << " MB)" << system::unlock;
   ClearAll();
   initialized = true;
 }

--- a/storage/tianmu/core/group_table.h
+++ b/storage/tianmu/core/group_table.h
@@ -187,9 +187,9 @@ class GroupTable : public mm::TraceableObject {
       size = 0;
       precision = 0;
       type = common::CT::INT;
-      si.order = ORDER_NOT_RELEVANT;         // direction for GROUP_CONCAT order // stonedb8
-                                             // by 0/1-ASC/2-DESC
-      si.separator = ',';                    // for GROUP_CONCAT
+      si.order = ORDER_NOT_RELEVANT;  // direction for GROUP_CONCAT order // stonedb8
+                                      // by 0/1-ASC/2-DESC
+      si.separator = ',';             // for GROUP_CONCAT
     }
 
     vcolumn::VirtualColumn *vc;
@@ -214,7 +214,7 @@ class GroupTable : public mm::TraceableObject {
   std::vector<bool> distinct;
   std::vector<vcolumn::VirtualColumn *> vc;
   std::vector<TIANMUAggregator *> aggregator;  // a table of actual aggregators
-  std::vector<ColumnBinEncoder *> encoder;      // encoders for grouping columns
+  std::vector<ColumnBinEncoder *> encoder;     // encoders for grouping columns
 
   // "distinct" part
   std::vector<std::shared_ptr<GroupDistinctTable>> gdistinct;  // Empty if not used

--- a/storage/tianmu/core/groupby_wrapper.cpp
+++ b/storage/tianmu/core/groupby_wrapper.cpp
@@ -240,9 +240,9 @@ void GroupByWrapper::AddAggregatedColumn(int orig_attr_no, TempTable::Attr &a, i
              : GBInputMode::GBIMODE_AS_INT64);
 
   TIANMU_LOG(LogCtl_Level::DEBUG,
-              "attr_no %d, input_mode[attr_no] %d, a.alias %s, a.si.separator "
-              "%s, direction %d, ag_type %d, ag_size %d",
-              attr_no, input_mode[attr_no], a.alias, a.si.separator.c_str(), a.si.order, ag_type, ag_size);
+             "attr_no %d, input_mode[attr_no] %d, a.alias %s, a.si.separator "
+             "%s, direction %d, ag_type %d, ag_size %d",
+             attr_no, input_mode[attr_no], a.alias, a.si.separator.c_str(), a.si.order, ag_type, ag_size);
 
   gt.AddAggregatedColumn(virt_col[attr_no], ag_oper, ag_distinct, ag_type, ag_size, ag_prec, ag_collation,
                          a.si);  // note: size will be automatically calculated for all numericals

--- a/storage/tianmu/core/item_tianmu_field.cpp
+++ b/storage/tianmu/core/item_tianmu_field.cpp
@@ -183,9 +183,10 @@ bool Item_tianmufield::get_date(MYSQL_TIME *ltime, uint fuzzydate) {
 }
 
 bool Item_tianmufield::get_time(MYSQL_TIME *ltime) {
-  if ((null_value = buf->null) || ((tianmu_type.attrtype == common::CT::DATETIME || tianmu_type.attrtype == common::CT::DATE) &&
-                                   buf->x == 0))  // zero date is illegal
-    return 1;                                     // like in Item_field::get_time - return 1 on null value.
+  if ((null_value = buf->null) ||
+      ((tianmu_type.attrtype == common::CT::DATETIME || tianmu_type.attrtype == common::CT::DATE) &&
+       buf->x == 0))  // zero date is illegal
+    return 1;         // like in Item_field::get_time - return 1 on null value.
   FeedValue();
   return ivalue->get_time(ltime);
 }

--- a/storage/tianmu/core/joiner_general.cpp
+++ b/storage/tianmu/core/joiner_general.cpp
@@ -62,7 +62,8 @@ void JoinerGeneral::ExecuteJoinConditions(Condition &cond) {
   bool loc_result;
   bool stop_execution = false;  // early stop for LIMIT
 
-  rc_control_.lock(m_conn->GetThreadID()) << "Starting joiner loop (" << mit.NumOfTuples() << " rows)." << system::unlock;
+  rc_control_.lock(m_conn->GetThreadID())
+      << "Starting joiner loop (" << mit.NumOfTuples() << " rows)." << system::unlock;
   // The main loop for checking conditions
   int64_t rows_passed = 0;
   int64_t rows_omitted = 0;

--- a/storage/tianmu/core/joiner_hash.cpp
+++ b/storage/tianmu/core/joiner_hash.cpp
@@ -75,7 +75,7 @@ void JoinerHash::ExecuteJoinConditions(Condition &cond) {
         first_found = false;
       } else {
         DimensionVector sec_dims1(mind->NumOfDimensions());  // Make sure the local descriptions are
-                                                          // compatible
+                                                             // compatible
         DimensionVector sec_dims2(mind->NumOfDimensions());
         cond[i].attr.vc->MarkUsedDims(sec_dims1);
         cond[i].val1.vc->MarkUsedDims(sec_dims2);
@@ -570,7 +570,7 @@ int64_t JoinerHash::NewMatchDim(MINewContents *new_mind1, MIUpdatingIterator *ta
                                 JoinerHashTable *hash_table, int *join_tuple, int tianmu_sysvar_jointhreadpool) {
   JoinerHashTable &tmp_jhash = *hash_table;
   TIANMU_LOG(LogCtl_Level::INFO, "NewMatchDim start, taskid %d, tianmu_sysvar_jointhreadpool %d",
-              task_mit1->GetTaskId(), tianmu_sysvar_jointhreadpool);
+             task_mit1->GetTaskId(), tianmu_sysvar_jointhreadpool);
   common::SetMySQLTHD(ci->Thd());
   current_txn_ = ci;
   for (int i = 0; i < cond_hashed; i++) {

--- a/storage/tianmu/core/joiner_hash_table.cpp
+++ b/storage/tianmu/core/joiner_hash_table.cpp
@@ -131,9 +131,9 @@ void JoinerHashTable::Initialize(int64_t max_table_size, bool easy_roughable) {
   // initialize everything
   ClearAll();
   Transaction *m_conn = current_txn_;
-  rc_control_.lock(m_conn->GetThreadID()) << "Hash join buffer initialized for up to " << no_rows << " rows, "
-                                        << key_buf_width << "+" << total_width - key_buf_width << " bytes."
-                                        << system::unlock;
+  rc_control_.lock(m_conn->GetThreadID())
+      << "Hash join buffer initialized for up to " << no_rows << " rows, " << key_buf_width << "+"
+      << total_width - key_buf_width << " bytes." << system::unlock;
   initialized = true;
 }
 

--- a/storage/tianmu/core/joiner_hash_table.h
+++ b/storage/tianmu/core/joiner_hash_table.h
@@ -115,8 +115,8 @@ class JoinerHashTable : public mm::TraceableObject {
     }
   }
 
-  int NumOfAttrs() { return no_attr; }         // total number of columns
-  int64_t NoRows() { return no_rows; }     // buffer size (max. number of rows)
+  int NumOfAttrs() { return no_attr; }  // total number of columns
+  int64_t NoRows() { return no_rows; }  // buffer size (max. number of rows)
   int64_t GetTupleValue(int col,
                         int64_t row) {  // columns have common numbering
     DEBUG_ASSERT(col >= no_key_attr);

--- a/storage/tianmu/core/joiner_mapped.cpp
+++ b/storage/tianmu/core/joiner_mapped.cpp
@@ -207,8 +207,8 @@ std::unique_ptr<JoinerMapFunction> JoinerMapped::GenerateFunction(vcolumn::Virtu
   auto map_function = std::make_unique<MultiMapsFunction>(m_conn);
   if (!map_function->Init(vc, mit)) return nullptr;
 
-  rc_control_.lock(m_conn->GetThreadID()) << "Join mapping (multimaps) created on " << mit.NumOfTuples() << " rows."
-                                        << system::unlock;
+  rc_control_.lock(m_conn->GetThreadID())
+      << "Join mapping (multimaps) created on " << mit.NumOfTuples() << " rows." << system::unlock;
   return std::move(map_function);
 }
 
@@ -387,7 +387,7 @@ void JoinerParallelMapped::ExecuteJoinConditions(Condition &cond) {
     task.dwStartPackno = tid * (packnums / tids);
     task.dwEndPackno = (tid == tids - 1) ? packnums : (tid + 1) * (packnums / tids);
     res.insert(ha_rcengine_->query_thread_pool.add_task(&JoinerParallelMapped::ExecuteMatchLoop, this, &indextable[tid],
-                                                 packrows, &matched_tuples[tid], vc2, task, map_function.get()));
+                                                        packrows, &matched_tuples[tid], vc2, task, map_function.get()));
   }
   res.get_all();
 
@@ -494,8 +494,8 @@ bool MultiMapsFunction::Init(vcolumn::VirtualColumn *vc, MIIterator &mit) {
     return false;
   int64_t span = key_table_max - key_table_min + 1;
   if (span < 0) return false;
-  rc_control_.lock(m_conn->GetThreadID()) << "MultiMapsFunction: constructing a multimap with " << mit.NumOfTuples()
-                                        << " tuples." << system::unlock;
+  rc_control_.lock(m_conn->GetThreadID())
+      << "MultiMapsFunction: constructing a multimap with " << mit.NumOfTuples() << " tuples." << system::unlock;
   while (mit.IsValid()) {
     if (mit.PackrowStarted()) vc->LockSourcePacks(mit);
     int64_t val = vc->GetValueInt64(mit);

--- a/storage/tianmu/core/joiner_mapped.h
+++ b/storage/tianmu/core/joiner_mapped.h
@@ -62,7 +62,7 @@ class JoinerMapped : public TwoDimensionalJoiner {
 
 class JoinerParallelMapped : public JoinerMapped {
  public:
-  JoinerParallelMapped(MultiIndex *_mind, TempTable *_table, JoinTips &_tips) : JoinerMapped(_mind, _table, _tips){}
+  JoinerParallelMapped(MultiIndex *_mind, TempTable *_table, JoinTips &_tips) : JoinerMapped(_mind, _table, _tips) {}
 
   void ExecuteJoinConditions(Condition &cond) override;
 
@@ -126,7 +126,7 @@ class OffsetMapFunction : public JoinerMapFunction {
 class MultiMapsFunction : public JoinerMapFunction {
  public:
   MultiMapsFunction(Transaction *_m_conn) : JoinerMapFunction(_m_conn) {}
-  ~MultiMapsFunction(){}
+  ~MultiMapsFunction() {}
 
   bool Init(vcolumn::VirtualColumn *vc, MIIterator &mit);
 

--- a/storage/tianmu/core/joiner_sort.cpp
+++ b/storage/tianmu/core/joiner_sort.cpp
@@ -35,7 +35,7 @@ void JoinerSort::ExecuteJoinConditions(Condition &cond) {
   if (vc1 == NULL || vc2 == NULL) {
     why_failed = JoinFailure::FAIL_COMPLEX;
     return;
-  } else {                                        // Normalize: let vc1 = a smaller table
+  } else {                                           // Normalize: let vc1 = a smaller table
     DimensionVector dims1(mind->NumOfDimensions());  // Initial dimension descriptions
     DimensionVector dims2(mind->NumOfDimensions());
     vc1->MarkUsedDims(dims1);
@@ -179,8 +179,8 @@ void JoinerSort::ExecuteJoinConditions(Condition &cond) {
     rc_control_.lock(m_conn->GetThreadID())
         << "Roughly omitted " << int(packrows_omitted / double(packrows_matched) * 10000.0) / 100.0 << "% packrows."
         << system::unlock;
-  rc_control_.lock(m_conn->GetThreadID()) << "Joining sorters created for " << actual_s1_size << " and " << actual_s2_size
-                                        << " tuples." << system::unlock;
+  rc_control_.lock(m_conn->GetThreadID())
+      << "Joining sorters created for " << actual_s1_size << " and " << actual_s2_size << " tuples." << system::unlock;
 
   // the main joiner loop
   int64_t no_of_traversed = 1;

--- a/storage/tianmu/core/just_a_table.h
+++ b/storage/tianmu/core/just_a_table.h
@@ -61,7 +61,7 @@ class JustATable : public std::enable_shared_from_this<JustATable> {
   //! Returns column value in the form required by complex expressions
   ValueOrNull GetComplexValue(const int64_t obj, const int attr);
 
-  virtual ~JustATable(){}
+  virtual ~JustATable() {}
 };
 
 }  // namespace core

--- a/storage/tianmu/core/mi_new_contents.cpp
+++ b/storage/tianmu/core/mi_new_contents.cpp
@@ -186,7 +186,7 @@ void MINewContents::Commit([[maybe_unused]] int64_t joined_tuples)  // commit ch
     dims_to_forget[optimized_dim_stay] = false;
     DimensionGroupMaterialized *ng = new DimensionGroupMaterialized(dims_to_forget);  // forgotten dimensions
     mind->dim_groups.push_back(ng);
-    ng->SetNumOfObj(1);                                           // set a dummy size 1 for a group containing forgotten
+    ng->SetNumOfObj(1);                                        // set a dummy size 1 for a group containing forgotten
                                                                // dimensions only
   } else if (content_type == enumMINCType::MCT_VIRTUAL_DIM) {  // optimized version: virtual dimension group
     DimensionGroupVirtual *nv = new DimensionGroupVirtual(dim_involved, optimized_dim_stay, f_opt,

--- a/storage/tianmu/core/mi_updating_iterator.cpp
+++ b/storage/tianmu/core/mi_updating_iterator.cpp
@@ -61,7 +61,7 @@ void MIUpdatingIterator::Commit(bool recalculate_no_tuples) {
                                     // (special case)
     if (recalculate_no_tuples)
       mind->UpdateNumOfTuples();  // not for parallel WHERE - shallow copy of
-                               // MultiIndex/Filter
+                                  // MultiIndex/Filter
   } else {
     multi_dim_filter->Commit();
     mind->IteratorUnlock();  // unlock to allow creating the iterator below

--- a/storage/tianmu/core/multi_index.cpp
+++ b/storage/tianmu/core/multi_index.cpp
@@ -308,7 +308,7 @@ void MultiIndex::UpdateNumOfTuples() {
 }
 
 int64_t MultiIndex::NumOfTuples(DimensionVector &dimensions,
-                             bool fail_on_overflow)  // for a given subset of dimensions
+                                bool fail_on_overflow)  // for a given subset of dimensions
 {
   std::vector<int> dg = ListInvolvedDimGroups(dimensions);
   if (dg.size() == 0) return 0;
@@ -322,7 +322,7 @@ int64_t MultiIndex::NumOfTuples(DimensionVector &dimensions,
 }
 
 int MultiIndex::MaxNumOfPacks(int dim)  // maximal (upper approx.) number of different nonempty data
-                                     // packs for the given dimension
+                                        // packs for the given dimension
 {
   int max_packs = 0;
   Filter *f = group_for_dim[dim]->GetFilter(dim);

--- a/storage/tianmu/core/multi_index.h
+++ b/storage/tianmu/core/multi_index.h
@@ -54,7 +54,7 @@ class MultiIndex {
     return 0;
   }
   int64_t NumOfTuples(DimensionVector &dimensions,
-                   bool fail_on_overflow = true);  // for a given subset of dimensions
+                      bool fail_on_overflow = true);  // for a given subset of dimensions
 
   bool ZeroTuples() { return (!no_tuples_too_big && no_tuples == 0); }
   bool TooManyTuples() { return no_tuples_too_big; }
@@ -135,8 +135,8 @@ class MultiIndex {
   // material_no_tuples and the dimensions from the list are deleted
 
   int MaxNumOfPacks(int dim);  // maximal (upper approx.) number of different
-                            // nonempty data packs for the given dimension
-  std::string Display();    // MultiIndex structure: f - Filter, i - IndexTable
+                               // nonempty data packs for the given dimension
+  std::string Display();       // MultiIndex structure: f - Filter, i - IndexTable
 
   Transaction &ConnInfo() const { return *m_conn; }
 

--- a/storage/tianmu/core/mysql_expression.cpp
+++ b/storage/tianmu/core/mysql_expression.cpp
@@ -20,8 +20,8 @@
 #include "common/assert.h"
 #include "core/compilation_tools.h"
 #include "core/engine.h"
-#include "item_timefunc.h"
 #include "core/transaction.h"
+#include "item_timefunc.h"
 #include "types/value_parser4txt.h"
 
 namespace Tianmu {
@@ -411,7 +411,8 @@ DataType MysqlExpression::EvalType(TypOfVars *tv) {
         type = DataType(common::CT::DATETIME, 17, 0, item->collation);
       else if ((item->type() != Item_tianmufield::get_tianmuitem_type() && item->data_type() == MYSQL_TYPE_DATE) ||
                (item->type() == Item_tianmufield::get_tianmuitem_type() &&
-                static_cast<Item_tianmufield *>(item)->IsAggregation() == false && item->data_type() == MYSQL_TYPE_DATE))
+                static_cast<Item_tianmufield *>(item)->IsAggregation() == false &&
+                item->data_type() == MYSQL_TYPE_DATE))
         type = DataType(common::CT::DATE, 17, 0, item->collation);
       else
         // type = DataType(common::CT::STRING, item->max_length, 0,
@@ -560,18 +561,20 @@ bool SameTIANMUField(Item_tianmufield *const &l, Item_tianmufield *const &r) {
 }
 
 bool SameTIANMUFieldSet(MysqlExpression::tianmu_fields_cache_t::value_type const &l,
-                     MysqlExpression::tianmu_fields_cache_t::value_type const &r) {
-  return l.second.size() == r.second.size() && equal(l.second.begin(), l.second.end(), r.second.begin(), SameTIANMUField);
+                        MysqlExpression::tianmu_fields_cache_t::value_type const &r) {
+  return l.second.size() == r.second.size() &&
+         equal(l.second.begin(), l.second.end(), r.second.begin(), SameTIANMUField);
 }
 
 bool operator==(Item const &, Item const &);
 
 namespace {
 bool generic_item_same(Item const &l_, Item const &r_) {
-  return ((&l_ == &r_) || ((l_.type() == r_.type()) && (l_.result_type() == r_.result_type()) &&
-                           (l_.cast_to_int_type() == r_.cast_to_int_type()) &&
-                           (l_.string_field_type(l_.max_length) == r_.string_field_type(l_.max_length)) && (l_.data_type() == r_.data_type()) &&
-                           (l_.const_for_execution() == r_.const_for_execution()) && (l_ == r_)));
+  return ((&l_ == &r_) ||
+          ((l_.type() == r_.type()) && (l_.result_type() == r_.result_type()) &&
+           (l_.cast_to_int_type() == r_.cast_to_int_type()) &&
+           (l_.string_field_type(l_.max_length) == r_.string_field_type(l_.max_length)) &&
+           (l_.data_type() == r_.data_type()) && (l_.const_for_execution() == r_.const_for_execution()) && (l_ == r_)));
 }
 }  // namespace
 
@@ -617,7 +620,8 @@ bool operator==(Item const &l_, Item const &r_) {
             const Item_date_add_interval *l = static_cast<const Item_date_add_interval *>(&l_);
             const Item_date_add_interval *r = static_cast<const Item_date_add_interval *>(&r_);
             same = same && dynamic_cast<const Item_date_add_interval *>(&r_);
-            same = same && ((l->get_interval_type() == r->get_interval_type()) && (l->is_subtract() == r->is_subtract()));
+            same =
+                same && ((l->get_interval_type() == r->get_interval_type()) && (l->is_subtract() == r->is_subtract()));
           }
           if (l->functype() == Item_func::IN_FUNC) {
             const Item_func_in *l = static_cast<const Item_func_in *>(&l_);
@@ -671,8 +675,10 @@ bool operator==(Item const &l_, Item const &r_) {
 bool MysqlExpression::operator==(MysqlExpression const &other) const {
   return ((mysql_type == other.mysql_type) && (decimal_precision == other.decimal_precision) &&
           (decimal_scale == other.decimal_scale) && (deterministic == other.deterministic) &&
-          (*item == *(other.item)) && (tianmu_fields_cache.size() == other.tianmu_fields_cache.size()) && vars == other.vars &&
-          equal(tianmu_fields_cache.begin(), tianmu_fields_cache.end(), other.tianmu_fields_cache.begin(), SameTIANMUFieldSet));
+          (*item == *(other.item)) && (tianmu_fields_cache.size() == other.tianmu_fields_cache.size()) &&
+          vars == other.vars &&
+          equal(tianmu_fields_cache.begin(), tianmu_fields_cache.end(), other.tianmu_fields_cache.begin(),
+                SameTIANMUFieldSet));
 }
 }  // namespace core
 }  // namespace Tianmu

--- a/storage/tianmu/core/pack_orderer.h
+++ b/storage/tianmu/core/pack_orderer.h
@@ -40,7 +40,7 @@ class PackOrderer {
   enum class State { INIT_VAL = -1, END = -2 };
 
   struct OrderStat {
-    OrderStat(int n, int o) : neutral(n), ordered(o){}
+    OrderStat(int n, int o) : neutral(n), ordered(o) {}
     int neutral;
     int ordered;
   };

--- a/storage/tianmu/core/parallel_hash_join.cpp
+++ b/storage/tianmu/core/parallel_hash_join.cpp
@@ -258,7 +258,7 @@ bool ParallelHashJoiner::PrepareBeforeJoin(Condition &cond) {
         first_found = false;
       } else {
         DimensionVector sec_dims1(mind->NumOfDimensions());  // Make sure the local descriptions are
-                                                          // compatible
+                                                             // compatible
         DimensionVector sec_dims2(mind->NumOfDimensions());
         cond[i].attr.vc->MarkUsedDims(sec_dims1);
         cond[i].val1.vc->MarkUsedDims(sec_dims2);
@@ -518,7 +518,7 @@ int64_t ParallelHashJoiner::TraverseDim(MIIterator &mit, int64_t *outer_tuples) 
 
   int traversed_fragment_count = (int)task_iterators.size();
   rc_control_.lock(m_conn->GetThreadID()) << "Begin traversed with " << traversed_fragment_count << " threads with "
-                                        << splitting_type << " type." << system::unlock;
+                                          << splitting_type << " type." << system::unlock;
 
   std::vector<TraverseTaskParams> traverse_task_params;
   traverse_task_params.reserve(task_iterators.size());
@@ -567,8 +567,8 @@ int64_t ParallelHashJoiner::TraverseDim(MIIterator &mit, int64_t *outer_tuples) 
 
   if (m_conn->Killed()) throw common::KilledException();
 
-  rc_control_.lock(m_conn->GetThreadID()) << "End traversed " << traversed_rows << "/" << rows_count << " rows."
-                                        << system::unlock;
+  rc_control_.lock(m_conn->GetThreadID())
+      << "End traversed " << traversed_rows << "/" << rows_count << " rows." << system::unlock;
 
   for (auto &params : traverse_task_params) {
     if (params.too_many_conflicts && !tianmu_sysvar_join_disable_switch_side) {
@@ -703,7 +703,7 @@ bool ParallelHashJoiner::CreateMatchingTasks(MIIterator &mit, int64_t rows_count
     if (packs_count > kJoinSplittedMinPacks) {
       // Splitting using packs.
       int split_count = (tianmu_sysvar_join_parallel > 1) ? tianmu_sysvar_join_parallel
-                                                           : EvaluateMatchedFragmentsWithPacks(packs_count);
+                                                          : EvaluateMatchedFragmentsWithPacks(packs_count);
       int packs_per_fragment = (packs_count + kJoinSplittedMinPacks) / split_count;
       for (int index = 0; index < split_count; ++index) {
         int packs_started = index * packs_per_fragment;
@@ -756,9 +756,9 @@ int64_t ParallelHashJoiner::MatchDim(MIIterator &mit) {
   std::vector<MITaskIterator *> task_iterators;
   CreateMatchingTasks(mit, rows_count, &task_iterators, &splitting_type);
 
-  rc_control_.lock(m_conn->GetThreadID()) << "Begin match dim of " << rows_count << " rows, spliting into "
-                                        << task_iterators.size() << " threads with " << splitting_type << " type."
-                                        << system::unlock;
+  rc_control_.lock(m_conn->GetThreadID())
+      << "Begin match dim of " << rows_count << " rows, spliting into " << task_iterators.size() << " threads with "
+      << splitting_type << " type." << system::unlock;
 
   auto &ftht = traversed_hash_tables_[0];
 
@@ -810,8 +810,8 @@ int64_t ParallelHashJoiner::MatchDim(MIIterator &mit) {
 
   if (m_conn->Killed()) throw common::KilledException();
 
-  rc_control_.lock(m_conn->GetThreadID()) << "End match dim. Produced tuples:" << matched_rows << "/" << rows_count
-                                        << system::unlock;
+  rc_control_.lock(m_conn->GetThreadID())
+      << "End match dim. Produced tuples:" << matched_rows << "/" << rows_count << system::unlock;
 
   for (auto &params : match_task_params) {
     multi_index_builder_->AddBuildItem(params.build_item);
@@ -1150,7 +1150,7 @@ int64_t ParallelHashJoiner::SubmitOuterMatched(MIIterator &miter) {
       params.build_item = multi_index_builder_->CreateBuildItem();
 
       res.insert(ha_rcengine_->query_thread_pool.add_task(&ParallelHashJoiner::AsyncSubmitOuterMatched, this, &params,
-                                                   outer_matched_filter_.get()));
+                                                          outer_matched_filter_.get()));
     }
   } catch (std::exception &e) {
     res.get_all_with_except();

--- a/storage/tianmu/core/parameterized_filter.cpp
+++ b/storage/tianmu/core/parameterized_filter.cpp
@@ -36,12 +36,11 @@
 namespace Tianmu {
 namespace core {
 ParameterizedFilter::ParameterizedFilter(uint32_t power, CondType filter_type)
-    : mind(new MultiIndex(power))
-    , mind_shallow_memory(false)
-    , rough_mind(nullptr)
-    , table(nullptr)
-    , filter_type(filter_type) {
-}
+    : mind(new MultiIndex(power)),
+      mind_shallow_memory(false),
+      rough_mind(nullptr),
+      table(nullptr),
+      filter_type(filter_type) {}
 
 ParameterizedFilter &ParameterizedFilter::operator=(const ParameterizedFilter &pf) {
   if (this != &pf) {
@@ -185,9 +184,9 @@ double ParameterizedFilter::EvaluateConditionNonJoinWeight(Descriptor &d, bool f
     // Processing descriptor on PK firstly
     if (d.IsleftIndexSearch()) eval = 0.001;
 
-  } else if (d.IsType_AttrAttr()) {           // attr=attr on the same table
+  } else if (d.IsType_AttrAttr()) {              // attr=attr on the same table
     uint64_t no_obj = d.attr.vc->NumOfTuples();  // changed to uint64_t to prevent negative
-                                              // logarithm for common::NULL_VALUE_64
+                                                 // logarithm for common::NULL_VALUE_64
     if (!d.encoded)
       return log(1 + double(2 * no_obj)) + 5;  // +5 as a penalty for complex expression
     else if (d.op == common::Operator::O_EQ) {
@@ -1048,11 +1047,8 @@ void ParameterizedFilter::UpdateMultiIndex(bool count_only, int64_t limit) {
   int no_of_delayed_conditions = 0;
   for (uint i = 0; i < descriptors.Size(); i++) {
     if (!descriptors[i].done)
-      if (descriptors[i].IsType_Join() 
-          || descriptors[i].IsDelayed() 
-          || descriptors[i].IsOuter() 
-          || descriptors[i].IsType_In() 
-          || descriptors[i].IsType_Exists()) {
+      if (descriptors[i].IsType_Join() || descriptors[i].IsDelayed() || descriptors[i].IsOuter() ||
+          descriptors[i].IsType_In() || descriptors[i].IsType_Exists()) {
         if (!descriptors[i].IsDelayed())
           no_of_join_conditions++;
         else
@@ -1073,12 +1069,8 @@ void ParameterizedFilter::UpdateMultiIndex(bool count_only, int64_t limit) {
 
   int desc_no = 0;
   for (uint i = 0; i < descriptors.Size(); i++) {
-    if (!descriptors[i].done 
-        && descriptors[i].IsInner() 
-        && !descriptors[i].IsType_Join() 
-        && !descriptors[i].IsDelayed() 
-        && !descriptors[i].IsType_In() 
-        && !descriptors[i].IsType_Exists()) {
+    if (!descriptors[i].done && descriptors[i].IsInner() && !descriptors[i].IsType_Join() &&
+        !descriptors[i].IsDelayed() && !descriptors[i].IsType_In() && !descriptors[i].IsType_Exists()) {
       ++desc_no;
       if (descriptors[i].attr.vc) {
         cur_dim = descriptors[i].attr.vc->GetDim();
@@ -1109,7 +1101,7 @@ void ParameterizedFilter::UpdateMultiIndex(bool count_only, int64_t limit) {
     if (mind->GetFilter(i))
       table->SetVCDistinctVals(i,
                                mind->GetFilter(i)->NumOfOnes());  // distinct values - not more than the
-                                                               // number of rows after WHERE
+                                                                  // number of rows after WHERE
   rough_mind->ClearLocalDescFilters();
 
   // Some displays
@@ -1332,8 +1324,9 @@ void ParameterizedFilter::ApplyDescriptor(int desc_number, int64_t limit)
 
       utils::result_set<void> res;
       for (int i = 0; i < task_num; ++i) {
-        res.insert(ha_rcengine_->query_thread_pool.add_task(&ParameterizedFilter::TaskProcessPacks, this, &taskIterator[i],
-                                                     current_txn_, rf, &dims, desc_number, limit, one_dim));
+        res.insert(ha_rcengine_->query_thread_pool.add_task(&ParameterizedFilter::TaskProcessPacks, this,
+                                                            &taskIterator[i], current_txn_, rf, &dims, desc_number,
+                                                            limit, one_dim));
       }
       res.get_all_with_except();
 

--- a/storage/tianmu/core/query.cpp
+++ b/storage/tianmu/core/query.cpp
@@ -522,17 +522,18 @@ bool Query::IsParameterFromWhere(const TabID &params_table) {
   return true;
 }
 
-const char *Query::GetTableName(Item_field *ifield)
-{
-    const char *table_name = NULL;
-    if (ifield->cached_table && !ifield->cached_table->is_view() && !ifield->cached_table->is_view_or_derived())//TIANMU UPGRADE
-        if (ifield->cached_table->referencing_view)
-            table_name = ifield->cached_table->referencing_view->table_name;
-        else
-            table_name = ifield->cached_table->table_name;
-    else if (ifield->get_result_field() && ifield->get_result_field()->table && ifield->get_result_field()->table->s->table_category != TABLE_CATEGORY_TEMPORARY)
-        table_name = ifield->get_result_field()->table->s->table_name.str;
-    return table_name;
+const char *Query::GetTableName(Item_field *ifield) {
+  const char *table_name = NULL;
+  if (ifield->cached_table && !ifield->cached_table->is_view() &&
+      !ifield->cached_table->is_view_or_derived())  // TIANMU UPGRADE
+    if (ifield->cached_table->referencing_view)
+      table_name = ifield->cached_table->referencing_view->table_name;
+    else
+      table_name = ifield->cached_table->table_name;
+  else if (ifield->get_result_field() && ifield->get_result_field()->table &&
+           ifield->get_result_field()->table->s->table_category != TABLE_CATEGORY_TEMPORARY)
+    table_name = ifield->get_result_field()->table->s->table_name.str;
+  return table_name;
 }
 
 void Query::GetPrecisionScale(Item *item, int &precision, int &scale, bool max_scale) {
@@ -682,7 +683,8 @@ TempTable *Query::Preexecute(CompiledQuery &qu, ResultSender *sender, [[maybe_un
             common::LogicalOperator lop = (step.type == CompiledQuery::StepType::AND_F ? common::LogicalOperator::O_AND
                                                                                        : common::LogicalOperator::O_OR);
             static_cast<SingleTreeCondition *>(conds[step.c1.n])
-                ->AddTree(lop, static_cast<SingleTreeCondition *>(conds[step.c2.n])->GetTree(), qu.GetNumOfDimens(step.t1));
+                ->AddTree(lop, static_cast<SingleTreeCondition *>(conds[step.c2.n])->GetTree(),
+                          qu.GetNumOfDimens(step.t1));
           } else {
             DEBUG_ASSERT(conds[step.c2.n]->IsType_Tree());
             conds[step.c1.n]->AddDescriptor(static_cast<SingleTreeCondition *>(conds[step.c2.n])->GetTree(),
@@ -1673,8 +1675,9 @@ bool Query::ClearSubselectTransformation(common::Operator &oper_for_subselect, I
   // expression with subselect
   Item *left_ref = ((Item_func *)cond_removed)->arguments()[0];
   if (dynamic_cast<Item_int_with_ref *>(left_ref) != NULL) left_ref = ((Item_int_with_ref *)left_ref)->real_item();
-  if (left_ref->type() != Item::REF_ITEM || /*((Item_ref *)left_ref)->ref_type() != Item_ref::DIRECT_REF ||*/ // stonedb8 DIRECT_REF is deleted
-      ((Item_ref *)left_ref)->real_item() != left_expr_for_subselect)
+  if (left_ref->type() != Item::REF_ITEM ||
+      /*((Item_ref *)left_ref)->ref_type() != Item_ref::DIRECT_REF ||*/  // stonedb8 DIRECT_REF is deleted
+          ((Item_ref *)left_ref)->real_item() != left_expr_for_subselect)
     return false;
   // set the operation type
   switch (((Item_func *)cond_removed)->functype()) {

--- a/storage/tianmu/core/query.h
+++ b/storage/tianmu/core/query.h
@@ -60,8 +60,8 @@ class Query final {
 
   void SetRoughQuery(bool set_rough) { rough_query = set_rough; }
   bool IsRoughQuery() { return rough_query; }
-  int Compile(CompiledQuery *compiled_query, Query_block *selects_list, Query_block *last_distinct, TabID *res_tab = NULL,
-              bool ignore_limit = false, Item *left_expr_for_subselect = NULL,
+  int Compile(CompiledQuery *compiled_query, Query_block *selects_list, Query_block *last_distinct,
+              TabID *res_tab = NULL, bool ignore_limit = false, Item *left_expr_for_subselect = NULL,
               common::Operator *oper_for_subselect = NULL, bool ignore_minmax = false, bool for_subq_in_where = false);
   TempTable *Preexecute(CompiledQuery &qu, ResultSender *sender, bool display_now = true);
   int BuildConditions(Item *conds, CondID &cond_id, CompiledQuery *cq, const TabID &tmp_table, CondType filter_type,

--- a/storage/tianmu/core/query_compile.cpp
+++ b/storage/tianmu/core/query_compile.cpp
@@ -118,7 +118,8 @@ int Query::FieldUnmysterify(Item *item, const char *&database_name, const char *
         Item *tmp_item = UnRef(is->get_arg(0));
         if (tmp_item->type() == Item::FIELD_ITEM)
           ifield = (Item_field *)tmp_item;
-        else if (static_cast<int>(tmp_item->type()) == static_cast<int>(Item_tianmufield::enumTIANMUFiledItem::TIANMUFIELD_ITEM))
+        else if (static_cast<int>(tmp_item->type()) ==
+                 static_cast<int>(Item_tianmufield::enumTIANMUFiledItem::TIANMUFIELD_ITEM))
           ifield = dynamic_cast<Item_tianmufield *>(tmp_item)->OriginalItem();
         else {
           return RETURN_QUERY_TO_MYSQL_ROUTE;
@@ -289,31 +290,31 @@ bool Query::FieldUnmysterify(Item *item, TabID &tab, AttrID &col) {
 }
 
 // stonedb8 start fix List<Item> to mem_root_deque<Item *> #49 TODO
-int Query::AddJoins(mem_root_deque<TABLE_LIST *> join, /*List<TABLE_LIST> &join,*/ TabID &tmp_table, std::vector<TabID> &left_tables,
-                    std::vector<TabID> &right_tables, bool in_subquery, bool &first_table /*= true*/,
-                    bool for_subq_in_where /*false*/) {
+int Query::AddJoins(mem_root_deque<TABLE_LIST *> join, /*List<TABLE_LIST> &join,*/ TabID &tmp_table,
+                    std::vector<TabID> &left_tables, std::vector<TabID> &right_tables, bool in_subquery,
+                    bool &first_table /*= true*/, bool for_subq_in_where /*false*/) {
   // on first call first_table = true. It indicates if it is the first table to
   // be added is_left is true iff it is nested left join which needs to be
   // flatten (all tables regardless of their join type need to be left-joined)
-// stonedb8 start
-//  TABLE_LIST *join_ptr;
-//  List_iterator<TABLE_LIST> li(join);
-//  std::vector<TABLE_LIST *> reversed;
-// stonedb8 end
+  // stonedb8 start
+  //  TABLE_LIST *join_ptr;
+  //  List_iterator<TABLE_LIST> li(join);
+  //  std::vector<TABLE_LIST *> reversed;
+  // stonedb8 end
 
-  if (join.empty()) // stonedb8
+  if (join.empty())                      // stonedb8
     return RETURN_QUERY_TO_MYSQL_ROUTE;  // no tables in table list in this
                                          // select
-  // if the table list was empty altogether, we wouldn't even enter
-  // Compilation(...) it must be sth. like `select 1 from t1 union select 2` and
-  // we are in the second select in the union
-// stonedb8 start
-//while ((join_ptr = li++) != nullptr) reversed.push_back(join_ptr);
-//size_t size = reversed.size();
-//  for (unsigned int i = 0; i < size; i++) {
-    for (TABLE_LIST *join_ptr : join) {
-    //join_ptr = reversed[size - i - 1];
-// stonedb8 end
+                                         // if the table list was empty altogether, we wouldn't even enter
+                                         // Compilation(...) it must be sth. like `select 1 from t1 union select 2` and
+                                         // we are in the second select in the union
+                                         // stonedb8 start
+                                         // while ((join_ptr = li++) != nullptr) reversed.push_back(join_ptr);
+  // size_t size = reversed.size();
+  //  for (unsigned int i = 0; i < size; i++) {
+  for (TABLE_LIST *join_ptr : join) {
+    // join_ptr = reversed[size - i - 1];
+    // stonedb8 end
     if (join_ptr->nested_join) {
       std::vector<TabID> local_left, local_right;
       if (!AddJoins(join_ptr->nested_join->join_list, tmp_table, local_left, local_right, in_subquery, first_table,
@@ -343,7 +344,8 @@ int Query::AddJoins(mem_root_deque<TABLE_LIST *> join, /*List<TABLE_LIST> &join,
       const char *table_path = 0;
       TabID tab(0);
       if (join_ptr->is_view_or_derived()) {
-        if (!Compile(cq, join_ptr->derived_query_expression()->first_query_block(), join_ptr->derived_query_expression()->union_distinct, &tab))
+        if (!Compile(cq, join_ptr->derived_query_expression()->first_query_block(),
+                     join_ptr->derived_query_expression()->union_distinct, &tab))
           return RETURN_QUERY_TO_MYSQL_ROUTE;
         table_alias = join_ptr->alias;
       } else {
@@ -921,8 +923,11 @@ int Query::Compile(CompiledQuery *compiled_query, Query_block *selects_list, Que
   CompiledQuery *saved_cq = cq;
   cq = compiled_query;
 
-  if ((selects_list->join)&&(selects_list != selects_list->join->query_expression()->global_parameters())) {  // only in case of unions this is set
-    SetLimit(selects_list->join->query_expression()->global_parameters(), 0, global_offset_value, (int64_t &)global_limit_value);
+  if ((selects_list->join) &&
+      (selects_list !=
+       selects_list->join->query_expression()->global_parameters())) {  // only in case of unions this is set
+    SetLimit(selects_list->join->query_expression()->global_parameters(), 0, global_offset_value,
+             (int64_t &)global_limit_value);
     global_order = &(selects_list->join->query_expression()->global_parameters()->order_list);
   }
 
@@ -930,44 +935,41 @@ int Query::Compile(CompiledQuery *compiled_query, Query_block *selects_list, Que
     int64_t limit_value = -1;
     int64_t offset_value = -1;
 
-		
-    if (!sl->join)
-		{
-// stonedb8 start
+    if (!sl->join) {
+      // stonedb8 start
       TIANMU_LOG(LogCtl_Level::ERROR, "sl->join is nil!!!!");
 
-//            sl->add_active_options(SELECT_NO_UNLOCK);
-//            JOIN *join = new JOIN(sl->master_unit()->thd, sl);
-//
-//            if (!join) {
-//
-//                sl->cleanup(0);
-//                return true;
-//            }
-//            sl->set_join(join);
-// stonedb8 end
-     }
-        
-        if (!JudgeErrors(sl))
-            return RETURN_QUERY_TO_MYSQL_ROUTE;
-        SetLimit(sl, sl == selects_list ? 0 : sl->join->query_expression()->global_parameters(), offset_value, limit_value);
+      //            sl->add_active_options(SELECT_NO_UNLOCK);
+      //            JOIN *join = new JOIN(sl->master_unit()->thd, sl);
+      //
+      //            if (!join) {
+      //
+      //                sl->cleanup(0);
+      //                return true;
+      //            }
+      //            sl->set_join(join);
+      // stonedb8 end
+    }
 
-        // stonedb8
-        //List<Item> *fields = &sl->fields_list; //mem_root_deque<Item *> *fields = sl->get_fields_list();
+    if (!JudgeErrors(sl)) return RETURN_QUERY_TO_MYSQL_ROUTE;
+    SetLimit(sl, sl == selects_list ? 0 : sl->join->query_expression()->global_parameters(), offset_value, limit_value);
 
-        Item *      conds = sl->where_cond();
-        ORDER *     order = sl->order_list.first;
+    // stonedb8
+    // List<Item> *fields = &sl->fields_list; //mem_root_deque<Item *> *fields = sl->get_fields_list();
+
+    Item *conds = sl->where_cond();
+    ORDER *order = sl->order_list.first;
 
     // if (order) global_order = 0;   //we want to zero global order (which
     // seems to be always present) if we find a local order by clause
     //  The above is not necessary since global_order is set only in case of
     //  real UNIONs
 
-        ORDER *           group = sl->group_list.first;
-        Item *            having = sl->having_cond();
-        // stonedb8 start fix List<Item> to mem_root_deque<Item *> #49
-        //List<TABLE_LIST> *join_list = sl->join_list;
-        bool              zero_result = sl->join->zero_result_cause != NULL;
+    ORDER *group = sl->group_list.first;
+    Item *having = sl->having_cond();
+    // stonedb8 start fix List<Item> to mem_root_deque<Item *> #49
+    // List<TABLE_LIST> *join_list = sl->join_list;
+    bool zero_result = sl->join->zero_result_cause != NULL;
 
     Item *field_for_subselect;
     Item *cond_to_reinsert = NULL;
@@ -1004,8 +1006,8 @@ int Query::Compile(CompiledQuery *compiled_query, Query_block *selects_list, Que
       std::vector<TabID> left_tables, right_tables;
       bool first_table = true;
       // stonedb8
-      if (!AddJoins(*sl->join_list, tmp_table, left_tables, right_tables, (res_tab != NULL && res_tab->n != 0), first_table,
-                    for_subq_in_where))
+      if (!AddJoins(*sl->join_list, tmp_table, left_tables, right_tables, (res_tab != NULL && res_tab->n != 0),
+                    first_table, for_subq_in_where))
         throw CompilationError();
 
       // stonedb8 start
@@ -1038,7 +1040,7 @@ int Query::Compile(CompiledQuery *compiled_query, Query_block *selects_list, Que
       // called recursively)
       cq = saved_cq;
       if (cond_to_reinsert && list_to_reinsert) list_to_reinsert->push_back(cond_to_reinsert);
-	  //sl->cleanup(0); // stonedb8
+      // sl->cleanup(0); // stonedb8
       return RETURN_QUERY_TO_MYSQL_ROUTE;
     }
 
@@ -1048,7 +1050,7 @@ int Query::Compile(CompiledQuery *compiled_query, Query_block *selects_list, Que
     if (sl == selects_list) {
       prev_result = tmp_table;
       if (global_order && !selects_list->next_query_block()) {  // trivial union with one select and
-                                                           // ext. order by
+                                                                // ext. order by
         tmp_table = TabID();
         cq->Union(prev_result, prev_result, tmp_table, true);
       }
@@ -1056,7 +1058,7 @@ int Query::Compile(CompiledQuery *compiled_query, Query_block *selects_list, Que
       cq->Union(prev_result, prev_result, tmp_table, union_all);
     if (sl == last_distinct) union_all = true;
     if (cond_to_reinsert && list_to_reinsert) list_to_reinsert->push_back(cond_to_reinsert);
-	//sl->cleanup(0); // stonedb8
+    // sl->cleanup(0); // stonedb8
   }
 
   cq->BuildTableIDStepsMap();

--- a/storage/tianmu/core/rc_attr.cpp
+++ b/storage/tianmu/core/rc_attr.cpp
@@ -323,11 +323,14 @@ void RCAttr::PostCommit() {
 
     ha_rcengine_->DeferRemove(Path() / common::COL_VERSION_DIR / m_version.ToString(), m_tid);
     if (m_share->has_filter_bloom)
-      ha_rcengine_->DeferRemove(Path() / common::COL_FILTER_DIR / common::COL_FILTER_BLOOM_DIR / m_version.ToString(), m_tid);
+      ha_rcengine_->DeferRemove(Path() / common::COL_FILTER_DIR / common::COL_FILTER_BLOOM_DIR / m_version.ToString(),
+                                m_tid);
     if (m_share->has_filter_cmap)
-      ha_rcengine_->DeferRemove(Path() / common::COL_FILTER_DIR / common::COL_FILTER_CMAP_DIR / m_version.ToString(), m_tid);
+      ha_rcengine_->DeferRemove(Path() / common::COL_FILTER_DIR / common::COL_FILTER_CMAP_DIR / m_version.ToString(),
+                                m_tid);
     if (m_share->has_filter_hist)
-      ha_rcengine_->DeferRemove(Path() / common::COL_FILTER_DIR / common::COL_FILTER_HIST_DIR / m_version.ToString(), m_tid);
+      ha_rcengine_->DeferRemove(Path() / common::COL_FILTER_DIR / common::COL_FILTER_HIST_DIR / m_version.ToString(),
+                                m_tid);
 
     m_version = m_tx->GetID();
   }

--- a/storage/tianmu/core/rc_attr.h
+++ b/storage/tianmu/core/rc_attr.h
@@ -294,7 +294,8 @@ class RCAttr final : public mm::TraceableObject, public PhysicalColumn, public P
   void LoadData(loader::ValueCache *nvs, Transaction *conn_info = NULL);
   void LoadPackInfo(Transaction *trans_ = current_txn_);
   void LoadProcessedData([[maybe_unused]] std::unique_ptr<system::Stream> &s,
-                         [[maybe_unused]] size_t no_rows){/* TODO */}
+                         [[maybe_unused]] size_t no_rows) { /* TODO */
+  }
   void PreparePackForLoad();
 
   bool SaveVersion();  // return true iff there was any change

--- a/storage/tianmu/core/rc_mem_table.cpp
+++ b/storage/tianmu/core/rc_mem_table.cpp
@@ -81,7 +81,7 @@ std::shared_ptr<RCMemTable> RCMemTable::CreateMemTable(std::shared_ptr<TableShar
   tb_mem = std::make_shared<RCMemTable>(normalized_name, mem_id, cf_id);
   ha_kvstore_->KVWriteMemTableMeta(tb_mem);
   TIANMU_LOG(LogCtl_Level::INFO, "Create RowStore: %s, CF ID: %d, RowStore ID: %u", normalized_name.c_str(), cf_id,
-              mem_id);
+             mem_id);
 
   return tb_mem;
 }
@@ -110,7 +110,7 @@ common::ErrorCode RCMemTable::DropMemTable(std::string table_name) {
   if (!tb_mem) return common::ErrorCode::SUCCESS;
 
   TIANMU_LOG(LogCtl_Level::INFO, "Dropping RowStore: %s, CF ID: %d, RowStore ID: %u", normalized_name.c_str(),
-              tb_mem->GetCFHandle()->GetID(), tb_mem->GetMemID());
+             tb_mem->GetCFHandle()->GetID(), tb_mem->GetMemID());
   return ha_kvstore_->KVDelMemTableMeta(normalized_name);
 }
 

--- a/storage/tianmu/core/rcattr_exeq_rs.cpp
+++ b/storage/tianmu/core/rcattr_exeq_rs.cpp
@@ -192,7 +192,8 @@ common::RSValue RCAttr::RoughCheck(int pack, Descriptor &d, bool additional_null
       }
 
       // add bloom filter for in/not in
-      if (res == common::RSValue::RS_SOME && (mvc->IsConst()) && (mvc->NumOfValues(mit) > 0 && mvc->NumOfValues(mit) < 64)) {
+      if (res == common::RSValue::RS_SOME && (mvc->IsConst()) &&
+          (mvc->NumOfValues(mit) > 0 && mvc->NumOfValues(mit) < 64)) {
         if (auto sp = GetFilter_Bloom()) {
           res = common::RSValue::RS_NONE;
           for (vcolumn::MultiValColumn::Iterator it = mvc->begin(mit), end = mvc->end(mit);

--- a/storage/tianmu/core/rcattr_exqp.cpp
+++ b/storage/tianmu/core/rcattr_exqp.cpp
@@ -145,7 +145,7 @@ common::ErrorCode RCAttr::EvaluateOnIndex_BetweenInt(MIUpdatingIterator &mit, in
         ++iter;
       } else {
         TIANMU_LOG(LogCtl_Level::ERROR, "GetCurKV valid! col:[%u]=%I64d, Path:%s", ColId(), pv1,
-                    m_share->owner->Path().data());
+                   m_share->owner->Path().data());
         break;
       }
     }
@@ -207,7 +207,7 @@ common::ErrorCode RCAttr::EvaluateOnIndex_BetweenString(MIUpdatingIterator &mit,
         ++iter;
       } else {
         TIANMU_LOG(LogCtl_Level::ERROR, "GetCurKV valid! col:[%u]=%s, Path:%s", ColId(), pv1.ToString().data(),
-                    m_share->owner->Path().data());
+                   m_share->owner->Path().data());
         break;
       }
     }
@@ -271,7 +271,7 @@ common::ErrorCode RCAttr::EvaluateOnIndex_BetweenString_UTF(MIUpdatingIterator &
         ++iter;
       } else {
         TIANMU_LOG(LogCtl_Level::ERROR, "GetCurKV valid! col:[%u]=%s, Path:%s", ColId(), pv1.ToString().data(),
-                    m_share->owner->Path().data());
+                   m_share->owner->Path().data());
         break;
       }
     }

--- a/storage/tianmu/core/sorter3.cpp
+++ b/storage/tianmu/core/sorter3.cpp
@@ -482,10 +482,10 @@ bool SorterLimit::PutValue(Sorter3 *s) {
       std::memcpy(buf + no_obj * total_bytes, buf1, tmp_noobj * total_bytes);
       no_obj += tmp_noobj;
       TIANMU_LOG(LogCtl_Level::DEBUG, "PutValue: no_obj %ld, tmp_noobj %ld, total_bytes %ld buf %s", no_obj, tmp_noobj,
-                  total_bytes, buf);
+                 total_bytes, buf);
     } else {
       TIANMU_LOG(LogCtl_Level::ERROR, "error in Putvalue, out of  boundary size %d no_obj+tmp_noobj %d", size,
-                  no_obj + tmp_noobj);
+                 no_obj + tmp_noobj);
       throw common::OutOfMemoryException("Out of boundary after merge sorters together.");
       return false;
     }

--- a/storage/tianmu/core/sorter3.h
+++ b/storage/tianmu/core/sorter3.h
@@ -32,7 +32,7 @@ namespace core {
 class Sorter3 : public mm::TraceableObject {
  public:
   Sorter3(uint _size, uint _key_bytes, uint _total_bytes)
-      : conn(current_txn_), key_bytes(_key_bytes), total_bytes(_total_bytes), size(_size){}
+      : conn(current_txn_), key_bytes(_key_bytes), total_bytes(_total_bytes), size(_size) {}
 
   static Sorter3 *CreateSorter(int64_t size, uint key_bytes, uint total_bytes, int64_t limit = -1,
                                int mem_modifier = 0);

--- a/storage/tianmu/core/sorter_wrapper.cpp
+++ b/storage/tianmu/core/sorter_wrapper.cpp
@@ -76,7 +76,7 @@ void SorterWrapper::InitOrderByVector(std::vector<int> &order_by) {
 void SorterWrapper::InitSorter(MultiIndex &mind, bool implicit_logic) {
   DimensionVector implicit_dims(mind.NumOfDimensions());  // these dimensions will be implicit
   DimensionVector one_pack_dims(mind.NumOfDimensions());  // these dimensions contain only one used pack
-                                                       // (potentially implicit)
+                                                          // (potentially implicit)
 
   // Prepare optimization guidelines
   for (int dim = 0; dim < mind.NumOfDimensions(); dim++) {
@@ -233,7 +233,7 @@ bool SorterWrapper::InitPackrow(MIIterator &mit)  // return true if the packrow 
   }
 
   TIANMU_LOG(LogCtl_Level::DEBUG, "InitPackrow: no_values_encoded %d, begin to loadpacks scol size %d ",
-              no_values_encoded, scol.size());
+             no_values_encoded, scol.size());
   // Not excluded: lock packs
   if (!ha_rcengine_->query_thread_pool.is_owner()) {
     utils::result_set<void> res;

--- a/storage/tianmu/core/temp_table.cpp
+++ b/storage/tianmu/core/temp_table.cpp
@@ -570,7 +570,8 @@ int64_t TempTable::Attr::GetMaxInt64(int pack) {
   for (int64_t i = start; i < stop; i++) {
     if (!IsNull(i)) {
       val = GetNotNullValueInt64(i);
-      if ((ATI::IsRealType(ct.GetTypeName()) && (max == common::TIANMU_BIGINT_MIN || *(double *)&val > *(double *)&max)) ||
+      if ((ATI::IsRealType(ct.GetTypeName()) &&
+           (max == common::TIANMU_BIGINT_MIN || *(double *)&val > *(double *)&max)) ||
           (!ATI::IsRealType(ct.GetTypeName()) && val > max))
         max = val;
     }
@@ -588,7 +589,8 @@ int64_t TempTable::Attr::GetMinInt64(int pack) {
   for (int64_t i = start; i < stop; i++) {
     if (!IsNull(i)) {
       val = GetNotNullValueInt64(i);
-      if ((ATI::IsRealType(ct.GetTypeName()) && (min == common::TIANMU_BIGINT_MAX || *(double *)&val < *(double *)&min)) ||
+      if ((ATI::IsRealType(ct.GetTypeName()) &&
+           (min == common::TIANMU_BIGINT_MAX || *(double *)&val < *(double *)&min)) ||
           (!ATI::IsRealType(ct.GetTypeName()) && val < min))
         min = val;
     }
@@ -1248,7 +1250,7 @@ void TempTable::Union(TempTable *t, int all) {
     return;
 
   Filter first_f(NumOfObj(), p_power), first_mask(NumOfObj(),
-                                               p_power);  // mask of objects to be added to the final result set
+                                                  p_power);  // mask of objects to be added to the final result set
   Filter sec_f(t->NumOfObj(), p_power), sec_mask(t->NumOfObj(), p_power);
   first_mask.Set();
   sec_mask.Set();
@@ -1290,8 +1292,8 @@ void TempTable::Union(TempTable *t, int all) {
       }
       input_buf = new uchar[size];
       dist_table.InitializeB(size, NumOfObj() + t->NumOfObj() / 2);  // optimization assumption: a
-                                                               // half of values in the second
-                                                               // table will be repetitions
+                                                                     // half of values in the second
+                                                                     // table will be repetitions
       MIIterator first_mit(&output_mind, p_power);
       MIIterator sec_mit(t->GetOutputMultiIndexP(), p_power);
       // check all objects from the first table
@@ -2165,7 +2167,7 @@ void TempTableForSubquery::ResetToTemplate(bool rough) {
     (*attrs[i]).buffer = orig_buf;
   }
 
-  filter = std::move(*template_filter); // shallow
+  filter = std::move(*template_filter);  // shallow
   filter_shallow_memory = true;
 
   for (int i = 0; i < no_global_virt_cols; i++)

--- a/storage/tianmu/core/temp_table.h
+++ b/storage/tianmu/core/temp_table.h
@@ -47,7 +47,7 @@ class Transaction;
 // Sepecial Instruction
 struct SI {
   std::string separator;  // group_concat separator
-  enum_order order; // stonedb8
+  enum_order order;       // stonedb8
 };
 
 //  TempTable - for storing a definition or content of a temporary table (view)
@@ -504,7 +504,7 @@ class TempTable : public JustATable {
 class TempTableForSubquery : public TempTable {
  public:
   TempTableForSubquery(JustATable *const t, int alias, Query *q)
-      : TempTable(t, alias, q), template_filter(0), is_attr_for_rough(false), rough_materialized(false){}
+      : TempTable(t, alias, q), template_filter(0), is_attr_for_rough(false), rough_materialized(false) {}
   ~TempTableForSubquery();
 
   void CreateTemplateIfNotExists();

--- a/storage/tianmu/core/temp_table_low.cpp
+++ b/storage/tianmu/core/temp_table_low.cpp
@@ -145,7 +145,7 @@ bool TempTable::OrderByAndMaterialize(std::vector<SortDescriptor> &ord, int64_t 
     sorted_table.InitSorter(*(filter.mind), false);
   if (sorted_table.GetSorter() && std::strcmp(sorted_table.GetSorter()->Name(), "Heap Sort") != 0) {
     TIANMU_LOG(LogCtl_Level::DEBUG, "Multi-thread order by is not supported for %s table.",
-                sorted_table.GetSorter()->Name());
+               sorted_table.GetSorter()->Name());
     task_num = 1;
   }
   // Put data
@@ -209,8 +209,8 @@ bool TempTable::OrderByAndMaterialize(std::vector<SortDescriptor> &ord, int64_t 
 
     utils::result_set<size_t> res;
     for (int i = 0; i < task_num; i++)
-      res.insert(ha_rcengine_->query_thread_pool.add_task(&TempTable::TaskPutValueInST, this, &taskIterator[i], current_txn_,
-                                                   &subsorted_table[i]));
+      res.insert(ha_rcengine_->query_thread_pool.add_task(&TempTable::TaskPutValueInST, this, &taskIterator[i],
+                                                          current_txn_, &subsorted_table[i]));
     if (filter.mind->m_conn->Killed()) throw common::KilledException("Query killed by user");
 
     for (int i = 0; i < task_num; ++i) {
@@ -220,9 +220,9 @@ bool TempTable::OrderByAndMaterialize(std::vector<SortDescriptor> &ord, int64_t 
   }
 
   TIANMU_LOG(LogCtl_Level::DEBUG,
-              "SortTable preparation done. row num %d, offset %d, limit %d, "
-              "task_num %d",
-              local_row, offset, limit, task_num);
+             "SortTable preparation done. row num %d, offset %d, limit %d, "
+             "task_num %d",
+             local_row, offset, limit, task_num);
 
   // Create output
   for (uint i = 0; i < NumOfAttrs(); i++) {
@@ -283,7 +283,7 @@ bool TempTable::OrderByAndMaterialize(std::vector<SortDescriptor> &ord, int64_t 
       global_row++;
     } while (valid && global_row < limit + offset &&
              !(sender && local_row >= tianmu_sysvar_result_sender_rows));  // a limit for
-                                                                            // streaming buffer
+                                                                           // streaming buffer
     // Note: what about SetNumOfMaterialized()? Only no_obj is set now.
     if (sender) {
       TempTable::RecordIterator iter = begin();
@@ -394,7 +394,7 @@ void TempTable::FillMaterializedBuffers(int64_t local_limit, int64_t local_offse
     for (uint i = 1; i < attrs.size(); i++) {
       if (!skip_parafilloutput[i]) {
         res.insert(ha_rcengine_->query_thread_pool.add_task(&TempTable::FillbufferTask, this, attrs[i], current_txn_,
-                                                     &page_start, start_row, page_end));
+                                                            &page_start, start_row, page_end));
       }
     }
     res.get_all_with_except();

--- a/storage/tianmu/core/transaction.cpp
+++ b/storage/tianmu/core/transaction.cpp
@@ -24,7 +24,7 @@
 #include "util/fs.h"
 
 namespace Tianmu {
-//current transaction, thread local var.
+// current transaction, thread local var.
 thread_local core::Transaction *current_txn_;
 
 namespace core {

--- a/storage/tianmu/core/transaction.h
+++ b/storage/tianmu/core/transaction.h
@@ -57,7 +57,7 @@ class Transaction final {
   void SetDebugLevel(int dbg_lev) { debug_level = dbg_lev; }
   int DebugLevel() { return debug_level; }
   void SetSessionTrace(int trace) { session_trace = trace; }
-  bool Explain() { return (thd ? thd->lex->is_explain() : false); } // stonedb8
+  bool Explain() { return (thd ? thd->lex->is_explain() : false); }  // stonedb8
   std::string GetExplainMsg() { return explain_msg; }
   void SetExplainMsg(const std::string &msg) { explain_msg = msg; }
   bool m_explicit_lock_tables = false;

--- a/storage/tianmu/exporter/export2file.cpp
+++ b/storage/tianmu/exporter/export2file.cpp
@@ -24,7 +24,7 @@ namespace Tianmu {
 namespace exporter {
 
 select_tianmu_export::select_tianmu_export(Query_result_export *se)
-: Query_result_export(se->get_sql_exchange()), se(se), prepared(false) {}
+    : Query_result_export(se->get_sql_exchange()), se(se), prepared(false) {}
 
 int select_tianmu_export::prepare(List<Item> &list, Query_expression *u) {
   bool blob_flag = 0;
@@ -39,18 +39,17 @@ int select_tianmu_export::prepare(List<Item> &list, Query_expression *u) {
       }
     }
   }
-      field_term_length = exchange->field.field_term->length();
-    if (!exchange->line.line_term->length())
-        exchange->line.line_term = exchange->field.field_term;  // Use this if it exists
-    field_sep_char = (exchange->field.enclosed->length() ? (*exchange->field.enclosed)[0]
-                                                   : field_term_length ? (*exchange->field.field_term)[0] : INT_MAX);
-    escape_char = (exchange->field.escaped->length() ? (*exchange->field.escaped)[0] : -1);
-    line_sep_char = (exchange->line.line_term->length() ? (*exchange->line.line_term)[0] : INT_MAX);
-  	if (!field_term_length)
-		exchange->field.opt_enclosed = 0;
-    if (!exchange->field.enclosed->length())
-        exchange->field.opt_enclosed = 1;  // A little quicker loop
-    fixed_row_size = (!field_term_length && !exchange->field.enclosed->length() && !blob_flag);
+  field_term_length = exchange->field.field_term->length();
+  if (!exchange->line.line_term->length())
+    exchange->line.line_term = exchange->field.field_term;  // Use this if it exists
+  field_sep_char =
+      (exchange->field.enclosed->length() ? (*exchange->field.enclosed)[0]
+                                          : field_term_length ? (*exchange->field.field_term)[0] : INT_MAX);
+  escape_char = (exchange->field.escaped->length() ? (*exchange->field.escaped)[0] : -1);
+  line_sep_char = (exchange->line.line_term->length() ? (*exchange->line.line_term)[0] : INT_MAX);
+  if (!field_term_length) exchange->field.opt_enclosed = 0;
+  if (!exchange->field.enclosed->length()) exchange->field.opt_enclosed = 1;  // A little quicker loop
+  fixed_row_size = (!field_term_length && !exchange->field.enclosed->length() && !blob_flag);
 
   prepared = true;
   return 0;

--- a/storage/tianmu/exporter/export2file.h
+++ b/storage/tianmu/exporter/export2file.h
@@ -28,13 +28,13 @@ class select_tianmu_export : public Query_result_export {
  public:
   // select_tianmu_export(sql_exchange *ex);
   select_tianmu_export(Query_result_export *se);
-  ~select_tianmu_export(){}
+  ~select_tianmu_export() {}
   int prepare(List<Item> &list, Query_expression *u) /*override*/;
   void SetRowCount(ha_rows x);
   void SendOk(THD *thd);
   sql_exchange *SqlExchange();
   bool IsPrepared() const { return prepared; }
-  bool send_data(THD *thd, mem_root_deque<Item *> &items) /*override*/; // stonedb8
+  bool send_data(THD *thd, mem_root_deque<Item *> &items) /*override*/;  // stonedb8
 
  private:
   Query_result_export *se;

--- a/storage/tianmu/handler/ha_rcengine.cpp
+++ b/storage/tianmu/handler/ha_rcengine.cpp
@@ -72,7 +72,7 @@ bool TIANMU_SetStatementAllowed(THD *thd, LEX *lex) {
 }
 
 int TIANMU_HandleSelect(THD *thd, LEX *lex, Query_result *&result, ulong setup_tables_done_option, int &res,
-                        int &optimize_after_tianmu, int &tianmu_free_join, int with_insert ) {
+                        int &optimize_after_tianmu, int &tianmu_free_join, int with_insert) {
   int ret = RCBASE_QUERY_ROUTE;
   try {
     // handle_select_ret is introduced here because in case of some exceptions

--- a/storage/tianmu/handler/ha_rcengine.h
+++ b/storage/tianmu/handler/ha_rcengine.h
@@ -23,12 +23,12 @@ namespace Tianmu {
 namespace dbhandler {
 
 void TIANMU_UpdateAndStoreColumnComment(TABLE *table, int field_id, Field *source_field, int source_field_id,
-                                     CHARSET_INFO *cs);
+                                        CHARSET_INFO *cs);
 
 bool TIANMU_SetStatementAllowed(THD *thd, LEX *lex);
 
 int TIANMU_HandleSelect(THD *thd, LEX *lex, Query_result *&result_output, ulong setup_tables_done_option, int &res,
-                     int &optimize_after_tianmu, int &tianmu_free_join, int with_insert = false);
+                        int &optimize_after_tianmu, int &tianmu_free_join, int with_insert = false);
 bool tianmu_load(THD *thd, sql_exchange *ex, TABLE_LIST *table_list, void *arg);
 
 }  // namespace dbhandler

--- a/storage/tianmu/handler/tianmu_handler.h
+++ b/storage/tianmu/handler/tianmu_handler.h
@@ -35,13 +35,14 @@ class TianmuHandler final : public handler {
    Get the row type from the storage engine.  If this method returns
    ROW_TYPE_NOT_USED, the information in HA_CREATE_INFO should be used.
    */
-  //enum row_type get_row_type() const override { return ROW_TYPE_COMPRESSED; }   // stonedb8  get_row_type() is deleted
+  // enum row_type get_row_type() const override { return ROW_TYPE_COMPRESSED; }   // stonedb8  get_row_type() is
+  // deleted
   /*
    The name of the index type that will be used for display
    don't implement this method unless you really have indexes
    */
-  // const char *index_type([[maybe_unused]] uint inx) override { return "LSMTREE"; }  // stonedb8 index_type() is deleted
-  // const char **bas_ext() const override; // stonedb8 bas_ext() is deleted
+  // const char *index_type([[maybe_unused]] uint inx) override { return "LSMTREE"; }  // stonedb8 index_type() is
+  // deleted const char **bas_ext() const override; // stonedb8 bas_ext() is deleted
   /*
    This is a list of flags that says what the storage engine
    implements. The current table flags are documented in
@@ -94,7 +95,7 @@ class TianmuHandler final : public handler {
   }
   int open(const char *name, int mode, uint test_if_locked,
            const dd::Table *table_def) override;  // stonedb8
-  int close() override;                    // required
+  int close() override;                           // required
 
   int write_row(uchar *buf __attribute__((unused))) override;
   int update_row(const uchar *old_data, uchar *new_data) override;
@@ -128,21 +129,20 @@ class TianmuHandler final : public handler {
   int delete_all_rows() override;
   ha_rows records_in_range(uint inx, key_range *min_key, key_range *max_key) override;
   int delete_table(const char *from, const dd::Table *table_def) override;  // stonedb8
-  int rename_table(const char *from, const char *to, const dd::Table *from_table_def, dd::Table *to_table_def) override; // stonedb8
+  int rename_table(const char *from, const char *to, const dd::Table *from_table_def,
+                   dd::Table *to_table_def) override;                                                   // stonedb8
   int create(const char *name, TABLE *table_arg, HA_CREATE_INFO *info, dd::Table *table_def) override;  // stonedb8
-  int truncate(dd::Table *table_def) override;  // stonedb8
+  int truncate(dd::Table *table_def) override;                                                          // stonedb8
 
   enum_alter_inplace_result check_if_supported_inplace_alter(TABLE *altered_table,
                                                              Alter_inplace_info *ha_alter_info) override;
-  bool inplace_alter_table(TABLE *altered_table [[maybe_unused]],
-                                   Alter_inplace_info *ha_alter_info
-                                   [[maybe_unused]],
-                                   const dd::Table *old_table_def
-                                   [[maybe_unused]],
-                                   dd::Table *new_table_def [[maybe_unused]]) override; // stonedb8
-  bool commit_inplace_alter_table(TABLE *altered_table [[maybe_unused]], Alter_inplace_info *ha_alter_info [[maybe_unused]],
-                                          bool commit [[maybe_unused]], const dd::Table *old_table_def [[maybe_unused]],
-                                          dd::Table *new_table_def [[maybe_unused]]) override;  // stonedb8
+  bool inplace_alter_table(TABLE *altered_table [[maybe_unused]], Alter_inplace_info *ha_alter_info [[maybe_unused]],
+                           const dd::Table *old_table_def [[maybe_unused]],
+                           dd::Table *new_table_def [[maybe_unused]]) override;  // stonedb8
+  bool commit_inplace_alter_table(TABLE *altered_table [[maybe_unused]],
+                                  Alter_inplace_info *ha_alter_info [[maybe_unused]], bool commit [[maybe_unused]],
+                                  const dd::Table *old_table_def [[maybe_unused]],
+                                  dd::Table *new_table_def [[maybe_unused]]) override;  // stonedb8
 
   THR_LOCK_DATA **store_lock(THD *thd, THR_LOCK_DATA **to,
                              enum thr_lock_type lock_type) override;  // required

--- a/storage/tianmu/handler/tianmu_handler_com.cpp
+++ b/storage/tianmu/handler/tianmu_handler_com.cpp
@@ -20,11 +20,11 @@
 #include <boost/algorithm/string.hpp>
 #include <boost/lexical_cast.hpp>
 
+#include "binlog.h"
 #include "core/transaction.h"
 #include "handler/tianmu_handler.h"
 #include "mm/initializer.h"
 #include "system/file_out.h"
-#include "binlog.h"
 
 handlerton *rcbase_hton;
 
@@ -42,10 +42,10 @@ namespace dbhandler {
  */
 bool tianmu_bootstrap = 0;
 
-char *strmov_str(char *dst, const char *src)
-{
-  while ((*dst++ = *src++)) ;
-  return dst-1;
+char *strmov_str(char *dst, const char *src) {
+  while ((*dst++ = *src++))
+    ;
+  return dst - 1;
 }
 
 static int rcbase_done_func([[maybe_unused]] void *p) {
@@ -63,7 +63,8 @@ static int rcbase_done_func([[maybe_unused]] void *p) {
   DBUG_RETURN(0);
 }
 
-handler *rcbase_create_handler(handlerton *hton, TABLE_SHARE *table, bool partitioned, MEM_ROOT *mem_root) {  // stonedb8 TODO
+handler *rcbase_create_handler(handlerton *hton, TABLE_SHARE *table, bool partitioned,
+                               MEM_ROOT *mem_root) {  // stonedb8 TODO
   return new (mem_root) TianmuHandler(hton, table);
 }
 
@@ -122,7 +123,7 @@ int rcbase_commit([[maybe_unused]] handlerton *hton, THD *thd, bool all) {
   int ret = 1;
   std::string error_message;
 
-  if (!( thd->is_error() || thd->killed || thd->transaction_rollback_request)) {
+  if (!(thd->is_error() || thd->killed || thd->transaction_rollback_request)) {
     try {
       ha_rcengine_->CommitTx(thd, all);
       ret = 0;
@@ -218,34 +219,34 @@ int rcbase_init_func(void *p) {
     hent = gethostbyname(glob_hostname);
     if (hent) strmov_str(global_hostIP_, inet_ntoa(*(struct in_addr *)(hent->h_addr_list[0])));
     snprintf(global_serverinfo_, sizeof(global_serverinfo_), "\tServerIp:%s\tServerHostName:%s\tServerPort:%d",
-                global_hostIP_, glob_hostname, mysqld_port);
+             global_hostIP_, glob_hostname, mysqld_port);
     ha_kvstore_ = new index::KVStore();
     ha_kvstore_->Init();
     ha_rcengine_ = new core::Engine();
     ret = ha_rcengine_->Init(rcbase_hton->slot);  // stonedb8
     {
       TIANMU_LOG(LogCtl_Level::INFO,
-                  "\n"
-                  "------------------------------------------------------------"
-                  "----------------------------------"
-                  "-------------\n"
-                  "    ######  ########  #######  ##     ## ######## ######   "
-                  "######   \n"
-                  "   ##    ##    ##    ##     ## ####   ## ##       ##    ## "
-                  "##    ## \n"
-                  "   ##          ##    ##     ## ## ##  ## ##       ##    ## "
-                  "##    ## \n"
-                  "    ######     ##    ##     ## ##  ## ## ######   ##    ## "
-                  "######## \n"
-                  "         ##    ##    ##     ## ##   #### ##       ##    ## "
-                  "##    ## \n"
-                  "   ##    ##    ##    ##     ## ##    ### ##       ##    ## "
-                  "##    ## \n"
-                  "    ######     ##     #######  ##     ## ######## ######   "
-                  "######   \n"
-                  "------------------------------------------------------------"
-                  "----------------------------------"
-                  "-------------\n");
+                 "\n"
+                 "------------------------------------------------------------"
+                 "----------------------------------"
+                 "-------------\n"
+                 "    ######  ########  #######  ##     ## ######## ######   "
+                 "######   \n"
+                 "   ##    ##    ##    ##     ## ####   ## ##       ##    ## "
+                 "##    ## \n"
+                 "   ##          ##    ##     ## ## ##  ## ##       ##    ## "
+                 "##    ## \n"
+                 "    ######     ##    ##     ## ##  ## ## ######   ##    ## "
+                 "######## \n"
+                 "         ##    ##    ##     ## ##   #### ##       ##    ## "
+                 "##    ## \n"
+                 "   ##    ##    ##    ##     ## ##    ### ##       ##    ## "
+                 "##    ## \n"
+                 "    ######     ##     #######  ##     ## ######## ######   "
+                 "######   \n"
+                 "------------------------------------------------------------"
+                 "----------------------------------"
+                 "-------------\n");
     }
 
   } catch (std::exception &e) {
@@ -370,7 +371,8 @@ int get_UpdatePerMinute_StatusVar([[maybe_unused]] MYSQL_THD thd, SHOW_VAR *outv
 
 char masteslave_info[8192];
 
-SHOW_VAR tianmu_masterslave_dump[] = {{"info", masteslave_info, SHOW_CHAR, SHOW_SCOPE_UNDEF}, {NullS, NullS, SHOW_LONG, SHOW_SCOPE_UNDEF}};
+SHOW_VAR tianmu_masterslave_dump[] = {{"info", masteslave_info, SHOW_CHAR, SHOW_SCOPE_UNDEF},
+                                      {NullS, NullS, SHOW_LONG, SHOW_SCOPE_UNDEF}};
 
 //  showtype
 //  =====================
@@ -379,7 +381,7 @@ SHOW_VAR tianmu_masterslave_dump[] = {{"info", masteslave_info, SHOW_CHAR, SHOW_
 //  SHOW_ARRAY, SHOW_FUNC, SHOW_DOUBLE
 
 int tianmu_throw_error_func([[maybe_unused]] MYSQL_THD thd, [[maybe_unused]] struct SYS_VAR *var,
-                             [[maybe_unused]] void *save, struct st_mysql_value *value) {
+                            [[maybe_unused]] void *save, struct st_mysql_value *value) {
   int buffer_length = 512;
   char buff[512] = {0};
 
@@ -409,24 +411,24 @@ void controlquerylog_update(MYSQL_THD thd, struct SYS_VAR *var, void *var_ptr, c
 void start_async_update(MYSQL_THD thd, struct SYS_VAR *var, void *var_ptr, const void *save);
 extern void async_join_update(MYSQL_THD thd, struct SYS_VAR *var, void *var_ptr, const void *save);
 
-#define STATUS_FUNCTION(name, showtype, member)                                                             \
+#define STATUS_FUNCTION(name, showtype, member)                                                    \
   int get_##name##_StatusVar([[maybe_unused]] MYSQL_THD thd, struct SHOW_VAR *outvar, char *tmp) { \
-    *((int64_t *)tmp) = ha_rcengine_->cache.member();                                                              \
-    outvar->value = tmp;                                                                                    \
-    outvar->type = showtype;                                                                                \
-    return 0;                                                                                               \
+    *((int64_t *)tmp) = ha_rcengine_->cache.member();                                              \
+    outvar->value = tmp;                                                                           \
+    outvar->type = showtype;                                                                       \
+    return 0;                                                                                      \
   }
 
-#define MM_STATUS_FUNCTION(name, showtype, member)                                                          \
+#define MM_STATUS_FUNCTION(name, showtype, member)                                                 \
   int get_##name##_StatusVar([[maybe_unused]] MYSQL_THD thd, struct SHOW_VAR *outvar, char *tmp) { \
-    *((int64_t *)tmp) = mm::TraceableObject::Instance()->member();                                          \
-    outvar->value = tmp;                                                                                    \
-    outvar->type = showtype;                                                                                \
-    return 0;                                                                                               \
+    *((int64_t *)tmp) = mm::TraceableObject::Instance()->member();                                 \
+    outvar->value = tmp;                                                                           \
+    outvar->type = showtype;                                                                       \
+    return 0;                                                                                      \
   }
 
 #define STATUS_MEMBER(name, label) \
-  { "Tianmu_" #label, (char *)get_##name##_StatusVar, SHOW_FUNC, SHOW_SCOPE_UNDEF}
+  { "Tianmu_" #label, (char *)get_##name##_StatusVar, SHOW_FUNC, SHOW_SCOPE_UNDEF }
 
 STATUS_FUNCTION(gdchits, SHOW_LONGLONG, getCacheHits)
 STATUS_FUNCTION(gdcmisses, SHOW_LONGLONG, getCacheMisses)
@@ -523,13 +525,13 @@ static MYSQL_SYSVAR_BOOL(ini_usemysqlimportexportdefaults, tianmu_sysvar_usemysq
                          PLUGIN_VAR_READONLY, "-", NULL, NULL, false);
 static MYSQL_SYSVAR_INT(ini_threadpoolsize, tianmu_sysvar_threadpoolsize, PLUGIN_VAR_READONLY, "-", NULL, NULL, 1, 0,
                         1000000, 0);
-static MYSQL_SYSVAR_INT(ini_cachesizethreshold, tianmu_sysvar_cachesizethreshold, PLUGIN_VAR_INT, "-", NULL, NULL, 4,
-                        0, 1024, 0);
-static MYSQL_SYSVAR_INT(ini_cachereleasethreshold, tianmu_sysvar_cachereleasethreshold, PLUGIN_VAR_INT, "-", NULL,
-                        NULL, 100, 0, 100000, 0);
+static MYSQL_SYSVAR_INT(ini_cachesizethreshold, tianmu_sysvar_cachesizethreshold, PLUGIN_VAR_INT, "-", NULL, NULL, 4, 0,
+                        1024, 0);
+static MYSQL_SYSVAR_INT(ini_cachereleasethreshold, tianmu_sysvar_cachereleasethreshold, PLUGIN_VAR_INT, "-", NULL, NULL,
+                        100, 0, 100000, 0);
 static MYSQL_SYSVAR_BOOL(insert_delayed, tianmu_sysvar_insert_delayed, PLUGIN_VAR_READONLY, "-", NULL, NULL, true);
-static MYSQL_SYSVAR_INT(insert_cntthreshold, tianmu_sysvar_insert_cntthreshold, PLUGIN_VAR_READONLY, "-", NULL, NULL,
-                        2, 0, 1000, 0);
+static MYSQL_SYSVAR_INT(insert_cntthreshold, tianmu_sysvar_insert_cntthreshold, PLUGIN_VAR_READONLY, "-", NULL, NULL, 2,
+                        0, 1000, 0);
 static MYSQL_SYSVAR_INT(insert_numthreshold, tianmu_sysvar_insert_numthreshold, PLUGIN_VAR_READONLY, "-", NULL, NULL,
                         10000, 0, 100000, 0);
 static MYSQL_SYSVAR_INT(insert_wait_ms, tianmu_sysvar_insert_wait_ms, PLUGIN_VAR_READONLY, "-", NULL, NULL, 100, 10,
@@ -538,8 +540,7 @@ static MYSQL_SYSVAR_INT(insert_wait_time, tianmu_sysvar_insert_wait_time, PLUGIN
                         600000, 0);
 static MYSQL_SYSVAR_INT(insert_max_buffered, tianmu_sysvar_insert_max_buffered, PLUGIN_VAR_READONLY, "-", NULL, NULL,
                         65536, 0, 10000000, 0);
-static MYSQL_SYSVAR_BOOL(compensation_start, tianmu_sysvar_compensation_start, PLUGIN_VAR_BOOL, "-", NULL, NULL,
-                         false);
+static MYSQL_SYSVAR_BOOL(compensation_start, tianmu_sysvar_compensation_start, PLUGIN_VAR_BOOL, "-", NULL, NULL, false);
 static MYSQL_SYSVAR_STR(hugefiledir, tianmu_sysvar_hugefiledir, PLUGIN_VAR_READONLY, "-", NULL, NULL, "");
 static MYSQL_SYSVAR_INT(cachinglevel, tianmu_sysvar_cachinglevel, PLUGIN_VAR_READONLY, "-", NULL, NULL, 1, 0, 512, 0);
 static MYSQL_SYSVAR_STR(mm_policy, tianmu_sysvar_mm_policy, PLUGIN_VAR_READONLY, "-", NULL, NULL, "");
@@ -551,13 +552,12 @@ static MYSQL_SYSVAR_INT(mm_largetemppool_threshold, tianmu_sysvar_mm_large_thres
                         "size threshold in MB for using large temp thread pool", NULL, NULL, 16, 0, 10240, 0);
 static MYSQL_SYSVAR_INT(sync_buffers, tianmu_sysvar_sync_buffers, PLUGIN_VAR_READONLY, "-", NULL, NULL, 0, 0, 1, 0);
 
-static MYSQL_SYSVAR_INT(query_threads, tianmu_sysvar_query_threads, PLUGIN_VAR_READONLY, "-", NULL, NULL, 0, 0, 100,
-                        0);
+static MYSQL_SYSVAR_INT(query_threads, tianmu_sysvar_query_threads, PLUGIN_VAR_READONLY, "-", NULL, NULL, 0, 0, 100, 0);
 static MYSQL_SYSVAR_INT(load_threads, tianmu_sysvar_load_threads, PLUGIN_VAR_READONLY, "-", NULL, NULL, 0, 0, 100, 0);
-static MYSQL_SYSVAR_INT(bg_load_threads, tianmu_sysvar_bg_load_threads, PLUGIN_VAR_READONLY, "-", NULL, NULL, 0, 0,
-                        100, 0);
-static MYSQL_SYSVAR_INT(insert_buffer_size, tianmu_sysvar_insert_buffer_size, PLUGIN_VAR_READONLY, "-", NULL, NULL,
-                        512, 512, 10000, 0);
+static MYSQL_SYSVAR_INT(bg_load_threads, tianmu_sysvar_bg_load_threads, PLUGIN_VAR_READONLY, "-", NULL, NULL, 0, 0, 100,
+                        0);
+static MYSQL_SYSVAR_INT(insert_buffer_size, tianmu_sysvar_insert_buffer_size, PLUGIN_VAR_READONLY, "-", NULL, NULL, 512,
+                        512, 10000, 0);
 
 static MYSQL_THDVAR_INT(session_debug_level, PLUGIN_VAR_INT, "session debug level", NULL, debug_update, 3, 0, 5, 0);
 static MYSQL_THDVAR_INT(control_trace, PLUGIN_VAR_OPCMDARG, "ini controltrace", NULL, trace_update, 0, 0, 100, 0);
@@ -639,8 +639,8 @@ void trace_update(MYSQL_THD thd, [[maybe_unused]] struct SYS_VAR *var, void *var
   }
 }
 
-void controlquerylog_update([[maybe_unused]] MYSQL_THD thd, [[maybe_unused]] struct SYS_VAR *var,
-                            void *var_ptr, const void *save) {
+void controlquerylog_update([[maybe_unused]] MYSQL_THD thd, [[maybe_unused]] struct SYS_VAR *var, void *var_ptr,
+                            const void *save) {
   *((int *)var_ptr) = *((int *)save);
   int control = *((int *)var_ptr);
   if (ha_rcengine_) {
@@ -681,63 +681,63 @@ void async_join_update([[maybe_unused]] MYSQL_THD thd, [[maybe_unused]] struct S
 
 // stonedb8
 static struct SYS_VAR *tianmu_showvars[] = {MYSQL_SYSVAR(bg_load_threads),
-                                                  MYSQL_SYSVAR(cachinglevel),
-                                                  MYSQL_SYSVAR(compensation_start),
-                                                  MYSQL_SYSVAR(control_trace),
-                                                  MYSQL_SYSVAR(data_distribution_policy),
-                                                  MYSQL_SYSVAR(disk_usage_threshold),
-                                                  MYSQL_SYSVAR(distinct_cache_size),
-                                                  MYSQL_SYSVAR(filterevaluation_speedup),
-                                                  MYSQL_SYSVAR(global_debug_level),
-                                                  MYSQL_SYSVAR(groupby_speedup),
-                                                  MYSQL_SYSVAR(hugefiledir),
-                                                  MYSQL_SYSVAR(index_cache_size),
-                                                  MYSQL_SYSVAR(index_search),
-                                                  MYSQL_SYSVAR(enable_rowstore),
-                                                  MYSQL_SYSVAR(ini_allowmysqlquerypath),
-                                                  MYSQL_SYSVAR(ini_cachefolder),
-                                                  MYSQL_SYSVAR(ini_cachereleasethreshold),
-                                                  MYSQL_SYSVAR(ini_cachesizethreshold),
-                                                  MYSQL_SYSVAR(ini_controlquerylog),
-                                                  MYSQL_SYSVAR(ini_knlevel),
-                                                  MYSQL_SYSVAR(ini_pushdown),
-                                                  MYSQL_SYSVAR(ini_servermainheapsize),
-                                                  MYSQL_SYSVAR(ini_threadpoolsize),
-                                                  MYSQL_SYSVAR(ini_usemysqlimportexportdefaults),
-                                                  MYSQL_SYSVAR(insert_buffer_size),
-                                                  MYSQL_SYSVAR(insert_cntthreshold),
-                                                  MYSQL_SYSVAR(insert_delayed),
-                                                  MYSQL_SYSVAR(insert_max_buffered),
-                                                  MYSQL_SYSVAR(insert_numthreshold),
-                                                  MYSQL_SYSVAR(insert_wait_ms),
-                                                  MYSQL_SYSVAR(insert_wait_time),
-                                                  MYSQL_SYSVAR(join_disable_switch_side),
-                                                  MYSQL_SYSVAR(enable_histogram_cmap_bloom),
-                                                  MYSQL_SYSVAR(join_parallel),
-                                                  MYSQL_SYSVAR(join_splitrows),
-                                                  MYSQL_SYSVAR(load_threads),
-                                                  MYSQL_SYSVAR(lookup_max_size),
-                                                  MYSQL_SYSVAR(max_execution_time),
-                                                  MYSQL_SYSVAR(minmax_speedup),
-                                                  MYSQL_SYSVAR(mm_hardlimit),
-                                                  MYSQL_SYSVAR(mm_largetempratio),
-                                                  MYSQL_SYSVAR(mm_largetemppool_threshold),
-                                                  MYSQL_SYSVAR(mm_policy),
-                                                  MYSQL_SYSVAR(mm_releasepolicy),
-                                                  MYSQL_SYSVAR(orderby_speedup),
-                                                  MYSQL_SYSVAR(parallel_filloutput),
-                                                  MYSQL_SYSVAR(parallel_mapjoin),
-                                                  MYSQL_SYSVAR(qps_log),
-                                                  MYSQL_SYSVAR(query_threads),
-                                                  MYSQL_SYSVAR(refresh_sys_tianmu),
-                                                  MYSQL_SYSVAR(session_debug_level),
-                                                  MYSQL_SYSVAR(sync_buffers),
-                                                  MYSQL_SYSVAR(trigger_error),
-                                                  MYSQL_SYSVAR(async_join),
-                                                  MYSQL_SYSVAR(force_hashjoin),
-                                                  MYSQL_SYSVAR(start_async),
-                                                  MYSQL_SYSVAR(result_sender_rows),
-                                                  NULL};
+                                            MYSQL_SYSVAR(cachinglevel),
+                                            MYSQL_SYSVAR(compensation_start),
+                                            MYSQL_SYSVAR(control_trace),
+                                            MYSQL_SYSVAR(data_distribution_policy),
+                                            MYSQL_SYSVAR(disk_usage_threshold),
+                                            MYSQL_SYSVAR(distinct_cache_size),
+                                            MYSQL_SYSVAR(filterevaluation_speedup),
+                                            MYSQL_SYSVAR(global_debug_level),
+                                            MYSQL_SYSVAR(groupby_speedup),
+                                            MYSQL_SYSVAR(hugefiledir),
+                                            MYSQL_SYSVAR(index_cache_size),
+                                            MYSQL_SYSVAR(index_search),
+                                            MYSQL_SYSVAR(enable_rowstore),
+                                            MYSQL_SYSVAR(ini_allowmysqlquerypath),
+                                            MYSQL_SYSVAR(ini_cachefolder),
+                                            MYSQL_SYSVAR(ini_cachereleasethreshold),
+                                            MYSQL_SYSVAR(ini_cachesizethreshold),
+                                            MYSQL_SYSVAR(ini_controlquerylog),
+                                            MYSQL_SYSVAR(ini_knlevel),
+                                            MYSQL_SYSVAR(ini_pushdown),
+                                            MYSQL_SYSVAR(ini_servermainheapsize),
+                                            MYSQL_SYSVAR(ini_threadpoolsize),
+                                            MYSQL_SYSVAR(ini_usemysqlimportexportdefaults),
+                                            MYSQL_SYSVAR(insert_buffer_size),
+                                            MYSQL_SYSVAR(insert_cntthreshold),
+                                            MYSQL_SYSVAR(insert_delayed),
+                                            MYSQL_SYSVAR(insert_max_buffered),
+                                            MYSQL_SYSVAR(insert_numthreshold),
+                                            MYSQL_SYSVAR(insert_wait_ms),
+                                            MYSQL_SYSVAR(insert_wait_time),
+                                            MYSQL_SYSVAR(join_disable_switch_side),
+                                            MYSQL_SYSVAR(enable_histogram_cmap_bloom),
+                                            MYSQL_SYSVAR(join_parallel),
+                                            MYSQL_SYSVAR(join_splitrows),
+                                            MYSQL_SYSVAR(load_threads),
+                                            MYSQL_SYSVAR(lookup_max_size),
+                                            MYSQL_SYSVAR(max_execution_time),
+                                            MYSQL_SYSVAR(minmax_speedup),
+                                            MYSQL_SYSVAR(mm_hardlimit),
+                                            MYSQL_SYSVAR(mm_largetempratio),
+                                            MYSQL_SYSVAR(mm_largetemppool_threshold),
+                                            MYSQL_SYSVAR(mm_policy),
+                                            MYSQL_SYSVAR(mm_releasepolicy),
+                                            MYSQL_SYSVAR(orderby_speedup),
+                                            MYSQL_SYSVAR(parallel_filloutput),
+                                            MYSQL_SYSVAR(parallel_mapjoin),
+                                            MYSQL_SYSVAR(qps_log),
+                                            MYSQL_SYSVAR(query_threads),
+                                            MYSQL_SYSVAR(refresh_sys_tianmu),
+                                            MYSQL_SYSVAR(session_debug_level),
+                                            MYSQL_SYSVAR(sync_buffers),
+                                            MYSQL_SYSVAR(trigger_error),
+                                            MYSQL_SYSVAR(async_join),
+                                            MYSQL_SYSVAR(force_hashjoin),
+                                            MYSQL_SYSVAR(start_async),
+                                            MYSQL_SYSVAR(result_sender_rows),
+                                            NULL};
 }  // namespace dbhandler
 }  // namespace Tianmu
 
@@ -749,11 +749,11 @@ mysql_declare_plugin(tianmu){
     "Tianmu storage engine",
     PLUGIN_LICENSE_GPL,
     Tianmu::dbhandler::rcbase_init_func, /* Plugin Init */
-    nullptr,       /* Plugin Check uninstall */
+    nullptr,                             /* Plugin Check uninstall */
     Tianmu::dbhandler::rcbase_done_func, /* Plugin Deinit */
     0x0001 /* 0.1 */,
-    Tianmu::dbhandler::statusvars,   /* status variables  */
+    Tianmu::dbhandler::statusvars,      /* status variables  */
     Tianmu::dbhandler::tianmu_showvars, /* system variables  */
     nullptr,                            /* config options    */
-    0                                 /* flags for plugin */
+    0                                   /* flags for plugin */
 } mysql_declare_plugin_end;

--- a/storage/tianmu/index/kv_store.h
+++ b/storage/tianmu/index/kv_store.h
@@ -18,10 +18,10 @@
 #define TIANMU_INDEX_KV_STORE_H_
 #pragma once
 
+#include <condition_variable>  // stonedb8 for centos7.9, gcc 11.2.1
 #include <mutex>
 #include <string>
 #include <thread>
-#include <condition_variable> // stonedb8 for centos7.9, gcc 11.2.1
 
 #include "common/common_definitions.h"
 #include "index/rdb_meta_manager.h"
@@ -41,30 +41,32 @@ namespace index {
 class KVStore final {
  public:
   KVStore(const KVStore &) = delete;
-  //mysql_real_data_home, pls refer to the system params.
-  KVStore() : kv_data_dir_(mysql_real_data_home){}
+  // mysql_real_data_home, pls refer to the system params.
+  KVStore() : kv_data_dir_(mysql_real_data_home) {}
 
   KVStore &operator=(const KVStore &) = delete;
   virtual ~KVStore() { UnInit(); }
 
-  //initialize rocksdb engine
+  // initialize rocksdb engine
   void Init();
-  //deinitialize rocksdb engine
+  // deinitialize rocksdb engine
   void UnInit();
 
-  //sending signal DeleteData
+  // sending signal DeleteData
   void DeleteDataSignal() { cv_drop_.notify_one(); }
-  //async Droping Data
+  // async Droping Data
   void AsyncDropData();
-  //gets rocksdb handler
+  // gets rocksdb handler
   rocksdb::TransactionDB *GetRdb() const { return txn_db_; }
 
   uint GetNextIndexId() { return ddl_manager_.get_and_update_next_number(&dict_manager_); }
-  //gets the column family
-  rocksdb::ColumnFamilyHandle *GetCfHandle(std::string &cf_name) { return cf_manager_.get_or_create_cf(txn_db_, cf_name); }
-  //gets the column family by ID
+  // gets the column family
+  rocksdb::ColumnFamilyHandle *GetCfHandle(std::string &cf_name) {
+    return cf_manager_.get_or_create_cf(txn_db_, cf_name);
+  }
+  // gets the column family by ID
   rocksdb::ColumnFamilyHandle *GetCfHandleByID(const uint32_t id) { return cf_manager_.get_cf_by_id(id); }
-  //drops the index by an index ID
+  // drops the index by an index ID
   bool IndexDroping(GlobalId &index) {
     return dict_manager_.is_drop_index_ongoing(index, MetaType::DDL_DROP_INDEX_ONGOING);
   }
@@ -72,7 +74,7 @@ class KVStore final {
   // find a table by table name returns this table handler
   std::shared_ptr<RdbTable> FindTable(std::string &name) { return ddl_manager_.find(name); }
   // Put table definition of `tbl` into the mapping, and also write it to the
-  // on-disk data dictionary. 
+  // on-disk data dictionary.
   common::ErrorCode KVWriteTableMeta(std::shared_ptr<RdbTable> tbl);
   common::ErrorCode KVDelTableMeta(const std::string &tablename);
   common::ErrorCode KVRenameTableMeta(const std::string &s_name, const std::string &d_name);
@@ -91,32 +93,32 @@ class KVStore final {
   }
 
   bool KVWriteBatch(rocksdb::WriteOptions &wopts, rocksdb::WriteBatch *batch);
-  //gets snapshot from rocksdb.
+  // gets snapshot from rocksdb.
   const rocksdb::Snapshot *GetRdbSnapshot() { return txn_db_->GetSnapshot(); }
-  //release the specific snapshot
+  // release the specific snapshot
   void ReleaseRdbSnapshot(const rocksdb::Snapshot *snapshot) { txn_db_->ReleaseSnapshot(snapshot); }
 
  private:
-  //initializationed?
+  // initializationed?
   bool inited_ = false;
-  //path where data located
+  // path where data located
   fs::path kv_data_dir_;
-  //async drop thread
+  // async drop thread
   std::thread drop_kv_thread_;
-  //drop mutex
+  // drop mutex
   std::mutex cv_drop_mtx_;
-  //condition var for drop table
+  // condition var for drop table
   std::condition_variable cv_drop_;
-  
-  //bb table options
+
+  // bb table options
   rocksdb::BlockBasedTableOptions bb_table_option_;
-  //rocksdb transaction
+  // rocksdb transaction
   rocksdb::TransactionDB *txn_db_;
-  //meta data manager
+  // meta data manager
   DICTManager dict_manager_;
-  //column family manager
+  // column family manager
   CFManager cf_manager_;
-  //ddl manager
+  // ddl manager
   DDLManager ddl_manager_;
 };
 
@@ -130,13 +132,14 @@ class IndexCompactFilter : public rocksdb::CompactionFilter {
   IndexCompactFilter(const IndexCompactFilter &) = delete;
   IndexCompactFilter &operator=(const IndexCompactFilter &) = delete;
 
-  //set a filter with input params
+  // set a filter with input params
   bool Filter(int level, const rocksdb::Slice &key, const rocksdb::Slice &existing_value, std::string *new_value,
               bool *value_changed) const override;
-  
+
   bool IgnoreSnapshots() const override { return true; }
-  //gets the name of index compact filter. fixed value
+  // gets the name of index compact filter. fixed value
   const char *Name() const override { return "IndexCompactFilter"; }
+
  private:
   const uint32_t cf_id_;
   mutable GlobalId prev_index_ = {0, 0};

--- a/storage/tianmu/index/kv_transaction.cpp
+++ b/storage/tianmu/index/kv_transaction.cpp
@@ -95,7 +95,8 @@ bool KVTransaction::Commit() {
   bool res = true;
   Releasesnapshot();
   auto index_write_batch = index_batch_->GetWriteBatch();
-  if (index_write_batch && index_write_batch->Count() > 0 && !ha_kvstore_->KVWriteBatch(write_opts_, index_write_batch)) {
+  if (index_write_batch && index_write_batch->Count() > 0 &&
+      !ha_kvstore_->KVWriteBatch(write_opts_, index_write_batch)) {
     res = false;
   }
   if (res && data_batch_->Count() > 0 && !ha_kvstore_->KVWriteBatch(write_opts_, data_batch_.get())) {

--- a/storage/tianmu/index/kv_transaction.h
+++ b/storage/tianmu/index/kv_transaction.h
@@ -26,56 +26,56 @@
 namespace Tianmu {
 namespace index {
 
-//key-value transaction based on rocksdb
+// key-value transaction based on rocksdb
 class KVTransaction {
  public:
-  //ctor.
+  // ctor.
   KVTransaction()
       : index_batch_(std::make_unique<rocksdb::WriteBatchWithIndex>(rocksdb::BytewiseComparator(), 0, true)),
         data_batch_(std::make_unique<rocksdb::WriteBatch>()),
         key_iter_(std::make_shared<KeyIterator>(this)) {}
-  //dctor.
+  // dctor.
   virtual ~KVTransaction();
 
-  //gets a value by key and cf.
+  // gets a value by key and cf.
   rocksdb::Status Get(rocksdb::ColumnFamilyHandle *column_family, const rocksdb::Slice &key, std::string *value);
-  //stores a (key-value) pair into column_family.
+  // stores a (key-value) pair into column_family.
   rocksdb::Status Put(rocksdb::ColumnFamilyHandle *column_family, const rocksdb::Slice &key,
                       const rocksdb::Slice &value);
-  //deletes a value by key from column_family.
+  // deletes a value by key from column_family.
   rocksdb::Status Delete(rocksdb::ColumnFamilyHandle *column_family, const rocksdb::Slice &key);
-  //gets a filter of specific colum_family.
+  // gets a filter of specific colum_family.
   rocksdb::Iterator *GetIterator(rocksdb::ColumnFamilyHandle *const column_family, bool skip_filter);
-  //gets the value by key and column_family.
+  // gets the value by key and column_family.
   rocksdb::Status GetData(rocksdb::ColumnFamilyHandle *column_family, const rocksdb::Slice &key, std::string *value);
-  //stores the (key-value) to column_family.
+  // stores the (key-value) to column_family.
   rocksdb::Status PutData(rocksdb::ColumnFamilyHandle *column_family, const rocksdb::Slice &key,
                           const rocksdb::Slice &value);
-  //delete one 'row' by the key.
+  // delete one 'row' by the key.
   rocksdb::Status SingleDeleteData(rocksdb::ColumnFamilyHandle *column_family, const rocksdb::Slice &key);
-  //gets the iterator of column_family with specific read options.
+  // gets the iterator of column_family with specific read options.
   rocksdb::Iterator *GetDataIterator(rocksdb::ReadOptions &ropts, rocksdb::ColumnFamilyHandle *const column_family);
-  //gets a KeyIterator.
+  // gets a KeyIterator.
   std::shared_ptr<KeyIterator> KeyIter() { return key_iter_; }
-  //acquire a snapshot 
+  // acquire a snapshot
   void Acquiresnapshot();
- //release a snapshot
+  // release a snapshot
   void Releasesnapshot();
-  //commit the transaction
+  // commit the transaction
   bool Commit();
-  //rollback the transaction
+  // rollback the transaction
   void Rollback();
 
  private:
-  //writes 'rows' in batch with index.
+  // writes 'rows' in batch with index.
   std::unique_ptr<rocksdb::WriteBatchWithIndex> index_batch_;
-  //wites 'rows' in batch.
+  // wites 'rows' in batch.
   std::unique_ptr<rocksdb::WriteBatch> data_batch_;
-  //writes options.
+  // writes options.
   rocksdb::WriteOptions write_opts_;
-  //reads options.
+  // reads options.
   rocksdb::ReadOptions read_opts_;
-  //iterator of key.
+  // iterator of key.
   std::shared_ptr<KeyIterator> key_iter_;
 };
 

--- a/storage/tianmu/index/rc_table_index.cpp
+++ b/storage/tianmu/index/rc_table_index.cpp
@@ -27,7 +27,6 @@
 namespace Tianmu {
 namespace index {
 
-
 const std::string generate_cf_name(uint index, TABLE *table) {
   const char *comment = table->key_info[index].comment.str;
   std::string key_comment = comment ? comment : "";
@@ -50,7 +49,7 @@ void create_rdbkey(TABLE *table, uint i, std::shared_ptr<RdbKey> &new_key_def, r
       case MYSQL_TYPE_INT24:
       case MYSQL_TYPE_SHORT:
       case MYSQL_TYPE_TINY: {
-        unsigned_flag = ((Field_num *)f)->is_unsigned(); // stonedb8
+        unsigned_flag = ((Field_num *)f)->is_unsigned();  // stonedb8
 
       } break;
       default:

--- a/storage/tianmu/index/rc_table_index.h
+++ b/storage/tianmu/index/rc_table_index.h
@@ -68,8 +68,8 @@ class RCTableIndex final {
 class KeyIterator final {
  public:
   KeyIterator() = delete;
-  KeyIterator(const KeyIterator &sec) : valid(sec.valid), iter_(sec.iter_), rdbkey_(sec.rdbkey_){}
-  KeyIterator(KVTransaction *tx) : trans_(tx){}
+  KeyIterator(const KeyIterator &sec) : valid(sec.valid), iter_(sec.iter_), rdbkey_(sec.rdbkey_) {}
+  KeyIterator(KVTransaction *tx) : trans_(tx) {}
   void ScanToKey(std::shared_ptr<RCTableIndex> tab, std::vector<std::string_view> &fields, common::Operator op);
   void ScanToEdge(std::shared_ptr<RCTableIndex> tab, bool forward);
   common::ErrorCode GetCurKV(std::vector<std::string> &keys, uint64_t &row);

--- a/storage/tianmu/index/rdb_meta_manager.cpp
+++ b/storage/tianmu/index/rdb_meta_manager.cpp
@@ -396,9 +396,9 @@ bool DDLManager::init(DICTManager *const dict, CFManager *const cf_manager_) {
     const int version = be_read_uint16(&ptr);
     if (version != static_cast<uint>(enumVersion::DDL_VERSION)) {
       TIANMU_LOG(LogCtl_Level::ERROR,
-                  "RocksDB: DDL ENTRY Version was not expected.Expected: %d, "
-                  "Actual: %d",
-                  static_cast<uint>(enumVersion::DDL_VERSION), version);
+                 "RocksDB: DDL ENTRY Version was not expected.Expected: %d, "
+                 "Actual: %d",
+                 static_cast<uint>(enumVersion::DDL_VERSION), version);
       return false;
     }
     ptr_end = ptr + real_val_size;
@@ -411,32 +411,32 @@ bool DDLManager::init(DICTManager *const dict, CFManager *const cf_manager_) {
       std::vector<ColAttr> vcols;
       if (!m_dict->get_index_info(gl_index_id, index_ver, index_type, vcols)) {
         TIANMU_LOG(LogCtl_Level::ERROR,
-                    "RocksDB: Could not get INDEXINFO for Index Number "
-                    "(%u,%u), table %s",
-                    gl_index_id.cf_id, gl_index_id.index_id, tdef->fullname().c_str());
+                   "RocksDB: Could not get INDEXINFO for Index Number "
+                   "(%u,%u), table %s",
+                   gl_index_id.cf_id, gl_index_id.index_id, tdef->fullname().c_str());
         return false;
       }
       if (max_index_id < gl_index_id.index_id) {
         TIANMU_LOG(LogCtl_Level::ERROR,
-                    "RocksDB: Found MetaType::MAX_INDEX_ID %u, but also found larger "
-                    "index %u from INDEXINFO.",
-                    max_index_id, gl_index_id.index_id);
+                   "RocksDB: Found MetaType::MAX_INDEX_ID %u, but also found larger "
+                   "index %u from INDEXINFO.",
+                   max_index_id, gl_index_id.index_id);
         return false;
       }
       // In some abnormal condition, gl_index_id.cf_id(CF Number) is greater
       // than 0 like 3 or 4 just log it and set the CF to 0.
       if (gl_index_id.cf_id != 0) {
         TIANMU_LOG(LogCtl_Level::ERROR,
-                    "Tianmu-RocksDB: Could not get Column Family Flags for CF "
-                    "Number %d, table %s",
-                    gl_index_id.cf_id, tdef->fullname().c_str());
+                   "Tianmu-RocksDB: Could not get Column Family Flags for CF "
+                   "Number %d, table %s",
+                   gl_index_id.cf_id, tdef->fullname().c_str());
         gl_index_id.cf_id = 0;
       }
       if (!m_dict->get_cf_flags(gl_index_id.cf_id, flags)) {
         TIANMU_LOG(LogCtl_Level::ERROR,
-                    "RocksDB: Could not get Column Family Flags for CF Number "
-                    "%d, table %s",
-                    gl_index_id.cf_id, tdef->fullname().c_str());
+                   "RocksDB: Could not get Column Family Flags for CF Number "
+                   "%d, table %s",
+                   gl_index_id.cf_id, tdef->fullname().c_str());
         return false;
       }
       rocksdb::ColumnFamilyHandle *const cfh = cf_manager_->get_cf_by_id(gl_index_id.cf_id);
@@ -466,9 +466,9 @@ bool DDLManager::init(DICTManager *const dict, CFManager *const cf_manager_) {
     const int version = be_read_uint16(&ptr);
     if (version != static_cast<uint>(enumVersion::DDL_VERSION)) {
       TIANMU_LOG(LogCtl_Level::ERROR,
-                  "RocksDB: DDL MEMTABLE ENTRY Version was not expected or "
-                  "currupt.Expected: %d, Actual: %d",
-                  static_cast<uint>(enumVersion::DDL_VERSION), version);
+                 "RocksDB: DDL MEMTABLE ENTRY Version was not expected or "
+                 "currupt.Expected: %d, Actual: %d",
+                 static_cast<uint>(enumVersion::DDL_VERSION), version);
       return false;
     }
 
@@ -477,7 +477,7 @@ bool DDLManager::init(DICTManager *const dict, CFManager *const cf_manager_) {
     std::string table_name = std::string(key.data() + INDEX_NUMBER_SIZE, key.size() - INDEX_NUMBER_SIZE);
     if (max_index_id < memtable_id) {
       TIANMU_LOG(LogCtl_Level::ERROR, "RocksDB: Found MAX_MEM_ID %u, but also found larger memtable id %u.",
-                  max_index_id, memtable_id);
+                 max_index_id, memtable_id);
       return false;
     }
     std::shared_ptr<core::RCMemTable> tb_mem = std::make_shared<core::RCMemTable>(table_name, memtable_id, cf_id);
@@ -862,7 +862,7 @@ bool DICTManager::update_max_index_id(rocksdb::WriteBatch *const batch, const ui
   if (get_max_index_id(&old_index_id)) {
     if (old_index_id > index_id) {
       TIANMU_LOG(LogCtl_Level::ERROR, "RocksDB: Found max index id %u but trying to update to %u.", old_index_id,
-                  index_id);
+                 index_id);
       return true;
     }
   }

--- a/storage/tianmu/index/rdb_meta_manager.h
+++ b/storage/tianmu/index/rdb_meta_manager.h
@@ -242,7 +242,7 @@ class DICTManager {
   bool init(rocksdb::DB *const rdb_dict, CFManager *const cf_manager_);
   inline void lock() { m_mutex.lock(); }
   inline void unlock() { m_mutex.unlock(); }
-  void cleanup(){}
+  void cleanup() {}
   inline rocksdb::ColumnFamilyHandle *get_system_cf() const { return m_system_cfh; }
   std::unique_ptr<rocksdb::WriteBatch> begin() const;
   bool commit(rocksdb::WriteBatch *const batch, const bool &sync = true) const;

--- a/storage/tianmu/loader/load_parser.cpp
+++ b/storage/tianmu/loader/load_parser.cpp
@@ -18,10 +18,10 @@
 #include "load_parser.h"
 
 #include "binlog.h"
-#include "log_event.h"
 #include "core/engine.h"
 #include "core/rc_attr.h"
 #include "loader/value_cache.h"
+#include "log_event.h"
 #include "system/io_parameters.h"
 #include "util/timer.h"
 

--- a/storage/tianmu/loader/parsing_strategy.cpp
+++ b/storage/tianmu/loader/parsing_strategy.cpp
@@ -408,7 +408,7 @@ void ParsingStrategy::GetValue(const char *value_ptr, size_t value_size, ushort 
       std::string valueStr(value_ptr, value_size);
       value_size = ati.CharLen();
       TIANMU_LOG(LogCtl_Level::DEBUG, "Data format error. DbName:%s ,TableName:%s ,Col %d, value:%s", dbname.c_str(),
-                  tablename.c_str(), col, valueStr.c_str());
+                 tablename.c_str(), col, valueStr.c_str());
       std::stringstream err_msg;
       err_msg << "data truncate,col num" << col << " value:" << valueStr << std::endl;
       common::PushWarning(current_txn_->Thd(), Sql_condition::SL_WARNING, ER_UNKNOWN_ERROR, err_msg.str().c_str());

--- a/storage/tianmu/mm/huge_heap_policy.cpp
+++ b/storage/tianmu/mm/huge_heap_policy.cpp
@@ -44,7 +44,7 @@ HugeHeap::HugeHeap(std::string hugedir, size_t size) : TCMHeap(0) {
     if (fd_ < 0) {
       heap_status_ = HEAP_STATUS::HEAP_OUT_OF_MEMORY;
       rc_control_ << system::lock << "Memory Manager Error: Unable to create hugepage file: " << huge_filename_
-                << system::unlock;
+                  << system::unlock;
       return;
     }
     // MAP_SHARED to have mmap fail immediately if not enough pages
@@ -55,7 +55,7 @@ HugeHeap::HugeHeap(std::string hugedir, size_t size) : TCMHeap(0) {
       unlink(huge_filename_);
       heap_status_ = HEAP_STATUS::HEAP_OUT_OF_MEMORY;
       rc_control_ << system::lock << "Memory Manager Error: hugepage file mmap error: " << std::strerror(errno)
-                << system::unlock;
+                  << system::unlock;
       return;
     }
 

--- a/storage/tianmu/mm/memory_handling_policy.cpp
+++ b/storage/tianmu/mm/memory_handling_policy.cpp
@@ -401,7 +401,7 @@ void MemoryHandling::EnsureNoLeakedTraceableObject() {
     if (it.first->IsLocked() && (it.first->NumOfLocks() > 1 || it.first->TraceableType() == TO_TYPE::TO_PACK)) {
       error_found = true;
       TIANMU_LOG(LogCtl_Level::ERROR, "Object @[%ld] locked too many times. Object type: %d, no. locks: %d",
-                  long(it.first), int(it.first->TraceableType()), int(it.first->NumOfLocks()));
+                 long(it.first), int(it.first->TraceableType()), int(it.first->NumOfLocks()));
     }
   }
   ASSERT(!error_found, "Objects locked too many times found.");

--- a/storage/tianmu/system/channel_out.h
+++ b/storage/tianmu/system/channel_out.h
@@ -66,7 +66,7 @@ class ChannelOut {
   virtual void close() = 0;
 
   virtual ChannelOut &operator<<(ChannelOut &(*_Pfn)(ChannelOut &)) = 0;
-  virtual ~ChannelOut(){}
+  virtual ~ChannelOut() {}
 };
 
 inline ChannelOut &endl(ChannelOut &inout) {

--- a/storage/tianmu/system/fet.h
+++ b/storage/tianmu/system/fet.h
@@ -60,7 +60,7 @@ class FunctionsExecutionTimes {
   class SortEntryLess {
    public:
     bool operator()(const SortEntry &e1, const SortEntry &e2) { return e1.e.time < e2.e.time; }
-  }; //class SortEntryLess
+  };  // class SortEntryLess
 
  public:
   FunctionsExecutionTimes() {
@@ -108,8 +108,8 @@ class FunctionsExecutionTimes {
   void Clear() { times_->clear(); }
   void Print() {
     TIANMU_LOG(LogCtl_Level::INFO,
-                "***** Function Execution Times "
-                "************************************************************");
+               "***** Function Execution Times "
+               "************************************************************");
     std::priority_queue<SortEntry, std::vector<SortEntry>, SortEntryLess> sq;
     char str[512] = {0};
     for (auto &iter : *times_) sq.push(SortEntry(iter.first, iter.second));
@@ -122,13 +122,13 @@ class FunctionsExecutionTimes {
 
     TIANMU_LOG(LogCtl_Level::INFO, "Number of distinct Data Packs loads: %u", (uint)count_distinct_dp_loads.size());
     TIANMU_LOG(LogCtl_Level::INFO, "Number of distinct Data Packs decompressions: %u",
-                (uint)count_distinct_dp_decompressions.size());
+               (uint)count_distinct_dp_decompressions.size());
     TIANMU_LOG(LogCtl_Level::INFO, "Size of DP read from disk: %fMB", ((double)NumOfBytesReadByDPs / 1_MB));
     TIANMU_LOG(LogCtl_Level::INFO, "Size of uncompressed DPs: %fMB", ((double)SizeOfUncompressedDP / 1_MB));
     TIANMU_LOG(LogCtl_Level::INFO,
-                "**************************************************************"
-                "***********"
-                "******************");
+               "**************************************************************"
+               "***********"
+               "******************");
   }
 
   std::map<std::string, Entry> *times_;
@@ -167,9 +167,7 @@ class FETOperator {
 
 inline void FunctionsExecutionTimes::FlushFET(int signum) { fet->Flush(); }
 
-inline void FunctionsExecutionTimes::InstallFlushSignal() {
-  signal(16, FunctionsExecutionTimes::FlushFET);
-}
+inline void FunctionsExecutionTimes::InstallFlushSignal() { signal(16, FunctionsExecutionTimes::FlushFET); }
 
 #define MEASURE_FET(X) FETOperator feto(X)
 

--- a/storage/tianmu/system/file_system.cpp
+++ b/storage/tianmu/system/file_system.cpp
@@ -42,7 +42,7 @@ int ClearDirectory(std::string const &path) {
     }
   } catch (fs::filesystem_error &e) {
     TIANMU_LOG(LogCtl_Level::ERROR, "Failed to ClearDirectory(%s). filesystem_error: %s %s %s", path.c_str(), e.what(),
-                e.path1().native().c_str(), e.path2().native().c_str());
+               e.path1().native().c_str(), e.path2().native().c_str());
     return 1;
   } catch (std::exception &e) {
     TIANMU_LOG(LogCtl_Level::ERROR, "Failed to ClearDirectory(%s). error: %s", path.c_str(), e.what());
@@ -69,7 +69,7 @@ void DeleteDirectory(std::string const &path) {
     }
   } catch (fs::filesystem_error &e) {
     TIANMU_LOG(LogCtl_Level::ERROR, "Failed to delete directory(%s). filesystem_error: %s %s %s", path.c_str(),
-                e.what(), e.path1().native().c_str(), e.path2().native().c_str());
+               e.what(), e.path1().native().c_str(), e.path2().native().c_str());
   } catch (std::exception &e) {
     TIANMU_LOG(LogCtl_Level::ERROR, "Failed to delete directory(%s). error: %s", path.c_str(), e.what());
   }

--- a/storage/tianmu/system/io_parameters.h
+++ b/storage/tianmu/system/io_parameters.h
@@ -46,7 +46,9 @@ enum class Parameter {
 class IOParameters {
  public:
   IOParameters() { Init(); }
-  IOParameters(std::string base_path, std::string table_name) : base_path_(base_path), table_name_(table_name) { Init(); }
+  IOParameters(std::string base_path, std::string table_name) : base_path_(base_path), table_name_(table_name) {
+    Init();
+  }
   IOParameters &operator=(const IOParameters &rhs) = delete;
   IOParameters(const IOParameters &io_params) = delete;
 
@@ -158,7 +160,8 @@ class IOParameters {
   std::string GetTableName() const { return table_name_; }
   void SetLogInfo(void *logptr) { loginfo_ptr_ = logptr; }
   void *GetLogInfo() const { return loginfo_ptr_; }
-public:
+
+ public:
   bool load_delayed_insert_ = false;
 
  private:

--- a/storage/tianmu/system/large_buffer.cpp
+++ b/storage/tianmu/system/large_buffer.cpp
@@ -77,7 +77,8 @@ void LargeBuffer::BufFlush() {
     TIANMU_LOG(LogCtl_Level::ERROR, "Write operation to file or pipe failed_.");
     throw common::FileException("Write operation to file or pipe failed_.");
   }
-  flush_thread_ = std::thread(std::bind(&LargeBuffer::BufFlushThread, this, tianmu_stream_.get(), buf_, buf_used_, &failed_));
+  flush_thread_ =
+      std::thread(std::bind(&LargeBuffer::BufFlushThread, this, tianmu_stream_.get(), buf_, buf_used_, &failed_));
   UseNextBuf();
 }
 

--- a/storage/tianmu/system/large_buffer.h
+++ b/storage/tianmu/system/large_buffer.h
@@ -64,7 +64,6 @@ class LargeBuffer final : public mm::TraceableObject {
   }
 
  private:
-
   void BufFlush();  // save the data to the file (in writing mode)
   void BufClose();  // close the buffer; warning: does not flush data in writing mode
   void UseNextBuf();
@@ -72,20 +71,20 @@ class LargeBuffer final : public mm::TraceableObject {
   void BufFlushThread(Stream *file, char *buf_ptr, int len, bool *failed);
 
  private:
-    int buf_used_;  // number of bytes loaded or reserved so far
-    char *buf_;     // current buf in bufs
-    int size_;
-    std::vector<std::unique_ptr<char[]>> bufs_;
-    int curr_buf_num_;     // buf = bufs + currBufNo
-    char *buf2next_;       // buf to be used next
-    int curr_buf2next_num_;
+  int buf_used_;  // number of bytes loaded or reserved so far
+  char *buf_;     // current buf in bufs
+  int size_;
+  std::vector<std::unique_ptr<char[]>> bufs_;
+  int curr_buf_num_;  // buf = bufs + currBufNo
+  char *buf2next_;    // buf to be used next
+  int curr_buf2next_num_;
 
-    std::unique_ptr<Stream> tianmu_stream_;
+  std::unique_ptr<Stream> tianmu_stream_;
 
-    std::mutex mutex_;
-    std::condition_variable cond_var_;
-    std::thread flush_thread_;
-    bool failed_;
+  std::mutex mutex_;
+  std::condition_variable cond_var_;
+  std::thread flush_thread_;
+  bool failed_;
 };
 }  // namespace system
 }  // namespace Tianmu

--- a/storage/tianmu/system/net_stream.cpp
+++ b/storage/tianmu/system/net_stream.cpp
@@ -26,9 +26,8 @@
 namespace Tianmu {
 namespace system {
 NetStream::NetStream(const IOParameters &iop) : net_(&current_txn_->Thd()->net), cached_size_(0), cached_offset_(0) {
-  //net_request_file(net_, iop.Path());
-  net_write_command(net_, 251, (uchar*) iop.Path(), strlen(iop.Path()),
-                    (uchar*) "", 0);
+  // net_request_file(net_, iop.Path());
+  net_write_command(net_, 251, (uchar *)iop.Path(), strlen(iop.Path()), (uchar *)"", 0);
   opened_ = true;
 }
 
@@ -70,7 +69,7 @@ size_t NetStream::Read(void *buf, size_t count) {
     opened_ = false;
     std::chrono::duration<double> diff = std::chrono::system_clock::now() - start;
     TIANMU_LOG(LogCtl_Level::INFO, "Failed to read from network: %s. Used %f seconds", std::strerror(errno),
-                diff.count());
+               diff.count());
     return copied;
   }
   if (len == 0) {

--- a/storage/tianmu/system/rc_system.cpp
+++ b/storage/tianmu/system/rc_system.cpp
@@ -24,33 +24,33 @@
 
 namespace Tianmu {
 
-//row-column channel control.
+// row-column channel control.
 system::Channel rc_control_(true);
-//query log channel flag.
+// query log channel flag.
 system::Channel rc_querylog_(true);
-//global host ip addr.
+// global host ip addr.
 char global_hostIP_[FN_REFLEN];
-//global server info.
+// global server info.
 char global_serverinfo_[FN_REFLEN];
-//key-value engine handler.
+// key-value engine handler.
 core::Engine *ha_rcengine_ = nullptr;
-//key-value store handler.
+// key-value store handler.
 index::KVStore *ha_kvstore_ = nullptr;
-//global mutex
+// global mutex
 std::mutex global_mutex_;
-//mutex of drop or rename
+// mutex of drop or rename
 std::shared_mutex drop_rename_mutex_;
 
 #ifdef FUNCTIONS_EXECUTION_TIMES
-//num of distinct DP loaded.
+// num of distinct DP loaded.
 LoadedDataPackCounter count_distinct_dp_loads;
-//num of distinct decompressed DP.
+// num of distinct decompressed DP.
 LoadedDataPackCounter count_distinct_dp_decompressions;
-//exe time of func.
+// exe time of func.
 FunctionsExecutionTimes *fet = nullptr;
-//num of bytes read by DP.
+// num of bytes read by DP.
 uint64_t NumOfBytesReadByDPs = 0;
-//size of un-compressed DP.
+// size of un-compressed DP.
 uint64_t SizeOfUncompressedDP = 0;
 #endif
 

--- a/storage/tianmu/system/rc_system.h
+++ b/storage/tianmu/system/rc_system.h
@@ -35,25 +35,25 @@ namespace index {
 class KVStore;
 }  // namespace index
 
-// Channel for debugging information, not 
+// Channel for debugging information, not
 // displayed in the standard running mode.
 extern system::Channel rc_control_;
-//the channel for query log.
+// the channel for query log.
 extern system::Channel rc_querylog_;
-//host ip addr.
+// host ip addr.
 extern char global_hostIP_[FN_REFLEN];
-//host server info string.
+// host server info string.
 extern char global_serverinfo_[FN_REFLEN];
 
-//row-column engine handler.
+// row-column engine handler.
 extern core::Engine *ha_rcengine_;
-//key-value store handler.
+// key-value store handler.
 extern index::KVStore *ha_kvstore_;
-//global mutex.
+// global mutex.
 extern std::mutex global_mutex_;
-//drop or rename mutex.
+// drop or rename mutex.
 extern std::shared_mutex drop_rename_mutex_;
-//current transaction handler.
+// current transaction handler.
 extern thread_local core::Transaction *current_txn_;
 
 }  // namespace Tianmu

--- a/storage/tianmu/system/res_manager.cpp
+++ b/storage/tianmu/system/res_manager.cpp
@@ -25,7 +25,7 @@ namespace system {
 
 ResourceManager::ResourceManager() {
   // Instantiate policies based on ConfigurationManager settings
- res_manage_policy_ = new MagMemoryPolicy(tianmu_sysvar_servermainheapsize);
+  res_manage_policy_ = new MagMemoryPolicy(tianmu_sysvar_servermainheapsize);
 }
 
 ResourceManager::~ResourceManager() { delete res_manage_policy_; }

--- a/storage/tianmu/system/res_manager.h
+++ b/storage/tianmu/system/res_manager.h
@@ -30,7 +30,8 @@ class ResourceManager : public ResourceManagerBase {
   ~ResourceManager();
 
   int GetMemoryScale() override { return res_manage_policy_->estimate(); }
-private:
+
+ private:
   ResourceManagerPolicy *res_manage_policy_;
 };
 

--- a/storage/tianmu/system/stdout.h
+++ b/storage/tianmu/system/stdout.h
@@ -113,7 +113,7 @@ class StdOut : public ChannelOut {
     return *this;
   }
 
-  void close() override{}
+  void close() override {}
 
   ChannelOut &operator<<(ChannelOut &(*_Pfn)(ChannelOut &)) override { return _Pfn(*this); }
 };

--- a/storage/tianmu/system/stream.h
+++ b/storage/tianmu/system/stream.h
@@ -23,7 +23,6 @@
 namespace Tianmu {
 namespace system {
 class Stream {
-
  public:
   Stream() = default;
   virtual ~Stream() = default;

--- a/storage/tianmu/system/tianmu_file.h
+++ b/storage/tianmu/system/tianmu_file.h
@@ -35,7 +35,7 @@ namespace system {
 */
 
 class TianmuFile : public Stream {
-private:
+ private:
   int fd_;
 
  public:

--- a/storage/tianmu/types/rc_data_types.h
+++ b/storage/tianmu/types/rc_data_types.h
@@ -540,7 +540,7 @@ static inline bool IsBin(DTCollation coll) { return (std::strstr(coll.collation-
 
 // stonedb8
 static inline bool IsCaseInsensitive(const DTCollation &coll) {
-  return (std::strstr(coll.collation->m_coll_name, "_ci") != 0); // stonedb8
+  return (std::strstr(coll.collation->m_coll_name, "_ci") != 0);  // stonedb8
 }
 
 inline DTCollation ResolveCollation(DTCollation first, DTCollation sec) {

--- a/storage/tianmu/types/rc_datetime.cpp
+++ b/storage/tianmu/types/rc_datetime.cpp
@@ -310,7 +310,7 @@ common::ErrorCode RCDateTime::Parse(const int64_t &v, RCDateTime &rcv, common::C
       return common::ErrorCode::SUCCESS;
     if (sign == 1 && at == common::CT::TIMESTAMP &&
         IsCorrectTIANMUTimestamp(short(rcv.dt.year), short(rcv.dt.month), short(rcv.dt.day), short(rcv.dt.hour),
-                              short(rcv.dt.minute), short(rcv.dt.second)))
+                                 short(rcv.dt.minute), short(rcv.dt.second)))
       return common::ErrorCode::SUCCESS;
   } else
     TIANMU_ERROR("type not supported");
@@ -643,7 +643,7 @@ void RCDateTime::AdjustTimezone(RCDateTime &dt) {
       thd->variables.time_zone->gmt_sec_to_TIME(
           &time_tmp, tianmu_sec_since_epoch(t.year, t.month, t.day, t.hour, t.minute, t.second));
       secs = tianmu_sec_since_epoch(time_tmp.year, time_tmp.month, time_tmp.day, time_tmp.hour, time_tmp.minute,
-                                     time_tmp.second);
+                                    time_tmp.second);
 
     } else {
       // time in client time zone is converted into UTC and expressed as seconds

--- a/storage/tianmu/types/rc_item_types.cpp
+++ b/storage/tianmu/types/rc_item_types.cpp
@@ -17,8 +17,8 @@
 
 #include "rc_item_types.h"
 
-#include "item_sum.h"
 #include "common/common_definitions.h"
+#include "item_sum.h"
 
 namespace Tianmu {
 namespace types {
@@ -28,7 +28,7 @@ Item_sum_int_rcbase::~Item_sum_int_rcbase() {}
 
 longlong Item_sum_int_rcbase::val_int() {
   DEBUG_ASSERT(fixed == 1);
-  return (longlong) count_;
+  return (longlong)count_;
 }
 
 String *Item_sum_int_rcbase::val_str([[maybe_unused]] String *str) { return NULL; }
@@ -42,7 +42,6 @@ void Item_sum_int_rcbase::int64_value(int64_t &value) {
 void Item_sum_int_rcbase::clear() {}
 bool Item_sum_int_rcbase::add() { return 0; }
 void Item_sum_int_rcbase::update_field() {}
-
 
 Item_sum_sum_rcbase::Item_sum_sum_rcbase() : Item_sum_num() { sum_ = 0; }
 Item_sum_sum_rcbase::~Item_sum_sum_rcbase() {}
@@ -169,8 +168,7 @@ my_decimal *Item_sum_hybrid_rcbase::val_decimal(my_decimal *val) {
   switch (hybrid_type_) {
     case STRING_RESULT:
       // stonedb8
-      str2my_decimal(E_DEC_FATAL_ERROR,  value_.ptr(), value_.length(),
-                     value_.charset(), val);
+      str2my_decimal(E_DEC_FATAL_ERROR, value_.ptr(), value_.length(), value_.charset(), val);
       break;
     case REAL_RESULT:
       double2my_decimal(E_DEC_FATAL_ERROR, sum_, val);

--- a/storage/tianmu/types/rc_item_types.h
+++ b/storage/tianmu/types/rc_item_types.h
@@ -57,7 +57,7 @@ class Item_sum_int_rcbase : public Item_sum_num {
   void update_field() override;
   const char *func_name() const override { return "count("; }
 
-public:
+ public:
   int64_t count_;
 };
 
@@ -83,14 +83,14 @@ class Item_sum_sum_rcbase : public Item_sum_num {
   void reset_field() override {}
   const char *func_name() const override { return "sum("; }
 
-public:
+ public:
   double sum_;
   Item_result hybrid_type_;
   my_decimal decimal_buffs_[1];
 };
 
 class Item_sum_hybrid_rcbase : public Item_sum {
-public:
+ public:
   Item_sum_hybrid_rcbase();
   ~Item_sum_hybrid_rcbase();
 
@@ -103,7 +103,7 @@ public:
   enum Sumfunctype sum_func() const override { return MIN_FUNC; }
   enum Item_result result_type() const override { return hybrid_type_; }
   // stonedb8 mysql8 delete field_type(), and this func is not called
-  //enum enum_field_types field_type() const override { return hybrid_field_type_; } 
+  // enum enum_field_types field_type() const override { return hybrid_field_type_; }
 
   bool any_value() { return is_values_; }
   my_decimal *dec_value();
@@ -117,8 +117,8 @@ public:
   const char *func_name() const override { return "min("; }
   bool get_date(MYSQL_TIME *ltime, uint fuzzydate) override { return get_date_from_string(ltime, fuzzydate); }
   bool get_time(MYSQL_TIME *ltime) override { return get_time_from_string(ltime); }
- 
-public:
+
+ public:
   String value_;
   enum_field_types hybrid_field_type_;
   Item_result hybrid_type_;

--- a/storage/tianmu/types/rc_num.cpp
+++ b/storage/tianmu/types/rc_num.cpp
@@ -30,14 +30,22 @@ namespace types {
 
 RCNum::RCNum(common::CT attrt) : value_(0), scale_(0), is_double_(false), is_dot_(false), attr_type_(attrt) {}
 
-RCNum::RCNum(int64_t value_, short scale, bool is_double_, common::CT attrt) { Assign(value_, scale, is_double_, attrt); }
+RCNum::RCNum(int64_t value_, short scale, bool is_double_, common::CT attrt) {
+  Assign(value_, scale, is_double_, attrt);
+}
 
-RCNum::RCNum(double value_) : value_(*(int64_t *)&value_), scale_(0), is_double_(true), is_dot_(false), attr_type_(common::CT::REAL) {
+RCNum::RCNum(double value_)
+    : value_(*(int64_t *)&value_), scale_(0), is_double_(true), is_dot_(false), attr_type_(common::CT::REAL) {
   null = (value_ == NULL_VALUE_D ? true : false);
 }
 
 RCNum::RCNum(const RCNum &rcn)
-    : ValueBasic<RCNum>(rcn), value_(rcn.value_), scale_(rcn.scale_), is_double_(rcn.is_double_), is_dot_(rcn.is_dot_), attr_type_(rcn.attr_type_) {
+    : ValueBasic<RCNum>(rcn),
+      value_(rcn.value_),
+      scale_(rcn.scale_),
+      is_double_(rcn.is_double_),
+      is_dot_(rcn.is_dot_),
+      attr_type_(rcn.attr_type_) {
   null = rcn.null;
 }
 
@@ -57,7 +65,8 @@ RCNum &RCNum::Assign(int64_t value_, short scale, bool is_double_, common::CT at
   }
   if (scale <= -1 && !is_double_) scale_ = 0;
   if (is_double_) {
-    if (!(this->attr_type_ == common::CT::REAL || this->attr_type_ == common::CT::FLOAT)) this->attr_type_ = common::CT::REAL;
+    if (!(this->attr_type_ == common::CT::REAL || this->attr_type_ == common::CT::FLOAT))
+      this->attr_type_ = common::CT::REAL;
     this->is_dot_ = false;
     scale_ = 0;
     null = (value_ == *(int64_t *)&NULL_VALUE_D ? true : false);
@@ -441,7 +450,8 @@ int RCNum::compare(const RCNum &rcn) const {
   if (IsNull() || rcn.IsNull()) return false;
   if (IsReal() || rcn.IsReal()) {
     if (IsReal() && rcn.IsReal())
-      return (*(double *)&value_ > *(double *)&rcn.value_ ? 1 : (*(double *)&value_ == *(double *)&rcn.value_ ? 0 : -1));
+      return (*(double *)&value_ > *(double *)&rcn.value_ ? 1
+                                                          : (*(double *)&value_ == *(double *)&rcn.value_ ? 0 : -1));
     else {
       if (IsReal())
         return (*this > rcn.ToReal() ? 1 : (*this == rcn.ToReal() ? 0 : -1));

--- a/storage/tianmu/types/rc_num.h
+++ b/storage/tianmu/types/rc_num.h
@@ -81,7 +81,9 @@ class RCNum : public ValueBasic<RCNum> {
   short Scale() const { return scale_; }
   int64_t ValueInt() const { return value_; }
   char *GetDataBytesPointer() const override { return (char *)&value_; }
-  int64_t GetIntPart() const { return is_double_ ? (int64_t)GetIntPartAsDouble() : value_ / (int64_t)Uint64PowOfTen(scale_); }
+  int64_t GetIntPart() const {
+    return is_double_ ? (int64_t)GetIntPartAsDouble() : value_ / (int64_t)Uint64PowOfTen(scale_);
+  }
 
   int64_t GetValueInt64() const { return value_; }
   double GetIntPartAsDouble() const;

--- a/storage/tianmu/types/text_stat.cpp
+++ b/storage/tianmu/types/text_stat.cpp
@@ -68,8 +68,7 @@ void TextStat::AddLen(int pos)  // value of len n puts 0 on position n (starting
 }
 
 // return false if cannot create encoding (too wide), do not actually create anything
-bool TextStat::CheckIfCreatePossible()
-{
+bool TextStat::CheckIfCreatePossible() {
   if (chars_found_for_decoding_) {
     valid_ = false;
     return false;
@@ -110,7 +109,7 @@ bool TextStat::CreateEncoding() {
     for (int i = 0; i < 256; i++) {
       if (chars_found_[256 * pos + i] == 1) {
         encode_table_[i + 256 * pos] = len_table_[pos];  // Encoding a string: Code(character c) =
-                                                       // encode_table_[c][pos]
+                                                         // encode_table_[c][pos]
         // Note: initial value of 255 means "illegal character", so we must not
         // allow to use such code value
         if (len_table_[pos] == 255) {

--- a/storage/tianmu/types/text_stat.h
+++ b/storage/tianmu/types/text_stat.h
@@ -44,10 +44,10 @@ class TextStat final {
                                  // reset temporary statistics
 
   int64_t Encode(const BString &rcbs,
-                 bool round_up = false);  // return common::NULL_VALUE_64 if not
-                                          // encodable, round_up = true =>
-                                          // fill the unused characters by
-                                          // max codes
+                 bool round_up = false);   // return common::NULL_VALUE_64 if not
+                                           // encodable, round_up = true =>
+                                           // fill the unused characters by
+                                           // max codes
   int64_t MaxCode() { return max_code_; }  // return the maximal code which may occur
   BString Decode(int64_t code);
 

--- a/storage/tianmu/types/value_parser4txt.cpp
+++ b/storage/tianmu/types/value_parser4txt.cpp
@@ -33,7 +33,7 @@ static int String2DateTime(const BString &s, RCDateTime &rcdt, common::CT at) {
     return 1;
   }
 
-  if ((at == common::CT::TIMESTAMP) && !validate_my_time(myt)) { // stonedb8
+  if ((at == common::CT::TIMESTAMP) && !validate_my_time(myt)) {  // stonedb8
     rcdt = RCDateTime(0, common::CT::TIMESTAMP);
     return 0;
   }
@@ -671,12 +671,12 @@ common::ErrorCode ValueParserForText::ParseDateTimeOrTimestamp(const BString &rc
   if (!EatWhiteSigns(buf, buflen) && !system::EatDTSeparators(buf, buflen)) {
     if ((at == common::CT::DATETIME &&
          RCDateTime::IsCorrectTIANMUDatetime((short)year, month, day, RCDateTime::GetSpecialValue(at).Hour(),
-                                          RCDateTime::GetSpecialValue(at).Minute(),
-                                          RCDateTime::GetSpecialValue(at).Second())) ||
+                                             RCDateTime::GetSpecialValue(at).Minute(),
+                                             RCDateTime::GetSpecialValue(at).Second())) ||
         (at == common::CT::TIMESTAMP &&
          RCDateTime::IsCorrectTIANMUTimestamp((short)year, month, day, RCDateTime::GetSpecialValue(at).Hour(),
-                                           RCDateTime::GetSpecialValue(at).Minute(),
-                                           RCDateTime::GetSpecialValue(at).Second())))
+                                              RCDateTime::GetSpecialValue(at).Minute(),
+                                              RCDateTime::GetSpecialValue(at).Second())))
       rcv = RCDateTime((short)year, month, day, RCDateTime::GetSpecialValue(at).Hour(),
                        RCDateTime::GetSpecialValue(at).Minute(), RCDateTime::GetSpecialValue(at).Second(), at);
     return common::ErrorCode::OUT_OF_RANGE;
@@ -738,7 +738,7 @@ common::ErrorCode ValueParserForText::ParseDateTimeOrTimestamp(const BString &rc
   try {
     if (at == common::CT::DATETIME) {
       if (RCDateTime::IsCorrectTIANMUDatetime((short)year, (short)month, (short)day, (short)hour, (short)minute,
-                                           (short)second)) {
+                                              (short)second)) {
         rcv = RCDateTime((short)year, (short)month, (short)day, (short)hour, (short)minute, (short)second, at);
         return tianmu_rc;
       } else {
@@ -749,7 +749,7 @@ common::ErrorCode ValueParserForText::ParseDateTimeOrTimestamp(const BString &rc
       }
     } else if (at == common::CT::TIMESTAMP) {
       if (RCDateTime::IsCorrectTIANMUTimestamp((short)year, (short)month, (short)day, (short)hour, (short)minute,
-                                            (short)second)) {
+                                               (short)second)) {
         // convert to UTC
         MYSQL_TIME myt;
         std::memset(&myt, 0, sizeof(MYSQL_TIME));

--- a/storage/tianmu/types/value_parser4txt.h
+++ b/storage/tianmu/types/value_parser4txt.h
@@ -27,8 +27,8 @@ namespace Tianmu {
 namespace types {
 class ValueParserForText {
  public:
-  ValueParserForText(){}
-  virtual ~ValueParserForText(){}
+  ValueParserForText() {}
+  virtual ~ValueParserForText() {}
 
   static auto GetParsingFuntion(const core::AttributeTypeInfo &at)
       -> std::function<common::ErrorCode(BString const &, int64_t &)> {

--- a/storage/tianmu/util/fs.h
+++ b/storage/tianmu/util/fs.h
@@ -22,6 +22,6 @@
 
 namespace Tianmu {
 namespace fs = std::experimental::filesystem;
-}  //namespace Tianmu
+}  // namespace Tianmu
 
 #endif  // TIANMU_UTIL_FS_H_

--- a/storage/tianmu/util/log_ctl.cpp
+++ b/storage/tianmu/util/log_ctl.cpp
@@ -49,8 +49,8 @@ logger::LogCtl_Level LogCtl::GetGlobalLevel() {
 }
 
 bool LogCtl::LogEnabled(logger::LogCtl_Level level) {
-// there is issue with TLS in thread pool so we disable session log level until
-// a fix is available.
+  // there is issue with TLS in thread pool so we disable session log level until
+  // a fix is available.
   return tianmu_sysvar_global_debug_level >= static_cast<int>(level);
 }
 
@@ -64,7 +64,7 @@ void LogCtl::LogMsg(logger::LogCtl_Level level, const char *file, int line, cons
     if (static_cast<size_t>(length) >= MAX_LOG_LEN) length = MAX_LOG_LEN - 1;
     buff[length] = '\0';
     tianmulog << system::lock << "[" << logger::get_level_str(level) << "] [" << basename(file) << ":" << line
-               << "] MSG: " << buff << system::unlock;
+              << "] MSG: " << buff << system::unlock;
     va_end(args);
   }
 }
@@ -78,7 +78,7 @@ void LogCtl::LogMsg(logger::LogCtl_Level level, const std::string &msg) {
 void LogCtl::LogMsg(logger::LogCtl_Level level, const char *file, int line, const std::string &msg) {
   if (LogEnabled(level)) {
     tianmulog << system::lock << "[" << logger::get_level_str(level) << "] [" << basename(file) << ":" << line
-               << "] MSG: " << msg << system::unlock;
+              << "] MSG: " << msg << system::unlock;
   }
 }
 

--- a/storage/tianmu/util/mapped_circular_buffer.h
+++ b/storage/tianmu/util/mapped_circular_buffer.h
@@ -36,9 +36,7 @@ namespace utils {
 
 // a memory-mapped circular buffer, support single-read, multiple write
 class MappedCircularBuffer {
-  static inline size_t round_up(size_t n, size_t multiple) { 
-     return ((n + multiple - 1) / multiple) * multiple; 
-  }
+  static inline size_t round_up(size_t n, size_t multiple) { return ((n + multiple - 1) / multiple) * multiple; }
 
  public:
   MappedCircularBuffer() = delete;
@@ -96,7 +94,6 @@ class MappedCircularBuffer {
     GetStat();
   }
 
-
   void Write(TAG tag, const void *data, size_t sz) {
     if (sz > MAX_BUF_SIZE) {
       throw std::invalid_argument("write data buffer size (" + std::to_string(sz) + ") exceeds system defined size");
@@ -126,7 +123,7 @@ class MappedCircularBuffer {
     ptr += sizeof(TAG);
     *(uint32_t *)ptr = sz;
     ptr += sizeof(uint32_t);
-    *(uint64_t *)ptr = 0;  
+    *(uint64_t *)ptr = 0;
     ptr += sizeof(uint64_t);
     std::memcpy(ptr, data, sz);
     hdr->write_offset += total_len;
@@ -263,7 +260,7 @@ class MappedCircularBuffer {
     std::atomic_ulong read_bytes{0};
   } stat;
 
-private:
+ private:
   uchar *start_addr_;
   std::mutex write_mutex_;
   int fd_;

--- a/storage/tianmu/util/qsort.h
+++ b/storage/tianmu/util/qsort.h
@@ -110,6 +110,8 @@ static void __quicksort_tianmu(char *b, int lo, int hi, int s, comp_func_tianmu 
 }
 
 // buf, total elements, element size, compare function
-static void qsort_tianmu(void *b, int l, int s, comp_func_tianmu cmpsrt) { __quicksort_tianmu((char *)b, 0, l - 1, s, cmpsrt, 0); }
+static void qsort_tianmu(void *b, int l, int s, comp_func_tianmu cmpsrt) {
+  __quicksort_tianmu((char *)b, 0, l - 1, s, cmpsrt, 0);
+}
 
 #endif  // TIANMU_UTIL_QSORT_H_

--- a/storage/tianmu/util/thread_pool.h
+++ b/storage/tianmu/util/thread_pool.h
@@ -77,7 +77,7 @@ class thread_pool final {
   bool is_owner() const { return tp_owner_ == this; }
 
   template <class F, class... Args>
-  auto add_task(F &&f, Args &&...args) -> std::future<typename std::result_of<F(Args...)>::type> {
+  auto add_task(F &&f, Args &&... args) -> std::future<typename std::result_of<F(Args...)>::type> {
     if (tp_owner_ == this) throw std::logic_error("add task in worker thread");
 
     auto task = std::make_shared<std::packaged_task<typename std::result_of<F(Args...)>::type()>>(

--- a/storage/tianmu/vc/const_expr_column.cpp
+++ b/storage/tianmu/vc/const_expr_column.cpp
@@ -118,8 +118,8 @@ size_t ConstExpressionColumn::MaxStringSizeImpl()  // maximal byte string length
   return ct.GetPrecision();
 }
 
-core::PackOntologicalStatus ConstExpressionColumn::GetPackOntologicalStatusImpl(
-    [[maybe_unused]] const core::MIIterator &mit) {
+core::PackOntologicalStatus ConstExpressionColumn::GetPackOntologicalStatusImpl([
+    [maybe_unused]] const core::MIIterator &mit) {
   if (last_val->IsNull()) return core::PackOntologicalStatus::NULLS_ONLY;
   return core::PackOntologicalStatus::UNIFORM;
 }

--- a/storage/tianmu/vc/expr_column.h
+++ b/storage/tianmu/vc/expr_column.h
@@ -110,7 +110,9 @@ class ExpressionColumn : public VirtualColumn {
     return common::ErrorCode::FAILED;
   }
 
-  const core::MysqlExpression::tianmu_fields_cache_t &GetTIANMUItems() const override { return expr_->GetTIANMUItems(); }
+  const core::MysqlExpression::tianmu_fields_cache_t &GetTIANMUItems() const override {
+    return expr_->GetTIANMUItems();
+  }
   core::MysqlExpression *expr_;  //!= NULL if ExpressionColumn encapsulates an expression. Note - a
                                  //! constant is an expression
 

--- a/storage/tianmu/vc/subselect_column.cpp
+++ b/storage/tianmu/vc/subselect_column.cpp
@@ -156,8 +156,8 @@ size_t SubSelectColumn::MaxStringSizeImpl()  // maximal byte string length in co
   return ct.GetPrecision();
 }
 
-core::PackOntologicalStatus SubSelectColumn::GetPackOntologicalStatusImpl(
-    [[maybe_unused]] const core::MIIterator &mit) {
+core::PackOntologicalStatus SubSelectColumn::GetPackOntologicalStatusImpl([
+    [maybe_unused]] const core::MIIterator &mit) {
   return core::PackOntologicalStatus::NORMAL;
 }
 

--- a/storage/tianmu/vc/virtual_column_base.h
+++ b/storage/tianmu/vc/virtual_column_base.h
@@ -72,7 +72,7 @@ class VirtualColumnBase : public core::Column {
 
   enum class single_col_t { SC_NOT = 0, SC_ATTR, SC_RCATTR };
 
-  virtual ~VirtualColumnBase(){}
+  virtual ~VirtualColumnBase() {}
 
   /////////////// Data access //////////////////////
 
@@ -321,7 +321,7 @@ class VirtualColumnBase : public core::Column {
   //! \brief Assign a value to a parameter
   //! It is up the to column user to set values of all the parameters before
   //! requesting any value from the column
-  virtual void SetParamTypes([[maybe_unused]] core::MysqlExpression::TypOfVars *types){}
+  virtual void SetParamTypes([[maybe_unused]] core::MysqlExpression::TypOfVars *types) {}
 
   /*! Mark as true each dimension used as source for variables in this
    * VirtualColumn


### PR DESCRIPTION
<!--

Thank you for contributing to StoneDB!

PR Title Format: <type>(<scope>): description to this pr (#issue_id)
e.g.
fix(util): fix sth..... (#1)

-->

## Summary about this PR
<!--

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".
e.g.:
Issue: close #1

-->

Issue Number: close #618

The total source file number is  **509**, the number of file actually need to be formatted is **140**;
```
root@ub01:/data/codebase/stonedb80/stonedb/storage/tianmu# find . -name *.h |wc
    313     313    7351
root@ub01:/data/codebase/stonedb80/stonedb/storage/tianmu# find . -name *.cpp |wc
    192     192    4839
root@ub01:/data/codebase/stonedb80/stonedb/storage/tianmu# find . -name *.hpp |wc
      0       0       0
root@ub01:/data/codebase/stonedb80/stonedb/storage/tianmu# find . -name *.cc |wc
      1       1      22
```

in storage\tianmu directory, execute the three command as below:
```
find . -name *.h  |xargs -i -n 1 clang-format --style=file -i {}
find . -name *.cpp  |xargs -i -n 1 clang-format --style=file -i {}
find . -name *.cc  |xargs -i -n 1 clang-format --style=file -i {}
```


## Tests Check List
<!-- At least one of next options must be included. -->

- [ ] Unit test
- [ ] Integration test
- [X] Manual test (add detailed scripts or steps below)
- [ ] No code

## Changelog
<!-- At least one of next options must be included. -->

- [X] New Feature
- [ ] Bug Fix
- [ ] Improvement
- [ ] Performance Improvement
- [ ] Build/Testing/CI/CD
- [ ] Documentation
- [ ] Not for changelog (changelog entry is not required)

## Documentation
<!-- At least one of next options must be included. -->

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
