### PR TITLE
fix(tianmu): Fix errors in the Q4 (exists subquery) and Q16  query result (#330, #331)

### DIFF
--- a/storage/tianmu/core/joiner.cpp
+++ b/storage/tianmu/core/joiner.cpp
@@ -48,7 +48,7 @@ JoinAlgType TwoDimensionalJoiner::ChooseJoinAlgorithm([[maybe_unused]] MultiInde
   });
 
   if (cond[0].IsType_Exists()) {
-    return choose_map_or_hash();
+    return JoinAlgType::JTYPE_GENERAL;  // nested loop
   }
 
   if (cond[0].IsType_In()) {

--- a/storage/tianmu/core/temp_table.cpp
+++ b/storage/tianmu/core/temp_table.cpp
@@ -2150,7 +2150,7 @@ TempTableForSubquery::~TempTableForSubquery() {
   for (uint i = 0; i < template_attrs.size(); i++) delete template_attrs[i];
 }
 
-void TempTableForSubquery::ResetToTemplate(bool rough) {
+void TempTableForSubquery::ResetToTemplate(bool rough, bool use_filter_shallow) {
   if (!template_filter) return;
 
   for (uint i = no_global_virt_cols; i < virt_cols.size(); i++) delete virt_cols[i];
@@ -2165,8 +2165,13 @@ void TempTableForSubquery::ResetToTemplate(bool rough) {
     (*attrs[i]).buffer = orig_buf;
   }
 
-  filter = std::move(*template_filter); // shallow
-  filter_shallow_memory = true;
+  if (use_filter_shallow) {
+    filter = std::move(*template_filter); // shallow
+    filter_shallow_memory = true;
+  } else {
+    filter = *template_filter;
+    filter_shallow_memory = false;
+  }
 
   for (int i = 0; i < no_global_virt_cols; i++)
     if (!virt_cols_for_having[i]) virt_cols[i]->SetMultiIndex(filter.mind);

--- a/storage/tianmu/core/temp_table.h
+++ b/storage/tianmu/core/temp_table.h
@@ -510,7 +510,7 @@ class TempTableForSubquery : public TempTable {
   void CreateTemplateIfNotExists();
   void Materialize(bool in_subq = false, ResultSender *sender = NULL, bool lazy = false) override;
   void RoughMaterialize(bool in_subq = false, ResultSender *sender = NULL, bool lazy = false) override;
-  void ResetToTemplate(bool rough);
+  void ResetToTemplate(bool rough, bool use_filter_shallow = false);
   void SetAttrsForRough();
   void SetAttrsForExact();
 


### PR DESCRIPTION
Q4 uses the EXISTS subquery
and previously optimized the EXISTS scenario using a parallel Hash Join, but an exception was found in the result set.
Roll back the EXISTS process to a NEstd loop,
and the query result is restored.
This time in advance to ensure the correctness.
On the basis of ensuring correctness,
the optimization of performance is considered.


## Q4

### Mysql/Innodb query result

```sql

mysql>     select
    ->         o_orderpriority,
    ->         count(*) as order_count
    ->     from
    ->         orders
    ->     where
    ->         o_orderdate >= date '1993-07-01'
    ->         and o_orderdate < date '1993-07-01' + interval '3' month
    ->         and exists (
    ->             select
    ->                 *
    ->             from
    ->                 lineitem
    ->             where
    ->                 l_orderkey = o_orderkey
    ->                 and l_commitdate < l_receiptdate
    ->         )
    ->     group by
    ->         o_orderpriority
    ->     order by
    ->         o_orderpriority
    ->     limit 100;

+-----------------+-------------+
| o_orderpriority | order_count |
+-----------------+-------------+
| 1-URGENT        |       57865 |
| 2-HIGH          |       57520 |
| 3-MEDIUM        |       57514 |
| 4-NOT SPECIFIED |       57900 |
| 5-LOW           |       57981 |
+-----------------+-------------+
5 rows in set (32.88 sec)


```

### Query results before optimization


![image](https://user-images.githubusercontent.com/3915817/192990703-1e0d1497-45e9-4ad2-8ac4-e89815e9645d.png)



### Stonedb Current query results:

 

```sql

mysql>         select
    ->             o_orderpriority,
    ->             count(*) as order_count
    ->         from
    ->             orders
    ->         where
    ->             o_orderdate >= date '1993-07-01'
    ->             and o_orderdate < date '1993-07-01' + interval '3' month
    ->             and exists (
    ->                 select
    ->                     *
    ->                 from
    ->                     lineitem
    ->                 where
    ->                     l_orderkey = o_orderkey
    ->                     and l_commitdate < l_receiptdate
    ->             )
    ->         group by
    ->             o_orderpriority
    ->         order by
    ->             o_orderpriority
    ->         limit 100;

+-----------------+-------------+
| o_orderpriority | order_count |
+-----------------+-------------+
| 1-URGENT        |       63225 |
| 2-HIGH          |       62671 |
| 3-MEDIUM        |       62736 |
| 4-NOT SPECIFIED |       63166 |
| 5-LOW           |       63167 |
+-----------------+-------------+
5 rows in set (2 min 58.34 sec)


```


## Q16


### mysql/innodb query result

```sql

mysql>         select
    ->             p_brand,
    ->             p_type,
    ->             p_size,
    ->             count(distinct ps_suppkey) as supplier_cnt
    ->         from
    ->             partsupp,
    ->             part
    ->         where
    ->             p_partkey = ps_partkey
    ->             and p_brand <> 'Brand#45'
    ->             and p_type not like 'MEDIUM POLISHED%'
    ->             and p_size in (49, 14, 23, 45, 19, 3, 36, 9)
    ->             and ps_suppkey not in (
    ->                 select
    ->                     s_suppkey
    ->                 from
    ->                     supplier
    ->                 where
    ->                     s_comment like '%Customer%Complaints%'
    ->             )
    ->         group by
    ->             p_brand,
    ->             p_type,
    ->             p_size
    ->         order by
    ->             supplier_cnt desc,
    ->             p_brand,
    ->             p_type,
    ->             p_size
    ->         limit 10;
+----------+--------------------------+--------+--------------+
| p_brand  | p_type                   | p_size | supplier_cnt |
+----------+--------------------------+--------+--------------+
| Brand#44 | STANDARD PLATED TIN      |      9 |          120 |
| Brand#12 | STANDARD POLISHED COPPER |     14 |          100 |
| Brand#11 | LARGE BRUSHED STEEL      |     36 |           96 |
| Brand#23 | PROMO BURNISHED STEEL    |     14 |           96 |
| Brand#34 | MEDIUM BRUSHED STEEL     |     23 |           96 |
| Brand#53 | PROMO BURNISHED BRASS    |     36 |           96 |
| Brand#54 | STANDARD BRUSHED COPPER  |     19 |           96 |
| Brand#32 | LARGE POLISHED COPPER    |     14 |           95 |
| Brand#43 | LARGE PLATED COPPER      |     19 |           95 |
| Brand#11 | SMALL BRUSHED STEEL      |      9 |           92 |
+----------+--------------------------+--------+--------------+
10 rows in set (26.00 sec)



```


### stonedb query result


```sql


mysql>         select
    ->             p_brand,
    ->             p_type,
    ->             p_size,
    ->             count(distinct ps_suppkey) as supplier_cnt
    ->         from
    ->             partsupp,
    ->             part
    ->         where
    ->             p_partkey = ps_partkey
    ->             and p_brand <> 'Brand#45'
    ->             and p_type not like 'MEDIUM POLISHED%'
    ->             and p_size in (49, 14, 23, 45, 19, 3, 36, 9)
    ->             and ps_suppkey not in (
    ->                 select
    ->                     s_suppkey
    ->                 from
    ->                     supplier
    ->                 where
    ->                     s_comment like '%Customer%Complaints%'
    ->             )
    ->         group by
    ->             p_brand,
    ->             p_type,
    ->             p_size
    ->         order by
    ->             supplier_cnt desc,
    ->             p_brand,
    ->             p_type,
    ->             p_size
    ->         limit 10;
+----------+--------------------------+--------+--------------+
| p_brand  | p_type                   | p_size | supplier_cnt |
+----------+--------------------------+--------+--------------+
| Brand#44 | STANDARD PLATED TIN      |      9 |          120 |
| Brand#12 | STANDARD POLISHED COPPER |     14 |          100 |
| Brand#11 | LARGE BRUSHED STEEL      |     36 |           96 |
| Brand#23 | PROMO BURNISHED STEEL    |     14 |           96 |
| Brand#34 | MEDIUM BRUSHED STEEL     |     23 |           96 |
| Brand#53 | PROMO BURNISHED BRASS    |     36 |           96 |
| Brand#54 | STANDARD BRUSHED COPPER  |     19 |           96 |
| Brand#32 | LARGE POLISHED COPPER    |     14 |           95 |
| Brand#43 | LARGE PLATED COPPER      |     19 |           95 |
| Brand#11 | SMALL BRUSHED STEEL      |      9 |           92 |
+----------+--------------------------+--------+--------------+
10 rows in set (54.52 sec)


```



<!--

Thank you for contributing to StoneDB!

PR Title Format: <type>(<scope>): description to this pr (#issue_id)
e.g.
fix(util): fix sth..... (#1)

-->

## Summary about this PR
<!--

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".
e.g.:
Issue: close #1

-->

Issue Number: close #330 #331 


## Tests Check List
<!-- At least one of next options must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

## Changelog
<!-- At least one of next options must be included. -->

- [ ] New Feature
- [x] Bug Fix
- [x] Improvement
- [ ] Performance Improvement
- [ ] Build/Testing/CI/CD
- [ ] Documentation
- [ ] Not for changelog (changelog entry is not required)

## Documentation
<!-- At least one of next options must be included. -->

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
