### PR TITLE
fix(tianmu): Fix errors in the Q2/Q16/Q17/Q18/Q20/Q22 query result (#330, #331) 

### DIFF
--- a/storage/tianmu/core/dimension_group.cpp
+++ b/storage/tianmu/core/dimension_group.cpp
@@ -100,7 +100,7 @@ DimensionGroup *DimensionGroupMaterialized::Clone(bool shallow) {
         new_value->t[i] = t[i];
       } else {
         new_value->t[i] = new IndexTable(*t[i]);
-      }s
+      }
       t[i]->Unlock();
     }
   }

--- a/storage/tianmu/core/dimension_group.cpp
+++ b/storage/tianmu/core/dimension_group.cpp
@@ -94,13 +94,13 @@ DimensionGroup *DimensionGroupMaterialized::Clone(bool shallow) {
   for (int i = 0; i < no_dims; i++) {
     if (t[i]) {
       new_value->nulls_possible[i] = nulls_possible[i];
-      t[i]->Lock();
       if (shallow) {
         new_value->t[i] = t[i];
       } else {
+        t[i]->Lock();
         new_value->t[i] = new IndexTable(*t[i]);
+        t[i]->Unlock();
       }
-      t[i]->Unlock();
     }
   }
   return new_value;

--- a/storage/tianmu/core/dimension_group.cpp
+++ b/storage/tianmu/core/dimension_group.cpp
@@ -91,12 +91,16 @@ DimensionGroupMaterialized::DimensionGroupMaterialized(DimensionVector &dims) {
 DimensionGroup *DimensionGroupMaterialized::Clone(bool shallow) {
   DimensionGroupMaterialized *new_value = new DimensionGroupMaterialized(dims_used);
   new_value->no_obj = no_obj;
-  if (shallow) return new_value;
+  // if (shallow) return new_value;
   for (int i = 0; i < no_dims; i++) {
     if (t[i]) {
       new_value->nulls_possible[i] = nulls_possible[i];
       t[i]->Lock();
-      new_value->t[i] = new IndexTable(*t[i]);
+      if (shallow) {
+        new_value->t[i] = t[i];
+      } else {
+        new_value->t[i] = new IndexTable(*t[i]);
+      }s
       t[i]->Unlock();
     }
   }

--- a/storage/tianmu/core/dimension_group.cpp
+++ b/storage/tianmu/core/dimension_group.cpp
@@ -91,7 +91,6 @@ DimensionGroupMaterialized::DimensionGroupMaterialized(DimensionVector &dims) {
 DimensionGroup *DimensionGroupMaterialized::Clone(bool shallow) {
   DimensionGroupMaterialized *new_value = new DimensionGroupMaterialized(dims_used);
   new_value->no_obj = no_obj;
-  // if (shallow) return new_value;
   for (int i = 0; i < no_dims; i++) {
     if (t[i]) {
       new_value->nulls_possible[i] = nulls_possible[i];

--- a/storage/tianmu/core/joiner.cpp
+++ b/storage/tianmu/core/joiner.cpp
@@ -48,7 +48,7 @@ JoinAlgType TwoDimensionalJoiner::ChooseJoinAlgorithm([[maybe_unused]] MultiInde
   });
 
   if (cond[0].IsType_Exists()) {
-    return choose_map_or_hash();
+    return JoinAlgType::JTYPE_GENERAL;  // nested loop
   }
 
   if (cond[0].IsType_In()) {

--- a/storage/tianmu/core/joiner.cpp
+++ b/storage/tianmu/core/joiner.cpp
@@ -52,7 +52,7 @@ JoinAlgType TwoDimensionalJoiner::ChooseJoinAlgorithm([[maybe_unused]] MultiInde
   }
 
   if (cond[0].IsType_In()) {
-    return JoinAlgType::JTYPE_GENERAL; // nested loop
+    return JoinAlgType::JTYPE_GENERAL;  // nested loop
   }
 
   if (!cond[0].IsType_JoinSimple()) {

--- a/storage/tianmu/core/multi_index.cpp
+++ b/storage/tianmu/core/multi_index.cpp
@@ -255,7 +255,8 @@ void MultiIndex::LockForGetIndex(int dim) {
   if (shallow_dim_groups) {
     return;
   }
-  group_for_dim[dim]->Lock(dim); }
+  group_for_dim[dim]->Lock(dim); 
+}
 
 void MultiIndex::UnlockFromGetIndex(int dim) {
   if (shallow_dim_groups) {

--- a/storage/tianmu/core/multi_index.cpp
+++ b/storage/tianmu/core/multi_index.cpp
@@ -38,6 +38,7 @@ MultiIndex::MultiIndex(uint32_t power) : m_conn(current_txn_) {
   group_for_dim = NULL;
   group_num_for_dim = NULL;
   iterator_lock = 0;
+  shallow_dim_groups = false;
 }
 
 MultiIndex::MultiIndex(const MultiIndex &s) : m_conn(s.m_conn) {
@@ -62,6 +63,7 @@ MultiIndex::MultiIndex(const MultiIndex &s) : m_conn(s.m_conn) {
     group_num_for_dim = NULL;
   }
   iterator_lock = 0;
+  shallow_dim_groups = false;
 }
 
 MultiIndex::MultiIndex(MultiIndex &s, bool shallow) : m_conn(s.m_conn) {
@@ -86,12 +88,15 @@ MultiIndex::MultiIndex(MultiIndex &s, bool shallow) : m_conn(s.m_conn) {
     group_num_for_dim = NULL;
   }
   iterator_lock = 0;
+  shallow_dim_groups = shallow;
 }
 
 MultiIndex::~MultiIndex() {
-  for (uint i = 0; i < dim_groups.size(); i++) {
-    delete dim_groups[i];
-    dim_groups[i] = NULL;
+  if (!shallow_dim_groups) {
+    for (uint i = 0; i < dim_groups.size(); i++) {
+      delete dim_groups[i];
+      dim_groups[i] = NULL;
+    }
   }
   delete[] dim_size;
   delete[] group_for_dim;
@@ -246,9 +251,18 @@ void MultiIndex::CheckIfVirtualCanBeDistinct()  // updates can_be_distinct table
   }
 }
 
-void MultiIndex::LockForGetIndex(int dim) { group_for_dim[dim]->Lock(dim); }
+void MultiIndex::LockForGetIndex(int dim) {
+  if (shallow_dim_groups) {
+    return;
+  }
+  group_for_dim[dim]->Lock(dim); }
 
-void MultiIndex::UnlockFromGetIndex(int dim) { group_for_dim[dim]->Unlock(dim); }
+void MultiIndex::UnlockFromGetIndex(int dim) {
+  if (shallow_dim_groups) {
+    return;
+  }
+  group_for_dim[dim]->Unlock(dim);
+}
 
 uint64_t MultiIndex::DimSize(int dim)  // the size of one dimension: material_no_tuples for materialized,
                                        // NumOfOnes for virtual
@@ -257,10 +271,16 @@ uint64_t MultiIndex::DimSize(int dim)  // the size of one dimension: material_no
 }
 
 void MultiIndex::LockAllForUse() {
+  if (shallow_dim_groups) {
+    return;
+  }
   for (int dim = 0; dim < no_dimensions; dim++) LockForGetIndex(dim);
 }
 
 void MultiIndex::UnlockAllFromUse() {
+  if (shallow_dim_groups) {
+    return;
+  }
   for (int dim = 0; dim < no_dimensions; dim++) UnlockFromGetIndex(dim);
 }
 

--- a/storage/tianmu/core/multi_index.cpp
+++ b/storage/tianmu/core/multi_index.cpp
@@ -251,16 +251,14 @@ void MultiIndex::CheckIfVirtualCanBeDistinct()  // updates can_be_distinct table
   }
 }
 
-void MultiIndex::LockForGetIndex(int dim) 
-{
+void MultiIndex::LockForGetIndex(int dim) {
   if (shallow_dim_groups) {
     return;
   }
-  group_for_dim[dim]->Lock(dim); 
+  group_for_dim[dim]->Lock(dim);
 }
 
-void MultiIndex::UnlockFromGetIndex(int dim) 
-{
+void MultiIndex::UnlockFromGetIndex(int dim) {
   if (shallow_dim_groups) {
     return;
   }
@@ -273,16 +271,14 @@ uint64_t MultiIndex::DimSize(int dim)  // the size of one dimension: material_no
   return group_for_dim[dim]->NumOfTuples();
 }
 
-void MultiIndex::LockAllForUse() 
-{
+void MultiIndex::LockAllForUse() {
   if (shallow_dim_groups) {
     return;
   }
   for (int dim = 0; dim < no_dimensions; dim++) LockForGetIndex(dim);
 }
 
-void MultiIndex::UnlockAllFromUse() 
-{
+void MultiIndex::UnlockAllFromUse() {
   if (shallow_dim_groups) {
     return;
   }
@@ -333,7 +329,7 @@ void MultiIndex::UpdateNumOfTuples() {
 }
 
 int64_t MultiIndex::NumOfTuples(DimensionVector &dimensions,
-                             bool fail_on_overflow)  // for a given subset of dimensions
+                                bool fail_on_overflow)  // for a given subset of dimensions
 {
   std::vector<int> dg = ListInvolvedDimGroups(dimensions);
   if (dg.size() == 0) return 0;
@@ -347,7 +343,7 @@ int64_t MultiIndex::NumOfTuples(DimensionVector &dimensions,
 }
 
 int MultiIndex::MaxNumOfPacks(int dim)  // maximal (upper approx.) number of different nonempty data
-                                     // packs for the given dimension
+                                        // packs for the given dimension
 {
   int max_packs = 0;
   Filter *f = group_for_dim[dim]->GetFilter(dim);

--- a/storage/tianmu/core/multi_index.cpp
+++ b/storage/tianmu/core/multi_index.cpp
@@ -251,14 +251,16 @@ void MultiIndex::CheckIfVirtualCanBeDistinct()  // updates can_be_distinct table
   }
 }
 
-void MultiIndex::LockForGetIndex(int dim) {
+void MultiIndex::LockForGetIndex(int dim) 
+{
   if (shallow_dim_groups) {
     return;
   }
   group_for_dim[dim]->Lock(dim); 
 }
 
-void MultiIndex::UnlockFromGetIndex(int dim) {
+void MultiIndex::UnlockFromGetIndex(int dim) 
+{
   if (shallow_dim_groups) {
     return;
   }
@@ -271,14 +273,16 @@ uint64_t MultiIndex::DimSize(int dim)  // the size of one dimension: material_no
   return group_for_dim[dim]->NumOfTuples();
 }
 
-void MultiIndex::LockAllForUse() {
+void MultiIndex::LockAllForUse() 
+{
   if (shallow_dim_groups) {
     return;
   }
   for (int dim = 0; dim < no_dimensions; dim++) LockForGetIndex(dim);
 }
 
-void MultiIndex::UnlockAllFromUse() {
+void MultiIndex::UnlockAllFromUse() 
+{
   if (shallow_dim_groups) {
     return;
   }

--- a/storage/tianmu/core/multi_index.h
+++ b/storage/tianmu/core/multi_index.h
@@ -54,7 +54,7 @@ class MultiIndex {
     return 0;
   }
   int64_t NumOfTuples(DimensionVector &dimensions,
-                   bool fail_on_overflow = true);  // for a given subset of dimensions
+                      bool fail_on_overflow = true);  // for a given subset of dimensions
 
   bool ZeroTuples() { return (!no_tuples_too_big && no_tuples == 0); }
   bool TooManyTuples() { return no_tuples_too_big; }
@@ -135,8 +135,8 @@ class MultiIndex {
   // material_no_tuples and the dimensions from the list are deleted
 
   int MaxNumOfPacks(int dim);  // maximal (upper approx.) number of different
-                            // nonempty data packs for the given dimension
-  std::string Display();    // MultiIndex structure: f - Filter, i - IndexTable
+                               // nonempty data packs for the given dimension
+  std::string Display();       // MultiIndex structure: f - Filter, i - IndexTable
 
   Transaction &ConnInfo() const { return *m_conn; }
 
@@ -179,8 +179,8 @@ class MultiIndex {
   void MultiplyNoTuples(uint64_t factor);  // the same as "no_tuples*=factor", but set
                                            // no_tuples_too_big whenever needed
 
-  int iterator_lock;  // 0 - unlocked, >0 - normal iterator exists, -1 -
-                      // updating iterator exists
+  int iterator_lock;        // 0 - unlocked, >0 - normal iterator exists, -1 -
+                            // updating iterator exists
   bool shallow_dim_groups;  // Indicates whether dim_groups is a shallow copy
 };
 }  // namespace core

--- a/storage/tianmu/core/multi_index.h
+++ b/storage/tianmu/core/multi_index.h
@@ -181,6 +181,7 @@ class MultiIndex {
 
   int iterator_lock;  // 0 - unlocked, >0 - normal iterator exists, -1 -
                       // updating iterator exists
+  bool shallow_dim_groups;  // Indicates whether dim_groups is a shallow copy
 };
 }  // namespace core
 }  // namespace Tianmu

--- a/storage/tianmu/core/temp_table.cpp
+++ b/storage/tianmu/core/temp_table.cpp
@@ -2150,7 +2150,7 @@ TempTableForSubquery::~TempTableForSubquery() {
   for (uint i = 0; i < template_attrs.size(); i++) delete template_attrs[i];
 }
 
-void TempTableForSubquery::ResetToTemplate(bool rough) {
+void TempTableForSubquery::ResetToTemplate(bool rough, bool use_filter_shallow) {
   if (!template_filter) return;
 
   for (uint i = no_global_virt_cols; i < virt_cols.size(); i++) delete virt_cols[i];
@@ -2165,8 +2165,13 @@ void TempTableForSubquery::ResetToTemplate(bool rough) {
     (*attrs[i]).buffer = orig_buf;
   }
 
-  filter = std::move(*template_filter); // shallow
-  filter_shallow_memory = true;
+  if (use_filter_shallow) {
+    filter = std::move(*template_filter); // shallow
+    filter_shallow_memory = true;
+  } else {
+    filter = *template_filter;
+    filter_shallow_memory = false;
+  }
 
   for (int i = 0; i < no_global_virt_cols; i++)
     if (!virt_cols_for_having[i]) virt_cols[i]->SetMultiIndex(filter.mind);

--- a/storage/tianmu/core/temp_table.cpp
+++ b/storage/tianmu/core/temp_table.cpp
@@ -570,7 +570,8 @@ int64_t TempTable::Attr::GetMaxInt64(int pack) {
   for (int64_t i = start; i < stop; i++) {
     if (!IsNull(i)) {
       val = GetNotNullValueInt64(i);
-      if ((ATI::IsRealType(ct.GetTypeName()) && (max == common::TIANMU_BIGINT_MIN || *(double *)&val > *(double *)&max)) ||
+      if ((ATI::IsRealType(ct.GetTypeName()) &&
+           (max == common::TIANMU_BIGINT_MIN || *(double *)&val > *(double *)&max)) ||
           (!ATI::IsRealType(ct.GetTypeName()) && val > max))
         max = val;
     }
@@ -588,7 +589,8 @@ int64_t TempTable::Attr::GetMinInt64(int pack) {
   for (int64_t i = start; i < stop; i++) {
     if (!IsNull(i)) {
       val = GetNotNullValueInt64(i);
-      if ((ATI::IsRealType(ct.GetTypeName()) && (min == common::TIANMU_BIGINT_MAX || *(double *)&val < *(double *)&min)) ||
+      if ((ATI::IsRealType(ct.GetTypeName()) &&
+           (min == common::TIANMU_BIGINT_MAX || *(double *)&val < *(double *)&min)) ||
           (!ATI::IsRealType(ct.GetTypeName()) && val < min))
         min = val;
     }
@@ -1248,7 +1250,7 @@ void TempTable::Union(TempTable *t, int all) {
     return;
 
   Filter first_f(NumOfObj(), p_power), first_mask(NumOfObj(),
-                                               p_power);  // mask of objects to be added to the final result set
+                                                  p_power);  // mask of objects to be added to the final result set
   Filter sec_f(t->NumOfObj(), p_power), sec_mask(t->NumOfObj(), p_power);
   first_mask.Set();
   sec_mask.Set();
@@ -1290,8 +1292,8 @@ void TempTable::Union(TempTable *t, int all) {
       }
       input_buf = new uchar[size];
       dist_table.InitializeB(size, NumOfObj() + t->NumOfObj() / 2);  // optimization assumption: a
-                                                               // half of values in the second
-                                                               // table will be repetitions
+                                                                     // half of values in the second
+                                                                     // table will be repetitions
       MIIterator first_mit(&output_mind, p_power);
       MIIterator sec_mit(t->GetOutputMultiIndexP(), p_power);
       // check all objects from the first table
@@ -2166,7 +2168,7 @@ void TempTableForSubquery::ResetToTemplate(bool rough, bool use_filter_shallow) 
   }
 
   if (use_filter_shallow) {
-    filter = std::move(*template_filter); // shallow
+    filter = std::move(*template_filter);  // shallow
     filter_shallow_memory = true;
   } else {
     filter = *template_filter;

--- a/storage/tianmu/core/temp_table.h
+++ b/storage/tianmu/core/temp_table.h
@@ -510,7 +510,7 @@ class TempTableForSubquery : public TempTable {
   void CreateTemplateIfNotExists();
   void Materialize(bool in_subq = false, ResultSender *sender = NULL, bool lazy = false) override;
   void RoughMaterialize(bool in_subq = false, ResultSender *sender = NULL, bool lazy = false) override;
-  void ResetToTemplate(bool rough);
+  void ResetToTemplate(bool rough, bool use_filter_shallow = false);
   void SetAttrsForRough();
   void SetAttrsForExact();
 

--- a/storage/tianmu/handler/tianmu_handler.cpp
+++ b/storage/tianmu/handler/tianmu_handler.cpp
@@ -584,7 +584,6 @@ int TianmuHandler::delete_all_rows() {
   DBUG_RETURN(ret);
 }
 
-
 int TianmuHandler::rename_table(const char *from, const char *to) {
   try {
     ha_rcengine_->RenameTable(current_txn_, from, to, ha_thd());
@@ -1483,7 +1482,7 @@ enum_alter_inplace_result TianmuHandler::check_if_supported_inplace_alter([[mayb
   DBUG_ENTER(__PRETTY_FUNCTION__);
   if ((ha_alter_info->handler_flags & ~TIANMU_SUPPORTED_ALTER_ADD_DROP_ORDER) &&
       (ha_alter_info->handler_flags != TIANMU_SUPPORTED_ALTER_COLUMN_NAME)) {
-    // support alter table column type 
+    // support alter table column type
     if (ha_alter_info->handler_flags & Alter_inplace_info::ALTER_STORED_COLUMN_TYPE)
       DBUG_RETURN(HA_ALTER_INPLACE_NOT_SUPPORTED);
     // support alter table column exceeded length


### PR DESCRIPTION
    There are two reasons for this:
        1. The current parallel Hash join is not perfect for handling the exists subquery
        2. The shallow copy of ParameterizedFilter is not properly processed in the temporary table

the same as https://github.com/stoneatom/stonedb/pull/620

<!--

Thank you for contributing to StoneDB!

PR Title Format: <type>(<scope>): description to this pr (#issue_id)
e.g.
fix(util): fix sth..... (#1)

-->

## Summary about this PR
<!--

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".
e.g.:
Issue: close #1

-->

Issue Number: close #330  #331 


## Tests Check List
<!-- At least one of next options must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

## Changelog
<!-- At least one of next options must be included. -->

- [ ] New Feature
- [x] Bug Fix
- [ ] Improvement
- [ ] Performance Improvement
- [ ] Build/Testing/CI/CD
- [ ] Documentation
- [ ] Not for changelog (changelog entry is not required)

## Documentation
<!-- At least one of next options must be included. -->

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
