### PR TITLE
feat(StoneDB 8.0): Fix up overloaded-virtual warning in function select_tianmu_export::prepare. (#547)

### DIFF
--- a/storage/tianmu/exporter/export2file.cpp
+++ b/storage/tianmu/exporter/export2file.cpp
@@ -26,19 +26,17 @@ namespace exporter {
 select_tianmu_export::select_tianmu_export(Query_result_export *se)
     : Query_result_export(se->get_sql_exchange()), se(se), prepared(false) {}
 
-int select_tianmu_export::prepare(List<Item> &list, Query_expression *u) {
+bool select_tianmu_export::prepare(THD *, const mem_root_deque<Item *> &list, Query_expression *u) {
   bool blob_flag = 0;
   unit = u;
-  {
-    List_iterator_fast<Item> li(list);
-    Item *item;
-    while ((item = li++)) {
-      if (item->max_length >= MAX_BLOB_WIDTH) {
-        blob_flag = 1;
-        break;
-      }
+
+  for (auto &it : list) {
+    if (it->max_length >= MAX_BLOB_WIDTH) {
+      blob_flag = 1;
+      break;
     }
   }
+
   field_term_length = exchange->field.field_term->length();
   if (!exchange->line.line_term->length())
     exchange->line.line_term = exchange->field.field_term;  // Use this if it exists
@@ -52,7 +50,7 @@ int select_tianmu_export::prepare(List<Item> &list, Query_expression *u) {
   fixed_row_size = (!field_term_length && !exchange->field.enclosed->length() && !blob_flag);
 
   prepared = true;
-  return 0;
+  return false;
 }
 
 void select_tianmu_export::SetRowCount(ha_rows x) { row_count = x; }

--- a/storage/tianmu/exporter/export2file.h
+++ b/storage/tianmu/exporter/export2file.h
@@ -29,7 +29,7 @@ class select_tianmu_export : public Query_result_export {
   // select_tianmu_export(sql_exchange *ex);
   select_tianmu_export(Query_result_export *se);
   ~select_tianmu_export() {}
-  int prepare(List<Item> &list, Query_expression *u) /*override*/;
+  bool prepare([[maybe_unused]] THD *, const mem_root_deque<Item *> &list, Query_expression *u) override;
   void SetRowCount(ha_rows x);
   void SendOk(THD *thd);
   sql_exchange *SqlExchange();


### PR DESCRIPTION
<!--

Thank you for contributing to StoneDB!

PR Title Format: <type>(<scope>): description to this pr (#issue_id)
e.g.
fix(util): fix sth..... (#1)

-->

## Summary about this PR
<!--

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".
e.g.:
Issue: close #1

-->

Issue Number: ref #547

prepare function is a virtual function of its base class, should override it but overload it;

## Tests Check List
<!-- At least one of next options must be included. -->

- [ ] Unit test
- [ ] Integration test
- [X] Manual test (add detailed scripts or steps below)
- [ ] No code

## Changelog
<!-- At least one of next options must be included. -->

- [X] New Feature
- [ ] Bug Fix
- [ ] Improvement
- [ ] Performance Improvement
- [ ] Build/Testing/CI/CD
- [ ] Documentation
- [ ] Not for changelog (changelog entry is not required)

## Documentation
<!-- At least one of next options must be included. -->

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
