### PR TITLE
feat(StoneDB 8.0): Fix up format-security/class-memaccess warnings. (#547)

### DIFF
--- a/storage/tianmu/compress/part_dict.cpp
+++ b/storage/tianmu/compress/part_dict.cpp
@@ -101,7 +101,7 @@ void PartDict<T>::Create(DataSet<T> *dataset) {
 
 template <class T>
 int PartDict<T>::compare(const void *p1, const void *p2) {
-  using AK = struct PartDict<T>::HashTab::AKey;
+  using AK = typename PartDict<T>::HashTab::AKey;
   if ((*reinterpret_cast<AK **>(const_cast<void *>(p1)))->count <
       (*reinterpret_cast<AK **>(const_cast<void *>(p2)))->count)
     return 1;

--- a/storage/tianmu/core/dpn.h
+++ b/storage/tianmu/core/dpn.h
@@ -91,12 +91,14 @@ struct DPN final {
 
   // as we are not POD with the atomic long
   DPN() { reset(); }
-  DPN(const DPN &dpn) { std::memcpy(this, &dpn, sizeof(DPN)); }
+  DPN(const DPN &dpn) {
+    std::memcpy(reinterpret_cast<void *>(this), const_cast<void *>(reinterpret_cast<const void *>(&dpn)), sizeof(DPN));
+  }
   DPN &operator=(const DPN &dpn) {
-    std::memcpy(this, &dpn, sizeof(DPN));
+    std::memcpy(reinterpret_cast<void *>(this), const_cast<void *>(reinterpret_cast<const void *>(&dpn)), sizeof(DPN));
     return *this;
   }
-  void reset() { std::memset(this, 0, sizeof(DPN)); }
+  void reset() { std::memset(reinterpret_cast<void *>(this), 0, sizeof(DPN)); }
 };
 
 const uint64_t DPN_INVALID_ADDR = -1;

--- a/storage/tianmu/core/engine.cpp
+++ b/storage/tianmu/core/engine.cpp
@@ -1370,7 +1370,7 @@ void Engine::LogStat() {
           msg + sql_statement_names[c].str + " " + std::to_string(delta) + "/" + std::to_string(sv.com_stat[c]) + ", ";
     }
     msg = msg + "queries " + std::to_string(queries) + "/" + std::to_string(atomic_global_query_id);  // stonedb8
-    TIANMU_LOG(LogCtl_Level::INFO, msg.c_str());
+    TIANMU_LOG(LogCtl_Level::INFO, "%s", msg.c_str());
   }
 
   TIANMU_LOG(LogCtl_Level::INFO,

--- a/storage/tianmu/core/engine_execute.cpp
+++ b/storage/tianmu/core/engine_execute.cpp
@@ -197,7 +197,7 @@ int Engine::Handle_Query(THD *thd, LEX *lex, Query_result *&result, ulong setup_
                     "Error: Query syntax not implemented in Tianmu, can "
                     "export "
                     "only to MySQL format (set TIANMU_DATAFORMAT to 'MYSQL').";
-                TIANMU_LOG(LogCtl_Level::ERROR, err_msg);
+                TIANMU_LOG(LogCtl_Level::ERROR, "%s", err_msg);
                 my_message(ER_SYNTAX_ERROR, err_msg, MYF(0));
                 throw ReturnMeToMySQLWithError();
               }

--- a/storage/tianmu/core/rcattr_exeq_rs.cpp
+++ b/storage/tianmu/core/rcattr_exeq_rs.cpp
@@ -993,7 +993,7 @@ void RCAttr::DisplayAttrStats(Filter *f)  // filter is for # of objects
   ss << "----------------------------------------------------------------------"
         "---------"
      << std::endl;
-  TIANMU_LOG(LogCtl_Level::DEBUG, ss.str().c_str());
+  TIANMU_LOG(LogCtl_Level::DEBUG, "%s", ss.str().c_str());
 }
 }  // namespace core
 }  // namespace Tianmu


### PR DESCRIPTION
<!--

Thank you for contributing to StoneDB!

PR Title Format: <type>(<scope>): description to this pr (#issue_id)
e.g.
fix(util): fix sth..... (#1)

-->

## Summary about this PR
<!--

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".
e.g.:
Issue: close #1

-->

Issue Number: ref #547

feat(StoneDB 8.0): Fix up format-security/class-memaccess warnings. (#547)

1 fix "warning: declaration ‘class Tianmu::compress::PartDict::HashTab::AKey’ does not declare anything";
2 fix "log_ctl.h:49:112: warning: format not a string literal and no format arguments [-Wformat-security]";
3 fix class-memaccess warning;

## Tests Check List
<!-- At least one of next options must be included. -->

- [ ] Unit test
- [ ] Integration test
- [X] Manual test (add detailed scripts or steps below)
- [ ] No code

## Changelog
<!-- At least one of next options must be included. -->

- [X] New Feature
- [ ] Bug Fix
- [ ] Improvement
- [ ] Performance Improvement
- [ ] Build/Testing/CI/CD
- [ ] Documentation
- [ ] Not for changelog (changelog entry is not required)

## Documentation
<!-- At least one of next options must be included. -->

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
