### PR TITLE
fix(StoneDB 8.0): fix ERROR 2013 (HY000): Lost connection to MySQL server during query. (#650)

### DIFF
--- a/storage/tianmu/core/engine.cpp
+++ b/storage/tianmu/core/engine.cpp
@@ -1148,12 +1148,14 @@ static void HandleDelayedLoad(int tid, std::vector<std::unique_ptr<char[]>> &vec
   thd->lex->query_tables = &tl;
   LEX_STRING lex_str = {const_cast<char *>(ex.file_name), addr.size()};
 
-  auto cmd = new (thd->mem_root)
+  thd->lex->m_sql_cmd = new (thd->mem_root)
       Sql_cmd_load_table(ex.filetype, false, lex_str, On_duplicate::ERROR, nullptr, nullptr, nullptr, nullptr, ex.field,
                          ex.line, ex.skip_lines, nullptr, nullptr, nullptr, nullptr);
-  if (cmd->execute(thd)) {
+
+  if (thd->lex->m_sql_cmd->execute(thd)) {
     thd->is_slave_error = 1;
   }
+
   // stonedb8 end
 
   thd->set_catalog({0, 1});  // TIANMU UPGRADE


### PR DESCRIPTION
<!--

Thank you for contributing to StoneDB!

PR Title Format: <type>(<scope>): description to this pr (#issue_id)
e.g.
fix(util): fix sth..... (#1)

-->

## Summary about this PR
<!--

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".
e.g.:
Issue: close #1

-->

Issue Number: close #650

1 cause reason: tianmu load construct Sql_cmd_load_table itself, but not assign it to thd->lex->m_sql_cmd;
2 thd->lex->m_sql_cmd(nullptr) is used later, so crashed;

## Tests Check List
<!-- At least one of next options must be included. -->

- [ ] Unit test
- [ ] Integration test
- [X] Manual test (add detailed scripts or steps below)
- [ ] No code

## Changelog
<!-- At least one of next options must be included. -->

- [ ] New Feature
- [X] Bug Fix
- [ ] Improvement
- [ ] Performance Improvement
- [ ] Build/Testing/CI/CD
- [ ] Documentation
- [ ] Not for changelog (changelog entry is not required)

## Documentation
<!-- At least one of next options must be included. -->

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
