### PR TITLE
feat(tianmu): to adapt `group by` command to MySQL8.0.(#718)

### DIFF
--- a/storage/tianmu/core/engine.cpp
+++ b/storage/tianmu/core/engine.cpp
@@ -2056,6 +2056,8 @@ Query_route_to Engine::Handle_Query(THD *thd, Query_expression *qe, Query_result
     return Query_route_to::TO_MYSQL;
   }
 
+  if (with_insert) result->create_table_for_query_block(thd);  // used for CTAS
+
   if (lock_tables(thd, thd->lex->query_tables, thd->lex->table_count, 0)) {
     TIANMU_LOG(LogCtl_Level::ERROR, "Failed to lock tables for query '%s'", thd->query().str);
     return Query_route_to::TO_TIANMU;

--- a/storage/tianmu/core/engine.ic
+++ b/storage/tianmu/core/engine.ic
@@ -56,7 +56,7 @@ static int optimize_select(THD *thd, ulong select_options, Query_result *result,
         }
       } else {  // it is a global_opton query block, such as limit, order by, etc.
         if (!select_lex->master_query_expression()->is_prepared())
-          if (err = select_lex->prepare(thd, nullptr))  // stonedb8
+          if ((err = select_lex->prepare(thd, nullptr)))
           {
             return err;
           }
@@ -67,7 +67,7 @@ static int optimize_select(THD *thd, ulong select_options, Query_result *result,
   } else {
     thd_proc_info(thd, "init");
     if (!select_lex->master_query_expression()->is_prepared())
-      if (err = select_lex->prepare(thd, nullptr))  // stonedb8
+      if ((err = select_lex->prepare(thd, nullptr)))
       {
         return err;
       }

--- a/storage/tianmu/core/query_compile.cpp
+++ b/storage/tianmu/core/query_compile.cpp
@@ -483,9 +483,9 @@ Query_route_to Query::AddFields(mem_root_deque<Item *> &fields, TabID const &tmp
 
 Query_route_to Query::AddGroupByFields(ORDER *group_by, const TabID &tmp_table) {
   for (; group_by; group_by = group_by->next) {
-    if (group_by->direction != ORDER_ASC) {
+    if (group_by->direction != ORDER_NOT_RELEVANT) {
       my_message(ER_SYNTAX_ERROR,
-                 "Tianmu specific error: Using DESC after GROUP BY clause not "
+                 "Tianmu specific error: Using ASC/DESC after GROUP BY clause not "
                  "allowed. Use "
                  "ORDER BY to order the result",
                  MYF(0));


### PR DESCRIPTION

<!--

Thank you for contributing to StoneDB!

PR Title Format: <type>(<scope>): description to this pr (#issue_id)
e.g.
fix(util): fix sth..... (#1)

-->

## Summary about this PR
<!--

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".
e.g.:
Issue: close #1

-->

Issue Number: close #718 

[summary]
In 5.7, group by is sorted by asc by default, but in 8.0, it is not sorted by default 
Init Query_result_create::table for CTAS to fix crash

## Tests Check List
<!-- At least one of next options must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

## Changelog
<!-- At least one of next options must be included. -->

- [x] New Feature
- [x] Bug Fix
- [ ] Improvement
- [ ] Performance Improvement
- [ ] Build/Testing/CI/CD
- [ ] Documentation
- [ ] Not for changelog (changelog entry is not required)

## Documentation
<!-- At least one of next options must be included. -->

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
