### PR TITLE
feat(StoneDB 8.0): tianmu_insert_delayed decides the binary log file events. (#723)

### DIFF
--- a/mysql-test/suite/tianmu/r/issue723-1.result
+++ b/mysql-test/suite/tianmu/r/issue723-1.result
@@ -1,0 +1,33 @@
+reset master;
+show variables like 'tianmu_insert_delayed';
+Variable_name	Value
+tianmu_insert_delayed	OFF
+use test;
+create table t1 (a int, b int) engine=tianmu DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+insert into t1 values(1,1);
+insert into t1 values(2,2);
+insert into t1 values(3,3);
+insert into t1 values(4,4);
+show binlog events;
+Log_name	Pos	Event_type	Server_id	End_log_pos	Info
+binlog.000001	4	Format_desc	1	126	#
+binlog.000001	126	Previous_gtids	1	157	#
+binlog.000001	157	Anonymous_Gtid	1	236	#
+binlog.000001	236	Query	1	410	#
+binlog.000001	410	Anonymous_Gtid	1	489	#
+binlog.000001	489	Query	1	571	#
+binlog.000001	571	Query	1	674	#
+binlog.000001	674	Query	1	757	#
+binlog.000001	757	Anonymous_Gtid	1	836	#
+binlog.000001	836	Query	1	918	#
+binlog.000001	918	Query	1	1021	#
+binlog.000001	1021	Query	1	1104	#
+binlog.000001	1104	Anonymous_Gtid	1	1183	#
+binlog.000001	1183	Query	1	1265	#
+binlog.000001	1265	Query	1	1368	#
+binlog.000001	1368	Query	1	1451	#
+binlog.000001	1451	Anonymous_Gtid	1	1530	#
+binlog.000001	1530	Query	1	1612	#
+binlog.000001	1612	Query	1	1715	#
+binlog.000001	1715	Query	1	1798	#
+drop table t1;

--- a/mysql-test/suite/tianmu/r/issue723-2.result
+++ b/mysql-test/suite/tianmu/r/issue723-2.result
@@ -1,0 +1,22 @@
+reset master;
+show variables like 'tianmu_insert_delayed';
+Variable_name	Value
+tianmu_insert_delayed	ON
+use test;
+create table t1 (a int, b int) engine=tianmu DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+insert into t1 values(1,1);
+insert into t1 values(2,2);
+insert into t1 values(3,3);
+insert into t1 values(4,4);
+show binlog events;
+Log_name	Pos	Event_type	Server_id	End_log_pos	Info
+binlog.000001	4	Format_desc	1	126	#
+binlog.000001	126	Previous_gtids	1	157	#
+binlog.000001	157	Anonymous_Gtid	1	236	#
+binlog.000001	236	Query	1	410	#
+binlog.000001	410	Anonymous_Gtid	1	489	#
+binlog.000001	489	Query	1	571	#
+binlog.000001	571	Begin_load_query	1	614	#
+binlog.000001	614	Execute_load_query	1	835	#
+binlog.000001	835	Query	1	918	#
+drop table t1;

--- a/mysql-test/suite/tianmu/t/alter_table_v1-master.opt
+++ b/mysql-test/suite/tianmu/t/alter_table_v1-master.opt
@@ -1,0 +1,1 @@
+--tianmu_insert_delayed=0

--- a/mysql-test/suite/tianmu/t/issue723-1-master.opt
+++ b/mysql-test/suite/tianmu/t/issue723-1-master.opt
@@ -1,0 +1,1 @@
+--tianmu_insert_delayed=0

--- a/mysql-test/suite/tianmu/t/issue723-1.test
+++ b/mysql-test/suite/tianmu/t/issue723-1.test
@@ -1,0 +1,12 @@
+reset master;
+show variables like 'tianmu_insert_delayed';
+use test;
+create table t1 (a int, b int) engine=tianmu DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+insert into t1 values(1,1);
+insert into t1 values(2,2);
+insert into t1 values(3,3);
+insert into t1 values(4,4);
+sleep 1;
+--replace_column 6 #
+show binlog events;
+drop table t1;

--- a/mysql-test/suite/tianmu/t/issue723-2-master.opt
+++ b/mysql-test/suite/tianmu/t/issue723-2-master.opt
@@ -1,0 +1,1 @@
+--tianmu_insert_delayed=1

--- a/mysql-test/suite/tianmu/t/issue723-2.test
+++ b/mysql-test/suite/tianmu/t/issue723-2.test
@@ -1,0 +1,12 @@
+reset master;
+show variables like 'tianmu_insert_delayed';
+use test;
+create table t1 (a int, b int) engine=tianmu DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+insert into t1 values(1,1);
+insert into t1 values(2,2);
+insert into t1 values(3,3);
+insert into t1 values(4,4);
+sleep 1;
+--replace_column 6 #
+show binlog events;
+drop table t1;

--- a/sql/sql_insert.cc
+++ b/sql/sql_insert.cc
@@ -35,6 +35,7 @@
 #include <map>
 #include <utility>
 
+#include "../storage/tianmu/handler/ha_my_tianmu.h"
 #include "field_types.h"
 #include "lex_string.h"
 #include "m_ctype.h"
@@ -681,7 +682,9 @@ bool Sql_cmd_insert_values::execute_inner(THD *thd) {
 
     if (!has_error ||
         thd->get_transaction()->cannot_safely_rollback(Transaction_ctx::STMT)) {
-      if (mysql_bin_log.is_open()) {
+      bool tianmu_engine = insert_table->s->db_type() ? insert_table->s->db_type()->db_type == DB_TYPE_TIANMU: false;
+      bool tianmu_engier_insert_delayed = tianmu_engine ? Tianmu::DBHandler::Tianmu_Get_Insert_Delayed_Flag(thd): false;
+      if (!tianmu_engier_insert_delayed && mysql_bin_log.is_open()) {
         int errcode = 0;
         if (!has_error) {
           /*

--- a/storage/tianmu/handler/ha_my_tianmu.cpp
+++ b/storage/tianmu/handler/ha_my_tianmu.cpp
@@ -160,5 +160,6 @@ bool Tianmu_Load(THD *thd, sql_exchange *ex, TABLE_LIST *table_list, void *arg) 
   return false;
 }
 
+bool Tianmu_Get_Insert_Delayed_Flag(THD *thd) { return tianmu_sysvar_insert_delayed; }
 }  // namespace DBHandler
 }  // namespace Tianmu

--- a/storage/tianmu/handler/ha_my_tianmu.h
+++ b/storage/tianmu/handler/ha_my_tianmu.h
@@ -38,6 +38,8 @@ void Tianmu_UpdateAndStoreColumnComment(TABLE *table, int field_id, Field *sourc
 // processing the load operation.
 bool Tianmu_Load(THD *thd, sql_exchange *ex, TABLE_LIST *table_list, void *arg);
 
+bool Tianmu_Get_Insert_Delayed_Flag(THD *thd);
+
 }  // namespace DBHandler
 }  //  namespace Tianmu
 


### PR DESCRIPTION

<!--

Thank you for contributing to StoneDB!

PR Title Format: <type>(<scope>): description to this pr (#issue_id)
e.g.
fix(util): fix sth..... (#1)

-->

## Summary about this PR
<!--

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".
e.g.:
Issue: close #1

-->

Issue Number: close #723

[summary]
 1 tianmu_insert_delayed=1,insert DML binary log will be convert to "load into outfile ..." with other insert DMLs;
 2 tianmu_insert_delayed=0,insert DML binary log is the normal binary log events;


## Tests Check List
<!-- At least one of next options must be included. -->

- [ ] Unit test
- [X] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

## Changelog
<!-- At least one of next options must be included. -->

- [x] New Feature
- [ ] Bug Fix
- [ ] Improvement
- [ ] Performance Improvement
- [ ] Build/Testing/CI/CD
- [ ] Documentation
- [ ] Not for changelog (changelog entry is not required)

## Documentation
<!-- At least one of next options must be included. -->

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
