### PR TITLE
fix(tianmu): feature: The error display is too general, and the cause of the error cannot be clearly located #706

### DIFF
--- a/storage/tianmu/.clang-format
+++ b/storage/tianmu/.clang-format
@@ -16,7 +16,7 @@ AllowShortBlocksOnASingleLine: Never
 AllowShortCaseLabelsOnASingleLine: false
 AllowShortFunctionsOnASingleLine: All
 AllowShortLambdasOnASingleLine: All
-AllowShortIfStatementsOnASingleLine: WithoutElse
+AllowShortIfStatementsOnASingleLine: Never 
 AllowShortLoopsOnASingleLine: true
 AlwaysBreakAfterDefinitionReturnType: None
 AlwaysBreakAfterReturnType: None

--- a/storage/tianmu/common/exception.h
+++ b/storage/tianmu/common/exception.h
@@ -62,17 +62,18 @@ inline bool IsWarning(ErrorCode tianmu_rc) {
   return tianmu_rc == ErrorCode::OUT_OF_RANGE || tianmu_rc == ErrorCode::VALUE_TRUNCATED;
 }
 
-class TIANMUError {
+class TianmuError {
  public:
-  TIANMUError(ErrorCode tianmu_error_code = ErrorCode::SUCCESS) : ec(tianmu_error_code) {}
-  TIANMUError(ErrorCode tianmu_error_code, std::string message) : ec(tianmu_error_code), message(message) {}
-  TIANMUError(const TIANMUError &tianmu_e) : ec(tianmu_e.ec), message(tianmu_e.message) {}
-  TIANMUError &operator=(const TIANMUError &) = default;
+  TianmuError(ErrorCode tianmu_error_code = ErrorCode::SUCCESS) : ec(tianmu_error_code) {}
+  TianmuError(ErrorCode tianmu_error_code, std::string message) : ec(tianmu_error_code), message(message) {}
+  TianmuError(const TianmuError &tianmu_e) : ec(tianmu_e.ec), message(tianmu_e.message) {}
+  TianmuError &operator=(const TianmuError &) = default;
   operator ErrorCode() { return ec; }
   ErrorCode GetErrorCode() { return ec; }
   bool operator==(ErrorCode tianmu_ec) { return tianmu_ec == ec; }
   const std::string &Message() {
-    if (!message.empty()) return message;
+    if (!message.empty())
+      return message;
     return error_messages[static_cast<int>(ec)];
   }
 
@@ -95,7 +96,7 @@ class Exception : public std::runtime_error {
 class InternalException : public Exception {
  public:
   InternalException(std::string const &msg) : Exception(msg) {}
-  InternalException(TIANMUError tianmu_error) : Exception(tianmu_error.Message()) {}
+  InternalException(TianmuError tianmu_error) : Exception(tianmu_error.Message()) {}
 };
 
 // the system lacks memory or cannot use disk cache
@@ -155,7 +156,7 @@ class NotImplementedException : public Exception {
 class FileException : public Exception {
  public:
   FileException(std::string const &msg) : Exception(msg) {}
-  FileException(TIANMUError tianmu_error) : Exception(tianmu_error.Message()) {}
+  FileException(TianmuError tianmu_error) : Exception(tianmu_error.Message()) {}
 };
 
 // wrong format of import file
@@ -178,7 +179,7 @@ class DataTypeConversionException : public Exception {
   DataTypeConversionException(std::string const &msg, int64_t val = NULL_VALUE_64, CT t = CT::UNK)
       : Exception(msg), value(val), type(t) {}
 
-  DataTypeConversionException(TIANMUError tianmu_error = ErrorCode::DATACONVERSION, int64_t val = NULL_VALUE_64,
+  DataTypeConversionException(TianmuError tianmu_error = ErrorCode::DATACONVERSION, int64_t val = NULL_VALUE_64,
                               CT t = CT::UNK)
       : Exception(tianmu_error.Message()), value(val), type(t) {}
 };
@@ -186,14 +187,14 @@ class DataTypeConversionException : public Exception {
 class UnsupportedDataTypeException : public Exception {
  public:
   UnsupportedDataTypeException(std::string const &msg) : Exception(msg) {}
-  UnsupportedDataTypeException(TIANMUError tianmu_error = ErrorCode::UNSUPPORTED_DATATYPE)
+  UnsupportedDataTypeException(TianmuError tianmu_error = ErrorCode::UNSUPPORTED_DATATYPE)
       : Exception(tianmu_error.Message()) {}
 };
 
 class NetStreamException : public Exception {
  public:
   NetStreamException(std::string const &msg) : Exception(msg) {}
-  NetStreamException(TIANMUError tianmu_error) : Exception(tianmu_error.Message()) {}
+  NetStreamException(TianmuError tianmu_error) : Exception(tianmu_error.Message()) {}
 };
 
 class AssertException : public Exception {

--- a/storage/tianmu/core/engine.h
+++ b/storage/tianmu/core/engine.h
@@ -120,7 +120,7 @@ class Engine final {
   void UnregisterMemTable(const std::string &from, const std::string &to);
 
   // For Load Data.
-  common::TIANMUError RunLoader(THD *thd, sql_exchange *ex, TABLE_LIST *table_list, void *arg);
+  common::TianmuError RunLoader(THD *thd, sql_exchange *ex, TABLE_LIST *table_list, void *arg);
 
   // transaction operations.
   void CommitTx(THD *thd, bool all);
@@ -175,9 +175,9 @@ class Engine final {
   static int Convert(int &is_null, String *value, types::RCDataType &rcitem, enum_field_types f_type);
   static void ComputeTimeZoneDiffInMinutes(THD *thd, short &sign, short &minutes);
   static std::string GetTablePath(TABLE *table);
-  static common::TIANMUError GetIOParams(std::unique_ptr<system::IOParameters> &io_params, THD &thd, sql_exchange &ex,
+  static common::TianmuError GetIOParams(std::unique_ptr<system::IOParameters> &io_params, THD &thd, sql_exchange &ex,
                                          TABLE *table = 0, void *arg = nullptr, bool for_exporter = false);
-  static common::TIANMUError GetRejectFileIOParameters(THD &thd, std::unique_ptr<system::IOParameters> &io_params);
+  static common::TianmuError GetRejectFileIOParameters(THD &thd, std::unique_ptr<system::IOParameters> &io_params);
   static fs::path GetNextDataDir();
 
  private:

--- a/storage/tianmu/core/engine_results.cpp
+++ b/storage/tianmu/core/engine_results.cpp
@@ -165,7 +165,8 @@ void restore_fields(mem_root_deque<Item *> &fields, std::map<int, Item *> &items
 
   int count = 0;
   for (auto it = fields.begin(); it != fields.end(); ++it) {
-    if (items_backup.find(count) != items_backup.end()) fields[count] = items_backup[count];
+    if (items_backup.find(count) != items_backup.end())
+      fields[count] = items_backup[count];
     count++;
   }
 }
@@ -206,7 +207,8 @@ void ResultSender::Init([[maybe_unused]] TempTable *t) {
 
 void ResultSender::Send(TempTable::RecordIterator &iter) {
   if ((iter.currentRowNumber() & 0x7fff) == 0)
-    if (current_txn_->Killed()) throw common::KilledException();
+    if (current_txn_->Killed())
+      throw common::KilledException();
 
   TempTable *owner(iter.Owner());
   if (!is_initialized) {
@@ -214,7 +216,8 @@ void ResultSender::Send(TempTable::RecordIterator &iter) {
     Init(owner);
     is_initialized = true;
   }
-  if (owner && !owner->IsSent()) owner->SetIsSent();
+  if (owner && !owner->IsSent())
+    owner->SetIsSent();
 
   // func found_rows() need limit_found_rows
   thd->current_found_rows++;
@@ -225,7 +228,8 @@ void ResultSender::Send(TempTable::RecordIterator &iter) {
   }
 
   if (limit) {
-    if (*limit == 0) return;
+    if (*limit == 0)
+      return;
     --(*limit);
   }
 
@@ -235,14 +239,16 @@ void ResultSender::Send(TempTable::RecordIterator &iter) {
 }
 
 void ResultSender::SendRow(const std::vector<std::unique_ptr<types::RCDataType>> &record, TempTable *owner) {
-  if (current_txn_->Killed()) throw common::KilledException();
+  if (current_txn_->Killed())
+    throw common::KilledException();
 
   if (!is_initialized) {
     owner->CreateDisplayableAttrP();
     Init(owner);
     is_initialized = true;
   }
-  if (owner && !owner->IsSent()) owner->SetIsSent();
+  if (owner && !owner->IsSent())
+    owner->SetIsSent();
 
   // func found_rows() need limit_found_rows
   thd->current_found_rows++;
@@ -253,7 +259,8 @@ void ResultSender::SendRow(const std::vector<std::unique_ptr<types::RCDataType>>
   }
 
   if (limit) {
-    if (*limit == 0) return;
+    if (*limit == 0)
+      return;
     --(*limit);
   }
 
@@ -328,7 +335,8 @@ void ResultSender::SendRecord(const std::vector<std::unique_ptr<types::RCDataTyp
         if (sum_type == Item_sum::COUNT_FUNC || sum_type == Item_sum::SUM_BIT_FUNC) {
           isum_int_rcbase = (types::Item_sum_int_rcbase *)is;
           Engine::Convert(is_null, value, rcdt, is->data_type());
-          if (is_null) value = 0;
+          if (is_null)
+            value = 0;
           isum_int_rcbase->int64_value(value);
           break;
         }
@@ -368,7 +376,8 @@ void ResultSender::Finalize(TempTable *result_table) {
     is_initialized = true;
     Init(result_table);
   }
-  if (result_table && !result_table->IsSent()) Send(result_table);
+  if (result_table && !result_table->IsSent())
+    Send(result_table);
   CleanUp();
   SendEof();
   ulonglong cost_time = (my_micro_time() - thd->start_utime) / 1000;
@@ -444,7 +453,8 @@ AttributeTypeInfo create_ati(THD *&thd, TABLE &tmp_table, Item *&item) {
   } else
     field =
         create_tmp_field(thd, &tmp_table, item, item->type(), (Func_ptr_array *)0, &tmp_field, &def_field, 0, 0, 0, 0);
-  if (!field) throw common::DatabaseException("failed to guess item type");
+  if (!field)
+    throw common::DatabaseException("failed to guess item type");
   AttributeTypeInfo ati = Engine::GetCorrespondingATI(*field);
   delete field;
   return ati;
@@ -459,7 +469,7 @@ void ResultExportSender::Init(TempTable *t) {
 
   std::unique_ptr<system::IOParameters> iop;
 
-  common::TIANMUError tianmu_error;
+  common::TianmuError tianmu_error;
 
   export_res->send_result_set_metadata(thd, fields, Protocol::SEND_NUM_ROWS | Protocol::SEND_EOF);
 
@@ -485,7 +495,8 @@ void ResultExportSender::Init(TempTable *t) {
   }
 
   rcbuffer = std::make_shared<system::LargeBuffer>();
-  if (!rcbuffer->BufOpen(*iop)) throw common::FileException("Unable to open file or named pipe.");
+  if (!rcbuffer->BufOpen(*iop))
+    throw common::FileException("Unable to open file or named pipe.");
 
   rcde = common::DataFormat::GetDataFormat(iop->GetEDF())->CreateDataExporter(*iop);
   rcde->Init(rcbuffer, t->GetATIs(iop->GetEDF() != common::EDF::TRI_UNKNOWN), f, deas);

--- a/storage/tianmu/handler/ha_my_tianmu.cpp
+++ b/storage/tianmu/handler/ha_my_tianmu.cpp
@@ -34,7 +34,8 @@ static bool AtLeastOneTianmuTableInvolved(Query_expression *qe) {
       TABLE_LIST *tb = sl->get_table_list();
       for (; tb; tb = tb->next_global) {
         TABLE *table = tb->table;
-        if (core::Engine::IsTianmuTable(table)) return true;
+        if (core::Engine::IsTianmuTable(table))
+          return true;
       }
     }
   }
@@ -86,7 +87,8 @@ Query_route_to ha_my_tianmu_query(THD *thd, Query_expression *qe, Query_result *
     // (e.g. thrown from ForbiddenMySQLQueryPath) we want to return
 
     // is explain, route to MySQL
-    if (thd->lex->is_explain()) return Query_route_to::TO_MYSQL;
+    if (thd->lex->is_explain())
+      return Query_route_to::TO_MYSQL;
 
     // is query, route to Tianmu
     ret = ha_rcengine_->Handle_Query(thd, qe, result, setup_tables_done_option, res, optimize_after_tianmu,
@@ -113,10 +115,11 @@ Query_route_to ha_my_tianmu_query(THD *thd, Query_expression *qe, Query_result *
 
 static int Tianmu_LoadData(THD *thd, sql_exchange *ex, TABLE_LIST *table_list, void *arg, char *errmsg, int len,
                            int &errcode) {
-  common::TIANMUError tianmu_error;
+  common::TianmuError tianmu_error;
   int ret = static_cast<int>(TianmuEngineReturnValues::LD_FAILED);
 
-  if (!core::Engine::IsTianmuTable(table_list->table)) return static_cast<int>(TianmuEngineReturnValues::LD_CONTINUE);
+  if (!core::Engine::IsTianmuTable(table_list->table))
+    return static_cast<int>(TianmuEngineReturnValues::LD_CONTINUE);
 
   try {
     tianmu_error = ha_rcengine_->RunLoader(thd, ex, table_list, arg);
@@ -127,10 +130,10 @@ static int Tianmu_LoadData(THD *thd, sql_exchange *ex, TABLE_LIST *table_list, v
                  static_cast<int>(TianmuEngineReturnValues::LD_FAILED));
 
   } catch (std::exception &e) {
-    tianmu_error = common::TIANMUError(common::ErrorCode::UNKNOWN_ERROR, e.what());
+    tianmu_error = common::TianmuError(common::ErrorCode::UNKNOWN_ERROR, e.what());
     TIANMU_LOG(LogCtl_Level::ERROR, "RunLoader Error: %s", tianmu_error.Message().c_str());
   } catch (...) {
-    tianmu_error = common::TIANMUError(common::ErrorCode::UNKNOWN_ERROR, "An unknown system exception error caught.");
+    tianmu_error = common::TianmuError(common::ErrorCode::UNKNOWN_ERROR, "An unknown system exception error caught.");
     TIANMU_LOG(LogCtl_Level::ERROR, "RunLoader Error: %s", tianmu_error.Message().c_str());
   }
 

--- a/storage/tianmu/system/file.cpp
+++ b/storage/tianmu/system/file.cpp
@@ -27,14 +27,17 @@ int TianmuFile::Open(std::string const &file, int flags, mode_t mode) {
   name_ = file;
 
   fd_ = open(file.c_str(), flags, mode);
-  if (fd_ == -1) ThrowError(errno);
+  if (fd_ == -1)
+    throw common::TianmuError(common::ErrorCode::FAILED,
+                              "ErrorCode: " + std::to_string(errno) + " - " + strerror(errno));
   return fd_;
 }
 
 size_t TianmuFile::Read(void *buf, size_t count) {
   DEBUG_ASSERT(fd_ != -1);
   auto read_bytes = read(fd_, buf, count);
-  if (read_bytes == -1) ThrowError(errno);
+  if (read_bytes == -1)
+    ThrowError(errno);
   return read_bytes;
 }
 
@@ -72,7 +75,8 @@ void TianmuFile::ReadExact(void *buf, size_t count) {
   size_t read_bytes = 0;
   while (read_bytes < count) {
     auto rb = Read((char *)buf + read_bytes, count - read_bytes);
-    if (rb == 0) break;
+    if (rb == 0)
+      break;
     read_bytes += rb;
   }
   if (read_bytes != count) {
@@ -87,7 +91,8 @@ void TianmuFile::WriteExact(const void *buf, size_t count) {
   while (total_writen_bytes < count) {
     auto writen_bytes = write(fd_, (reinterpret_cast<char *>(const_cast<void *>(buf))) + total_writen_bytes,
                               count - total_writen_bytes);
-    if (writen_bytes == -1) ThrowError(errno);
+    if (writen_bytes == -1)
+      ThrowError(errno);
     total_writen_bytes += writen_bytes;
   }
 }
@@ -98,7 +103,8 @@ off_t TianmuFile::Seek(off_t pos, int whence) {
 
   new_pos = lseek(fd_, pos, whence);
 
-  if (new_pos == (off_t)-1) ThrowError(errno);
+  if (new_pos == (off_t)-1)
+    ThrowError(errno);
   return new_pos;
 }
 
@@ -106,7 +112,8 @@ off_t TianmuFile::Tell() {
   off_t pos;
   DEBUG_ASSERT(fd_ != -1);
   pos = lseek(fd_, 0, SEEK_CUR);
-  if (pos == (off_t)-1) ThrowError(errno);
+  if (pos == (off_t)-1)
+    ThrowError(errno);
   return pos;
 }
 

--- a/storage/tianmu/types/rc_datetime.cpp
+++ b/storage/tianmu/types/rc_datetime.cpp
@@ -63,7 +63,8 @@ RCDateTime::RCDateTime(short yh, short mm, short ds, common::CT at) : at(at) {
     dt.second = std::abs(ds);
     dt.minute = std::abs(mm);
     dt.time_hour = std::abs(yh);
-    if (yh < 0 || mm < 0 || ds < 0) dt.neg = 1;
+    if (yh < 0 || mm < 0 || ds < 0)
+      dt.neg = 1;
   } else
     TIANMU_ERROR("type not supported");
 }
@@ -100,11 +101,11 @@ RCDateTime::RCDateTime(RCNum &rcn, common::CT at) : at(at) {
   null = rcn.null;
   if (!null) {
     if (core::ATI::IsRealType(rcn.Type()))
-      throw common::DataTypeConversionException(common::TIANMUError(common::ErrorCode::DATACONVERSION));
+      throw common::DataTypeConversionException(common::TianmuError(common::ErrorCode::DATACONVERSION));
     if (rcn.Type() == common::CT::NUM && rcn.Scale() > 0)
-      throw common::DataTypeConversionException(common::TIANMUError(common::ErrorCode::DATACONVERSION));
+      throw common::DataTypeConversionException(common::TianmuError(common::ErrorCode::DATACONVERSION));
     if (Parse((int64_t)rcn, *this, at) != common::ErrorCode::SUCCESS)
-      throw common::DataTypeConversionException(common::TIANMUError(common::ErrorCode::DATACONVERSION));
+      throw common::DataTypeConversionException(common::TianmuError(common::ErrorCode::DATACONVERSION));
   }
 }
 
@@ -140,7 +141,8 @@ RCDateTime &RCDateTime::Assign(int64_t v, common::CT at) {
 }
 
 int64_t RCDateTime::GetInt64() const {
-  if (null) return common::NULL_VALUE_64;
+  if (null)
+    return common::NULL_VALUE_64;
   return *reinterpret_cast<int64_t *>(const_cast<DT *>(&dt));
 }
 
@@ -154,7 +156,8 @@ bool RCDateTime::ToInt64(int64_t &value) const {
       return true;
     } else if (at == common::CT::TIME) {
       value = dt.time_hour * 10000 + Minute() * 100 + Second();
-      if (dt.Neg()) value = -value;
+      if (dt.Neg())
+        value = -value;
       return true;
     } else {
       value = Year() * 10000 + Month() * 100 + Day();
@@ -173,7 +176,8 @@ BString RCDateTime::ToBString() const {
   if (!IsNull()) {
     BString rcs(0, 30, true);
     char *buf = rcs.val;
-    if (dt.Neg()) *buf++ = '-';
+    if (dt.Neg())
+      *buf++ = '-';
     if (at == common::CT::YEAR) {
       std::sprintf(buf, "%04d", (int)std::abs(Year()));
     } else if (at == common::CT::DATE) {
@@ -198,7 +202,8 @@ common::ErrorCode RCDateTime::Parse(const BString &rcs, RCDateTime &rcv, common:
 common::ErrorCode RCDateTime::Parse(const int64_t &v, RCDateTime &rcv, common::CT at, int precision) {
   int64_t tmp_v = v < 0 ? -v : v;
   int sign = 1;
-  if (v < 0) sign = -1;
+  if (v < 0)
+    sign = -1;
 
   rcv.at = at;
   if (v == common::NULL_VALUE_64) {
@@ -261,7 +266,8 @@ common::ErrorCode RCDateTime::Parse(const int64_t &v, RCDateTime &rcv, common::C
     rcv.dt.hour = tmp_v;
 
     if (IsCorrectTIANMUTime(short(rcv.dt.hour * sign), short(rcv.dt.minute * sign), short(rcv.dt.second * sign))) {
-      if (sign == -1) rcv.dt.neg = 1;
+      if (sign == -1)
+        rcv.dt.neg = 1;
       return common::ErrorCode::SUCCESS;
     } else {
       rcv = RC_TIME_SPEC;
@@ -320,42 +326,50 @@ common::ErrorCode RCDateTime::Parse(const int64_t &v, RCDateTime &rcv, common::C
 }
 
 bool RCDateTime::CanBeYear(int64_t year) {
-  if (year >= 0 && year <= 9999) return true;
+  if (year >= 0 && year <= 9999)
+    return true;
   return false;
 }
 
 bool RCDateTime::CanBeMonth(int64_t month) {
-  if (month >= 1 && month <= 12) return true;
+  if (month >= 1 && month <= 12)
+    return true;
   return false;
 }
 
 bool RCDateTime::CanBeDay(int64_t day) {
-  if (day >= 1 && day <= 31) return true;
+  if (day >= 1 && day <= 31)
+    return true;
   return false;
 }
 
 bool RCDateTime::CanBeHour(int64_t hour) {
-  if (hour >= 0 && hour <= 23) return true;
+  if (hour >= 0 && hour <= 23)
+    return true;
   return false;
 }
 
 bool RCDateTime::CanBeMinute(int64_t minute) {
-  if (minute >= 0 && minute <= 59) return true;
+  if (minute >= 0 && minute <= 59)
+    return true;
   return false;
 }
 
 bool RCDateTime::CanBeSecond(int64_t second) { return RCDateTime::CanBeMinute(second); }
 
 bool RCDateTime::CanBeDate(int64_t year, int64_t month, int64_t day) {
-  if (year == RC_DATE_SPEC.Year() && month == RC_DATE_SPEC.Month() && day == RC_DATE_SPEC.Day()) return true;
+  if (year == RC_DATE_SPEC.Year() && month == RC_DATE_SPEC.Month() && day == RC_DATE_SPEC.Day())
+    return true;
   if (CanBeYear(year) && CanBeMonth(month) && (day > 0 && (day <= NoDaysInMonth((ushort)year, (ushort)month))))
     return true;
   return false;
 }
 
 bool RCDateTime::CanBeTime(int64_t hour, int64_t minute, int64_t second) {
-  if (hour == RC_TIME_SPEC.Hour() && minute == RC_TIME_SPEC.Minute() && second == RC_TIME_SPEC.Second()) return true;
-  if (hour >= -838 && hour <= 838 && CanBeMinute(minute) && CanBeSecond(second)) return true;
+  if (hour == RC_TIME_SPEC.Hour() && minute == RC_TIME_SPEC.Minute() && second == RC_TIME_SPEC.Second())
+    return true;
+  if (hour >= -838 && hour <= 838 && CanBeMinute(minute) && CanBeSecond(second))
+    return true;
   return false;
 }
 
@@ -385,7 +399,8 @@ bool RCDateTime::IsCorrectTIANMUYear(short year) {
 }
 
 bool RCDateTime::IsCorrectTIANMUDate(short year, short month, short day) {
-  if (year == RC_DATE_SPEC.Year() && month == RC_DATE_SPEC.Month() && day == RC_DATE_SPEC.Day()) return true;
+  if (year == RC_DATE_SPEC.Year() && month == RC_DATE_SPEC.Month() && day == RC_DATE_SPEC.Day())
+    return true;
   if (CanBeYear(year) && CanBeMonth(month) && (day > 0 && (day <= NoDaysInMonth(year, month)))) {
     if (((year >= RC_DATE_MIN.Year() && month >= RC_DATE_MIN.Month() && day >= RC_DATE_MIN.Day()) &&
          (year <= RC_DATE_MAX.Year() && month <= RC_DATE_MAX.Month() && day <= RC_DATE_MAX.Day())))
@@ -395,13 +410,17 @@ bool RCDateTime::IsCorrectTIANMUDate(short year, short month, short day) {
 }
 
 bool RCDateTime::IsCorrectTIANMUTime(short hour, short minute, short second) {
-  if (hour == RC_TIME_SPEC.Hour() && minute == RC_TIME_SPEC.Minute() && second == RC_TIME_SPEC.Second()) return true;
+  if (hour == RC_TIME_SPEC.Hour() && minute == RC_TIME_SPEC.Minute() && second == RC_TIME_SPEC.Second())
+    return true;
   bool haspositive = false;
   bool hasnegative = false;
-  if (hour < 0 || minute < 0 || second < 0) hasnegative = true;
-  if (hour > 0 || minute > 0 || second > 0) haspositive = true;
+  if (hour < 0 || minute < 0 || second < 0)
+    hasnegative = true;
+  if (hour > 0 || minute > 0 || second > 0)
+    haspositive = true;
 
-  if (hasnegative == haspositive && (hour != 0 || minute != 0 || second != 0)) return false;
+  if (hasnegative == haspositive && (hour != 0 || minute != 0 || second != 0))
+    return false;
 
   if (hour >= -RC_TIME_MIN.Hour() && hour <= RC_TIME_MAX.Hour() && (CanBeMinute(minute) || CanBeMinute(-minute)) &&
       (CanBeSecond(second) || CanBeSecond(-second)))
@@ -416,7 +435,8 @@ bool RCDateTime::IsCorrectTIANMUTimestamp(short year, short month, short day, sh
   if (CanBeYear(year) && CanBeMonth(month) && (day > 0 && (day <= NoDaysInMonth(year, month))) && CanBeHour(hour) &&
       CanBeMinute(minute) && CanBeSecond(second)) {
     RCDateTime rcdt(year, month, day, hour, minute, second, common::CT::TIMESTAMP);
-    if (rcdt >= RC_TIMESTAMP_MIN && rcdt <= RC_TIMESTAMP_MAX) return true;
+    if (rcdt >= RC_TIMESTAMP_MIN && rcdt <= RC_TIMESTAMP_MAX)
+      return true;
   }
   return false;
 }
@@ -437,8 +457,10 @@ bool RCDateTime::IsCorrectTIANMUDatetime(short year, short month, short day, sho
 }
 
 bool RCDateTime::IsLeapYear(short year) {
-  if (year == 0) return false;
-  if (!CanBeYear(year)) throw common::DataTypeConversionException(common::ErrorCode::DATACONVERSION);
+  if (year == 0)
+    return false;
+  if (!CanBeYear(year))
+    throw common::DataTypeConversionException(common::ErrorCode::DATACONVERSION);
   return ((year & 3) == 0 && year % 100) || ((year & 3) == 0 && year % 400 == 0);
 }
 
@@ -447,7 +469,8 @@ ushort RCDateTime::NoDaysInMonth(short year, ushort month) {
 
   if (!CanBeYear(year) || !CanBeMonth(month))
     throw common::DataTypeConversionException(common::ErrorCode::DATACONVERSION);
-  if (month == 2 && IsLeapYear(year)) return 29;
+  if (month == 2 && IsLeapYear(year))
+    return 29;
   return no_days[month - 1];
 }
 
@@ -459,7 +482,8 @@ short RCDateTime::ToCorrectYear(uint v, common::CT at, bool is_year_2 /*= false*
       if (v <= 0 || v > 2155)
         return v;
       else if (v < 100) {
-        if (v <= 69) return v + 2000;
+        if (v <= 69)
+          return v + 2000;
         return v + 1900;
       }
       return (short)v;
@@ -467,7 +491,8 @@ short RCDateTime::ToCorrectYear(uint v, common::CT at, bool is_year_2 /*= false*
     case common::CT::DATETIME:
     case common::CT::TIMESTAMP:
       if (v < 100) {
-        if (v <= 69) return v + 2000;
+        if (v <= 69)
+          return v + 2000;
         return v + 1900;
       }
       return (short)v;
@@ -504,7 +529,8 @@ RCDateTime RCDateTime::GetCurrent() {
 }
 
 bool RCDateTime::operator==(const RCDataType &rcv) const {
-  if (!AreComparable(at, rcv.Type()) || IsNull() || rcv.IsNull()) return false;
+  if (!AreComparable(at, rcv.Type()) || IsNull() || rcv.IsNull())
+    return false;
   if (rcv.GetValueType() == ValueTypeEnum::DATE_TIME_TYPE)
     return compare(dynamic_cast<RCDateTime &>(const_cast<RCDataType &>(rcv))) == 0;
   else if (rcv.GetValueType() == ValueTypeEnum::NUMERIC_TYPE) {
@@ -514,7 +540,8 @@ bool RCDateTime::operator==(const RCDataType &rcv) const {
 }
 
 bool RCDateTime::operator<(const RCDataType &rcv) const {
-  if (!AreComparable(at, rcv.Type()) || IsNull() || rcv.IsNull()) return false;
+  if (!AreComparable(at, rcv.Type()) || IsNull() || rcv.IsNull())
+    return false;
   if (rcv.GetValueType() == ValueTypeEnum::DATE_TIME_TYPE)
     return compare(dynamic_cast<RCDateTime &>(const_cast<RCDataType &>(rcv))) < 0;
   else if (rcv.GetValueType() == ValueTypeEnum::NUMERIC_TYPE)
@@ -523,7 +550,8 @@ bool RCDateTime::operator<(const RCDataType &rcv) const {
 }
 
 bool RCDateTime::operator>(const RCDataType &rcv) const {
-  if (!AreComparable(at, rcv.Type()) || IsNull() || rcv.IsNull()) return false;
+  if (!AreComparable(at, rcv.Type()) || IsNull() || rcv.IsNull())
+    return false;
   if (rcv.GetValueType() == ValueTypeEnum::DATE_TIME_TYPE)
     return compare(dynamic_cast<RCDateTime &>(const_cast<RCDataType &>(rcv))) > 0;
   else if (rcv.GetValueType() == ValueTypeEnum::NUMERIC_TYPE)
@@ -532,7 +560,8 @@ bool RCDateTime::operator>(const RCDataType &rcv) const {
 }
 
 bool RCDateTime::operator>=(const RCDataType &rcv) const {
-  if (!AreComparable(at, rcv.Type()) || IsNull() || rcv.IsNull()) return false;
+  if (!AreComparable(at, rcv.Type()) || IsNull() || rcv.IsNull())
+    return false;
   if (rcv.GetValueType() == ValueTypeEnum::DATE_TIME_TYPE)
     return compare(dynamic_cast<RCDateTime &>(const_cast<RCDataType &>(rcv))) >= 0;
   else if (rcv.GetValueType() == ValueTypeEnum::NUMERIC_TYPE)
@@ -541,7 +570,8 @@ bool RCDateTime::operator>=(const RCDataType &rcv) const {
 }
 
 bool RCDateTime::operator<=(const RCDataType &rcv) const {
-  if (!AreComparable(at, rcv.Type()) || IsNull() || rcv.IsNull()) return false;
+  if (!AreComparable(at, rcv.Type()) || IsNull() || rcv.IsNull())
+    return false;
   if (rcv.GetValueType() == ValueTypeEnum::DATE_TIME_TYPE)
     return compare(dynamic_cast<RCDateTime &>(const_cast<RCDataType &>(rcv))) <= 0;
   else if (rcv.GetValueType() == ValueTypeEnum::NUMERIC_TYPE)
@@ -550,7 +580,8 @@ bool RCDateTime::operator<=(const RCDataType &rcv) const {
 }
 
 bool RCDateTime::operator!=(const RCDataType &rcv) const {
-  if (!AreComparable(at, rcv.Type()) || IsNull() || rcv.IsNull()) return false;
+  if (!AreComparable(at, rcv.Type()) || IsNull() || rcv.IsNull())
+    return false;
   if (rcv.GetValueType() == ValueTypeEnum::DATE_TIME_TYPE)
     return compare(dynamic_cast<RCDateTime &>(const_cast<RCDataType &>(rcv))) != 0;
   else if (rcv.GetValueType() == ValueTypeEnum::NUMERIC_TYPE)
@@ -559,7 +590,8 @@ bool RCDateTime::operator!=(const RCDataType &rcv) const {
 }
 
 int64_t RCDateTime::operator-(const RCDateTime &sec) const {
-  if (at != common::CT::DATE || sec.at != common::CT::DATE || IsNull() || sec.IsNull()) return common::NULL_VALUE_64;
+  if (at != common::CT::DATE || sec.at != common::CT::DATE || IsNull() || sec.IsNull())
+    return common::NULL_VALUE_64;
   int64_t result = 0;  // span in days for [sec., ..., this]
   bool notless_than_sec = (this->operator>(sec));
   if (notless_than_sec) {
@@ -613,7 +645,8 @@ int RCDateTime::compare(const RCDateTime &rcv) const {
 }
 
 int RCDateTime::compare(const RCNum &rcv) const {
-  if (IsNull() || rcv.IsNull()) return false;
+  if (IsNull() || rcv.IsNull())
+    return false;
   int64_t tmp;
   ToInt64(tmp);
   return int(tmp - (const_cast<RCNum &>(rcv)).GetIntPart());


### PR DESCRIPTION
## Summary about this PR
[summary]
1. Modify the error message when can't find the file with command load infile.
2. Modify class TIANMUError to TianmuError.
3. Modify the value of param AllowShortIfStatementsOnASingleLine to Never.

Issue Number: close #706


## Tests Check List
<!-- At least one of next options must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

## Changelog
<!-- At least one of next options must be included. -->

- [x] New Feature
- [ ] Bug Fix
- [ ] Improvement
- [ ] Performance Improvement
- [ ] Build/Testing/CI/CD
- [ ] Documentation
- [ ] Not for changelog (changelog entry is not required)

## Documentation
<!-- At least one of next options must be included. -->

- [x] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
