### PR TITLE
fix(tianmu)Question with date format of NULL (#682)

### DIFF
--- a/mysql-test/suite/tianmu/r/issue682.result
+++ b/mysql-test/suite/tianmu/r/issue682.result
@@ -1,0 +1,229 @@
+use test;
+set sql_mode='STRICT_TRANS_TABLES,NO_AUTO_CREATE_USER,NO_ENGINE_SUBSTITUTION';
+Warnings:
+Warning	3135	'NO_ZERO_DATE', 'NO_ZERO_IN_DATE' and 'ERROR_FOR_DIVISION_BY_ZERO' sql modes should be used with strict mode. They will be merged with strict mode in a future release.
+create table t1(a date not null);
+insert ignore into t1 values (0);
+insert into t1 values (0);
+insert ignore into t1 values (null);
+Warnings:
+Warning	1048	Column 'a' cannot be null
+insert into t1 values (null);
+ERROR 23000: Column 'a' cannot be null
+insert into t1 values (20221020);
+select * from t1;
+a
+0000-00-00
+0000-00-00
+0000-00-00
+2022-10-20
+select * from t1 where a is null;
+a
+0000-00-00
+0000-00-00
+0000-00-00
+delete from t1 where a is null;
+delete from t1 where a=0;
+select * from t1 where a is null;
+a
+select * from t1;
+a
+2022-10-20
+delete from t1 where a ='20221020';
+select * from t1;
+a
+drop table t1;
+create table t1(a date);
+insert ignore into t1 values (0);
+insert into t1 values (0);
+insert ignore into t1 values (null);
+insert into t1 values (null);
+insert into t1 values (20221020);
+select * from t1;
+a
+0000-00-00
+0000-00-00
+NULL
+NULL
+2022-10-20
+select * from t1 where a is null;
+a
+NULL
+NULL
+delete from t1 where a is null;
+select * from t1 where a is null;
+a
+select * from t1;
+a
+0000-00-00
+0000-00-00
+2022-10-20
+delete from t1 where a ='20221020';
+select * from t1;
+a
+0000-00-00
+0000-00-00
+drop table t1;
+create table t1(a datetime not null);
+insert ignore into t1 values (0);
+insert into t1 values (0);
+insert ignore into t1 values (null);
+Warnings:
+Warning	1048	Column 'a' cannot be null
+insert into t1 values (null);
+ERROR 23000: Column 'a' cannot be null
+insert into t1 values (20221020);
+select * from t1;
+a
+0000-00-00 00:00:00
+0000-00-00 00:00:00
+0000-00-00 00:00:00
+2022-10-20 00:00:00
+select * from t1 where a is null;
+a
+0000-00-00 00:00:00
+0000-00-00 00:00:00
+0000-00-00 00:00:00
+delete from t1 where a is null;
+delete from t1 where a=0;
+select * from t1 where a is null;
+a
+select * from t1;
+a
+2022-10-20 00:00:00
+delete from t1 where a ='20221020';
+select * from t1;
+a
+drop table t1;
+create table t1(a TIME not null);
+insert ignore into t1 values (0);
+insert into t1 values (0);
+insert ignore into t1 values (null);
+Warnings:
+Warning	1048	Column 'a' cannot be null
+insert into t1 values (null);
+ERROR 23000: Column 'a' cannot be null
+insert into t1 values ('12:13:14');
+select * from t1;
+a
+00:00:00
+00:00:00
+00:00:00
+12:13:14
+select * from t1 where a is null;
+a
+delete from t1 where a is null;
+delete from t1 where a=0;
+select * from t1 where a is null;
+a
+select * from t1;
+a
+12:13:14
+delete from t1 where a ='12:13:14';
+select * from t1;
+a
+drop table t1;
+CREATE TABLE t1 (a varchar(10));
+CREATE TABLE t2 (a varchar(10), b date  not null);
+CREATE TABLE t3 (a varchar(10), b TIME  not null);
+INSERT INTO t1 VALUES ('test1');
+INSERT  ignore  INTO t2 VALUES
+('test1','2016-12-13'),('test1','2016-12-14'),('test1','2016-12-15'),('test1',null);
+Warnings:
+Warning	1048	Column 'b' cannot be null
+INSERT ignore INTO t3 VALUES
+('test1','11:13:14'), ('test1','12:13:14'), ('test1','10:13:14'),('test1',null);
+Warnings:
+Warning	1048	Column 'b' cannot be null
+SELECT *
+FROM t1 LEFT JOIN t2
+ON t2.a = 'test1' AND t2.b = '20161213'
+WHERE t1.a = 'test1';
+a	a	b
+test1	test1	2016-12-13
+SELECT *
+FROM t1 LEFT JOIN t2
+ON t2.a = 'test1' 
+WHERE t1.a = 'test1' 
+or t2.b is null;
+a	a	b
+test1	test1	2016-12-13
+test1	test1	2016-12-14
+test1	test1	2016-12-15
+test1	test1	0000-00-00
+SELECT *
+FROM t1 LEFT JOIN t3
+ON t3.a = 'test1' 
+AND t3.b = '12:13:14'
+WHERE t1.a = 'test1';
+a	a	b
+test1	test1	12:13:14
+SELECT *
+FROM t1 LEFT JOIN t3
+ON t3.a = 'test1' 
+WHERE t1.a = 'test1' 
+or t3.b is null;
+a	a	b
+test1	test1	11:13:14
+test1	test1	12:13:14
+test1	test1	10:13:14
+test1	test1	00:00:00
+drop table t1,t2,t3;
+set sql_mode='STRICT_TRANS_TABLES,NO_AUTO_CREATE_USER,NO_ENGINE_SUBSTITUTION,NO_ZERO_IN_DATE,NO_ZERO_DATE';
+Warnings:
+Warning	3135	'NO_ZERO_DATE', 'NO_ZERO_IN_DATE' and 'ERROR_FOR_DIVISION_BY_ZERO' sql modes should be used with strict mode. They will be merged with strict mode in a future release.
+create table t1(a date not null);
+insert ignore into t1 values (0);
+Warnings:
+Warning	1264	Out of range value for column 'a' at row 1
+insert into t1 values (0);
+ERROR 22007: Incorrect date value: '0' for column 'a' at row 1
+insert ignore into t1 values (null);
+Warnings:
+Warning	1048	Column 'a' cannot be null
+insert into t1 values (null);
+ERROR 23000: Column 'a' cannot be null
+insert into t1 values (20221020);
+select * from t1;
+a
+0000-00-00
+0000-00-00
+2022-10-20
+Warnings:
+Warning	1292	Incorrect date value: '0000-00-00' for column 'a' at row 1
+Warning	1292	Incorrect date value: '0000-00-00' for column 'a' at row 1
+select * from t1 where a is null;
+a
+0000-00-00
+0000-00-00
+Warnings:
+Warning	1292	Incorrect date value: '0000-00-00' for column 'a' at row 1
+Warning	1292	Incorrect date value: '0000-00-00' for column 'a' at row 1
+delete from t1 where a is null;
+ERROR 22007: Incorrect date value: '0000-00-00' for column 'a' at row 1
+delete from t1 where a=0;
+ERROR 22007: Incorrect date value: '0000-00-00' for column 'a' at row 1
+select * from t1 where a is null;
+a
+0000-00-00
+0000-00-00
+Warnings:
+Warning	1292	Incorrect date value: '0000-00-00' for column 'a' at row 1
+Warning	1292	Incorrect date value: '0000-00-00' for column 'a' at row 1
+select * from t1;
+a
+0000-00-00
+0000-00-00
+2022-10-20
+Warnings:
+Warning	1292	Incorrect date value: '0000-00-00' for column 'a' at row 1
+Warning	1292	Incorrect date value: '0000-00-00' for column 'a' at row 1
+delete from t1 where a ='20221020';
+select * from t1;
+a
+0000-00-00
+0000-00-00
+Warnings:
+Warning	1292	Incorrect date value: '0000-00-00' for column 'a' at row 1
+Warning	1292	Incorrect date value: '0000-00-00' for column 'a' at row 1
+drop table t1;

--- a/mysql-test/suite/tianmu/t/issue682.test
+++ b/mysql-test/suite/tianmu/t/issue682.test
@@ -1,0 +1,135 @@
+--source include/have_tianmu.inc
+
+use test;
+set sql_mode='STRICT_TRANS_TABLES,NO_AUTO_CREATE_USER,NO_ENGINE_SUBSTITUTION';
+create table t1(a date not null);
+insert ignore into t1 values (0);
+insert into t1 values (0);
+insert ignore into t1 values (null);
+-- error 1048
+insert into t1 values (null);
+insert into t1 values (20221020);
+select * from t1;
+select * from t1 where a is null;
+delete from t1 where a is null;
+delete from t1 where a=0;
+select * from t1 where a is null;
+select * from t1;
+delete from t1 where a ='20221020';
+select * from t1;
+drop table t1;
+
+
+create table t1(a date);
+insert ignore into t1 values (0);
+insert into t1 values (0);
+insert ignore into t1 values (null);
+insert into t1 values (null);
+insert into t1 values (20221020);
+select * from t1;
+select * from t1 where a is null;
+delete from t1 where a is null;
+select * from t1 where a is null;
+select * from t1;
+delete from t1 where a ='20221020';
+select * from t1;
+drop table t1;
+
+create table t1(a datetime not null);
+insert ignore into t1 values (0);
+insert into t1 values (0);
+insert ignore into t1 values (null);
+-- error 1048
+insert into t1 values (null);
+insert into t1 values (20221020);
+select * from t1;
+select * from t1 where a is null;
+delete from t1 where a is null;
+delete from t1 where a=0;
+select * from t1 where a is null;
+select * from t1;
+delete from t1 where a ='20221020';
+select * from t1;
+drop table t1;
+
+
+create table t1(a TIME not null);
+insert ignore into t1 values (0);
+insert into t1 values (0);
+insert ignore into t1 values (null);
+-- error 1048
+insert into t1 values (null);
+insert into t1 values ('12:13:14');
+select * from t1;
+select * from t1 where a is null;
+delete from t1 where a is null;
+delete from t1 where a=0;
+select * from t1 where a is null;
+select * from t1;
+delete from t1 where a ='12:13:14';
+select * from t1;
+drop table t1;
+
+
+CREATE TABLE t1 (a varchar(10));
+CREATE TABLE t2 (a varchar(10), b date  not null);
+CREATE TABLE t3 (a varchar(10), b TIME  not null);
+
+INSERT INTO t1 VALUES ('test1');
+INSERT  ignore  INTO t2 VALUES
+('test1','2016-12-13'),('test1','2016-12-14'),('test1','2016-12-15'),('test1',null);
+INSERT ignore INTO t3 VALUES
+('test1','11:13:14'), ('test1','12:13:14'), ('test1','10:13:14'),('test1',null);
+
+SELECT *
+FROM t1 LEFT JOIN t2
+  ON t2.a = 'test1' AND t2.b = '20161213'
+WHERE t1.a = 'test1';
+
+SELECT *
+FROM t1 LEFT JOIN t2
+  ON t2.a = 'test1' 
+WHERE t1.a = 'test1' 
+or t2.b is null;
+
+
+SELECT *
+FROM t1 LEFT JOIN t3
+  ON t3.a = 'test1' 
+  AND t3.b = '12:13:14'
+WHERE t1.a = 'test1';
+
+SELECT *
+FROM t1 LEFT JOIN t3
+  ON t3.a = 'test1' 
+WHERE t1.a = 'test1' 
+or t3.b is null;
+
+drop table t1,t2,t3;
+
+set sql_mode='STRICT_TRANS_TABLES,NO_AUTO_CREATE_USER,NO_ENGINE_SUBSTITUTION,NO_ZERO_IN_DATE,NO_ZERO_DATE';
+create table t1(a date not null);
+insert ignore into t1 values (0);
+-- error 1292
+insert into t1 values (0);
+insert ignore into t1 values (null);
+-- error 1048
+insert into t1 values (null);
+insert into t1 values (20221020);
+select * from t1;
+select * from t1 where a is null;
+-- error 1292
+delete from t1 where a is null;
+-- error 1292
+delete from t1 where a=0;
+select * from t1 where a is null;
+select * from t1;
+delete from t1 where a ='20221020';
+select * from t1;
+drop table t1;
+
+
+
+
+
+

--- a/storage/tianmu/core/query_compile.cpp
+++ b/storage/tianmu/core/query_compile.cpp
@@ -987,7 +987,13 @@ int Query::Compile(CompiledQuery *compiled_query, SELECT_LEX *selects_list, SELE
     SetLimit(sl, sl == selects_list ? 0 : sl->join->unit->global_parameters(), offset_value, limit_value);
 
     List<Item> *fields = &sl->fields_list;
-    Item *conds = sl->where_cond();
+
+    Item *conds = nullptr;
+    if (ifNewJoinForTianmu || !sl->join->where_cond)
+      conds = sl->where_cond();
+    else
+      conds = sl->join->where_cond;
+
     ORDER *order = sl->order_list.first;
 
     // if (order) global_order = 0;   //we want to zero global order (which


### PR DESCRIPTION
Cause:
When the date in MySQL is 0, the value is considered to be null. MySQL handles this problem. If you query the statement of isull, you will convert isnull to=0. This problem is that the value with the date of 0 is inserted into the table. The query and deletion results of the tianmu engine are not consistent. The reason for the inconsistency is that the syntax parsing logic of the query and deletion of tianmu is not the same 
>Supplementary description of date type on MySQL official website:
<img width="1043" alt="lQLPJxbJU4noaETNBEfNCCWwjasZm-ZjXkkDSutaV4CqAA_2085_1095" src="https://user-images.githubusercontent.com/106147765/197437673-bb771d0d-c83a-42f5-a14e-5e4aaaadf247.png">
Solution:

Unified query logic and modification logic for date format processing. Keep the phenomenon of tianmu consistent with innodb.

<!--

Thank you for contributing to StoneDB!

PR Title Format: <type>(<scope>): description to this pr (#issue_id)
e.g.
fix(util): fix sth..... (#1)

-->

## Summary about this PR
<!--

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".
e.g.:
Issue: close #1

-->

Issue Number: close #682


## Tests Check List
<!-- At least one of next options must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

## Changelog
<!-- At least one of next options must be included. -->

- [ ] New Feature
- [x] Bug Fix
- [ ] Improvement
- [ ] Performance Improvement
- [ ] Build/Testing/CI/CD
- [ ] Documentation
- [ ] Not for changelog (changelog entry is not required)

## Documentation
<!-- At least one of next options must be included. -->

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
