### PR TITLE
fix(tianmu):EXPLAIN query Q4, MySQL server has gone away (#727)

### DIFF
--- a/storage/tianmu/core/query_compile.cpp
+++ b/storage/tianmu/core/query_compile.cpp
@@ -1101,11 +1101,8 @@ int Query::Compile(CompiledQuery *compiled_query, SELECT_LEX *selects_list, SELE
       cq = saved_cq;
       if (cond_to_reinsert && list_to_reinsert)
         list_to_reinsert->push_back(cond_to_reinsert);
-      sl->cleanup(0);
-      if (ifNewJoinForTianmu) {
-        delete sl->join;
-        sl->join = nullptr;
-      }
+      if (ifNewJoinForTianmu)
+        sl->cleanup(true);
       return RETURN_QUERY_TO_MYSQL_ROUTE;
     }
 
@@ -1127,11 +1124,8 @@ int Query::Compile(CompiledQuery *compiled_query, SELECT_LEX *selects_list, SELE
       union_all = true;
     if (cond_to_reinsert && list_to_reinsert)
       list_to_reinsert->push_back(cond_to_reinsert);
-    sl->cleanup(0);
-    if (ifNewJoinForTianmu) {
-      delete sl->join;
-      sl->join = nullptr;
-    }
+    if (ifNewJoinForTianmu)
+      sl->cleanup(true);
   }
 
   cq->BuildTableIDStepsMap();


### PR DESCRIPTION

<!--

Thank you for contributing to StoneDB!

PR Title Format: <type>(<scope>): description to this pr (#issue_id)
e.g.
fix(util): fix sth..... (#1)

-->

## Summary about this PR
<!--

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".
e.g.:
Issue: close #1

-->

Issue Number: close #727 

[summary]
Eplain query Q4 lead to crash,because assert(join == NULL) in SELECT_LEX::optimize() function. 
the root cause is that the new join is not released. we can use sl->cleanup(true) to release it

## Tests Check List
<!-- At least one of next options must be included. -->

- [ ] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

## Changelog
<!-- At least one of next options must be included. -->

- [ ] New Feature
- [x] Bug Fix
- [ ] Improvement
- [ ] Performance Improvement
- [ ] Build/Testing/CI/CD
- [ ] Documentation
- [ ] Not for changelog (changelog entry is not required)

## Documentation
<!-- At least one of next options must be included. -->

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
