### PR TITLE
fix(tianmu): fix query syntax (WHERE NOT IN ) is not supported. (#767)

### DIFF
--- a/mysql-test/suite/tianmu/r/issue767.result
+++ b/mysql-test/suite/tianmu/r/issue767.result
@@ -1,0 +1,152 @@
+use test;
+create table t1(val int) ENGINE=tianmu;
+create table t2(val2 int) ENGINE=tianmu;
+insert into t1 values(0);
+insert into t1 values(1);
+insert into t1 values(10);
+insert into t1 values(11);
+insert into t1 values(20);
+insert into t1 values(21);
+insert into t1 values(42);
+insert into t1 values(43);
+insert into t2 values(0);
+insert into t2 values(1);
+insert into t2 values(10);
+insert into t2 values(11);
+insert into t2 values(20);
+insert into t2 values(21);
+insert into t2 values(42);
+insert into t2 values(43);
+select * from t1 where 42 not in (select * from t1 where val > 42);
+val
+0
+1
+10
+11
+20
+21
+42
+43
+select * from t1 where 42 not in (select * from t1 where val < 10);
+val
+0
+1
+10
+11
+20
+21
+42
+43
+select * from t1 where 42 not in (select * from t1 where val >= 42);
+val
+select * from t1 where 42 not in (select * from t1 where val <= 10);
+val
+0
+1
+10
+11
+20
+21
+42
+43
+insert into t2 values(10);
+select * from t1 where val not in (select * from t2 where val2 > 10);
+val
+0
+1
+10
+select * from t1 where val not in (select * from t2 where val2 >= 10);
+val
+0
+1
+select * from t1 where val not in (select * from t2 where val2 < 10);
+val
+10
+11
+20
+21
+42
+43
+select * from t1 where val not in (select * from t2 where val2 <=10);
+val
+11
+20
+21
+42
+43
+select * from t1 where val not in (select * from t2 where val2 > t1.val);
+val
+0
+1
+10
+11
+20
+21
+42
+43
+select * from t1 where val not in (select * from t2 where val2 >= t1.val);
+val
+select * from t1 where val not in (select * from t2 where val2 < t1.val);
+val
+0
+1
+10
+11
+20
+21
+42
+43
+select * from t1 where val not in (select * from t2 where val2 <= t1.val);
+val
+select * from t1 where val not in (select * from t2 where val2 > t1.val and val2 >t1.val +10);
+val
+0
+1
+10
+11
+20
+21
+42
+43
+select * from t1 where val not in (select * from t2 where val2 >= t1.val and val2 >= t1.val +10);
+val
+0
+1
+10
+11
+20
+21
+42
+43
+select * from t1 where val not in (select * from t2 where val2 < t1.val and val2 <t1.val +10);
+val
+0
+1
+10
+11
+20
+21
+42
+43
+select * from t1 where val not in (select * from t2 where val2 <= t1.val and val2 >= t1.val +10);
+val
+0
+1
+10
+11
+20
+21
+42
+43
+select * from t1 where val not in (select * from t2 where val2 > t1.val);
+val
+0
+1
+10
+11
+20
+21
+42
+43
+drop table t1;
+drop table t2;

--- a/mysql-test/suite/tianmu/t/issue767.test
+++ b/mysql-test/suite/tianmu/t/issue767.test
@@ -1,0 +1,49 @@
+--source include/have_tianmu.inc
+use test;
+create table t1(val int) ENGINE=tianmu;
+create table t2(val2 int) ENGINE=tianmu;
+
+insert into t1 values(0);
+insert into t1 values(1);
+insert into t1 values(10);
+insert into t1 values(11);
+insert into t1 values(20);
+insert into t1 values(21);
+insert into t1 values(42);
+insert into t1 values(43);
+insert into t2 values(0);
+insert into t2 values(1);
+insert into t2 values(10);
+insert into t2 values(11);
+insert into t2 values(20);
+insert into t2 values(21);
+insert into t2 values(42);
+insert into t2 values(43);
+
+#original case(just test not in)
+select * from t1 where 42 not in (select * from t1 where val > 42);
+select * from t1 where 42 not in (select * from t1 where val < 10);
+select * from t1 where 42 not in (select * from t1 where val >= 42);
+select * from t1 where 42 not in (select * from t1 where val <= 10);
+
+#independent subquery
+insert into t2 values(10);
+select * from t1 where val not in (select * from t2 where val2 > 10);
+select * from t1 where val not in (select * from t2 where val2 >= 10);
+select * from t1 where val not in (select * from t2 where val2 < 10);
+select * from t1 where val not in (select * from t2 where val2 <=10);
+
+#dependent subquery
+select * from t1 where val not in (select * from t2 where val2 > t1.val);
+select * from t1 where val not in (select * from t2 where val2 >= t1.val);
+select * from t1 where val not in (select * from t2 where val2 < t1.val);
+select * from t1 where val not in (select * from t2 where val2 <= t1.val);
+
+select * from t1 where val not in (select * from t2 where val2 > t1.val and val2 >t1.val +10);
+select * from t1 where val not in (select * from t2 where val2 >= t1.val and val2 >= t1.val +10);
+select * from t1 where val not in (select * from t2 where val2 < t1.val and val2 <t1.val +10);
+select * from t1 where val not in (select * from t2 where val2 <= t1.val and val2 >= t1.val +10);
+select * from t1 where val not in (select * from t2 where val2 > t1.val);
+
+drop table t1;
+drop table t2;

--- a/storage/tianmu/core/compiled_query.cpp
+++ b/storage/tianmu/core/compiled_query.cpp
@@ -328,6 +328,7 @@ void CompiledQuery::CQStep::Print(Query *query) {
     case StepType::TMP_TABLE: {
       std::sprintf(buf, "T:%d = TMP_TABLE(", N(t1.n));
       for (auto ele : tables1) std::sprintf(buf + std::strlen(buf), "T:%d,", N(ele.n));
+      std::sprintf(buf + std::strlen(buf), ")");
     } break;
     case StepType::CREATE_VC:
       if (mysql_expr.size() == 1) {

--- a/storage/tianmu/core/joiner.cpp
+++ b/storage/tianmu/core/joiner.cpp
@@ -48,11 +48,11 @@ JoinAlgType TwoDimensionalJoiner::ChooseJoinAlgorithm([[maybe_unused]] MultiInde
   });
 
   if (cond[0].IsType_Exists()) {
-    return choose_map_or_hash();
+    return JoinAlgType::JTYPE_GENERAL;  // nested loop
   }
 
   if (cond[0].IsType_In()) {
-    return choose_map_or_hash();
+    return JoinAlgType::JTYPE_GENERAL;  // nested loop
   }
 
   if (!cond[0].IsType_JoinSimple()) {

--- a/storage/tianmu/core/query_compile.cpp
+++ b/storage/tianmu/core/query_compile.cpp
@@ -973,7 +973,12 @@ QueryRouteTo Query::Compile(CompiledQuery *compiled_query, Query_block *selects_
 
     // according the meaning of `part`, which describs in JOIN::optimize
     if (!sl->join) {
-      TIANMU_LOG(LogCtl_Level::ERROR, "sl->join is nil!!!!");
+      auto thd = current_txn_->Thd();
+      DEBUG_ASSERT(thd != nullptr);
+      JOIN *join = new (thd->mem_root) JOIN(thd, sl);
+
+      sl->set_join(thd, join);
+      TIANMU_LOG(LogCtl_Level::INFO, "sl->join is nullptr!");
     }
 
     if (JudgeErrors(sl) == QueryRouteTo::TO_MYSQL)

--- a/storage/tianmu/core/temp_table.cpp
+++ b/storage/tianmu/core/temp_table.cpp
@@ -2426,7 +2426,7 @@ TempTableForSubquery::~TempTableForSubquery() {
   for (auto it : template_attrs_) delete it;
 }
 
-void TempTableForSubquery::ResetToTemplate(bool rough) {
+void TempTableForSubquery::ResetToTemplate(bool rough, bool use_filter_shallow) {
   if (!template_filter_)
     return;
 
@@ -2442,8 +2442,13 @@ void TempTableForSubquery::ResetToTemplate(bool rough) {
     (*attrs_[i]).buffer_ = orig_buf;
   }
 
-  filter_ = std::move(*template_filter_);  // shallow
-  filter_shallow_memory_ = true;
+  if (use_filter_shallow) {
+    filter_ = std::move(*template_filter_);  // shallow
+    filter_shallow_memory_ = true;
+  } else {
+    filter_ = *template_filter_;
+    filter_shallow_memory_ = false;
+  }
 
   for (int i = 0; i < num_of_global_virtual_columns_; i++)
     if (!virtual_columns_for_having_[i])

--- a/storage/tianmu/core/temp_table.h
+++ b/storage/tianmu/core/temp_table.h
@@ -572,7 +572,7 @@ class TempTableForSubquery : public TempTable {
   void CreateTemplateIfNotExists();
   void Materialize(bool in_subq = false, ResultSender *sender = nullptr, bool lazy = false) override;
   void RoughMaterialize(bool in_subq = false, ResultSender *sender = nullptr, bool lazy = false) override;
-  void ResetToTemplate(bool rough);
+  void ResetToTemplate(bool rough, bool use_filter_shallow = false);
   void SetAttrsForRough();
   void SetAttrsForExact();
 


### PR DESCRIPTION
<!--

Thank you for contributing to StoneDB!

PR Title Format: <type>(<scope>): description to this pr (#issue_id)
e.g.
fix(util): fix sth..... (#1)

-->

## Summary about this PR
<!--

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".
e.g.:
Issue: close #1

-->

Issue Number: ref #767

[summary]
1 'sub_select' item is the left argument,not the right argument of 'item_func';
2 5.7 use 'item_func_not' class to represent the meaning of the syntax "not", while 8.0 use a variable 'value_transform';
3 porting new join code from 5.7 for this case；
3.1 solve throwing exception  ”select * from t1 where val not in (select * from t2 where val2 >= 10);“
4 porting ChooseJoinAlgorithm from 5.7 for this case;
4.1 solve incorrect result set for some sql in the mtr（which one is forgotton...)
5 porting ResetToTemplate modification from 5.7 for this case;
5.1 solve incorrect result set "select * from t1 where val not in (select * from t2 where val2 > t1.val);"


## Tests Check List
<!-- At least one of next options must be included. -->

- [ ] Unit test
- [X] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

## Changelog
<!-- At least one of next options must be included. -->

- [ ] New Feature
- [X] Bug Fix
- [ ] Improvement
- [ ] Performance Improvement
- [ ] Build/Testing/CI/CD
- [ ] Documentation
- [ ] Not for changelog (changelog entry is not required)

## Documentation
<!-- At least one of next options must be included. -->

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
