### PR TITLE
    fix(tianmu): fix query with ESCAPE (#271 #272)

### DIFF
--- a/mysql-test/suite/tianmu/r/issue271.result
+++ b/mysql-test/suite/tianmu/r/issue271.result
@@ -1,0 +1,166 @@
+USE test;
+DROP TABLE IF EXISTS test1;
+CREATE TABLE test1(a varchar(100)) ENGINE=TIANMU DEFAULT CHARSET=utf8mb4;
+INSERT INTO test1 VALUES ('hakan%'), ('hakank'), ("ha%an");
+SET @OLD_SQL_MODE12595=@@SQL_MODE, @@SQL_MODE='';
+SHOW LOCAL VARIABLES LIKE 'SQL_MODE';
+Variable_name	Value
+sql_mode	
+SELECT * FROM test1 WHERE a LIKE 'hakan*%' ESCAPE '*';
+a
+hakan%
+SELECT * FROM test1 WHERE a LIKE 'ha|%an' ESCAPE '|';
+a
+ha%an
+SELECT * FROM test1 WHERE a LIKE 'hakan%' ESCAPE '';
+a
+hakan%
+hakank
+SELECT * FROM test1 WHERE a LIKE 'hakan\%' ESCAPE '\\';
+a
+hakan%
+SELECT * FROM test1 WHERE a LIKE 'hakan\n%' ESCAPE '\n';
+a
+hakan%
+SET @@SQL_MODE='NO_BACKSLASH_ESCAPES';
+SHOW LOCAL VARIABLES LIKE 'SQL_MODE';
+Variable_name	Value
+sql_mode	NO_BACKSLASH_ESCAPES
+SELECT * FROM test1 WHERE a LIKE 'hakan%' ESCAPE ' ';
+a
+hakan%
+hakank
+SELECT * FROM test1 WHERE a LIKE 'hakan\n%' ESCAPE 'n';
+a
+SELECT * FROM test1 WHERE a LIKE 'hakan\%' ESCAPE '%';
+a
+SELECT * FROM test1 WHERE a LIKE 'hakan\%' ESCAPE '*';
+a
+SET @OLD_SQL_MODE12595=@@SQL_MODE, @@SQL_MODE='';
+SHOW LOCAL VARIABLES LIKE 'SQL_MODE';
+Variable_name	Value
+sql_mode	
+DROP TABLE test1;
+CREATE TABLE test1(a varchar(100)) ENGINE=TIANMU DEFAULT CHARSET=ascii;
+INSERT INTO test1 VALUES ('hakan%'), ('hakank'), ("ha%an");
+SET @OLD_SQL_MODE12595=@@SQL_MODE, @@SQL_MODE='';
+SHOW LOCAL VARIABLES LIKE 'SQL_MODE';
+Variable_name	Value
+sql_mode	
+SELECT * FROM test1 WHERE a LIKE 'hakan*%' ESCAPE '*';
+a
+hakan%
+SELECT * FROM test1 WHERE a LIKE 'ha|%an' ESCAPE '|';
+a
+ha%an
+SELECT * FROM test1 WHERE a LIKE 'hakan%' ESCAPE '';
+a
+hakan%
+hakank
+SELECT * FROM test1 WHERE a LIKE 'hakan\%' ESCAPE '\\';
+a
+hakan%
+SELECT * FROM test1 WHERE a LIKE 'hakan\n%' ESCAPE '\n';
+a
+hakan%
+SET @@SQL_MODE='NO_BACKSLASH_ESCAPES';
+SHOW LOCAL VARIABLES LIKE 'SQL_MODE';
+Variable_name	Value
+sql_mode	NO_BACKSLASH_ESCAPES
+SELECT * FROM test1 WHERE a LIKE 'hakan%' ESCAPE ' ';
+a
+hakan%
+hakank
+SELECT * FROM test1 WHERE a LIKE 'hakan\n%' ESCAPE 'n';
+a
+SELECT * FROM test1 WHERE a LIKE 'hakan\%' ESCAPE '%';
+a
+SELECT * FROM test1 WHERE a LIKE 'hakan\%' ESCAPE '*';
+a
+SET @OLD_SQL_MODE12595=@@SQL_MODE, @@SQL_MODE='';
+SHOW LOCAL VARIABLES LIKE 'SQL_MODE';
+Variable_name	Value
+sql_mode	
+DROP TABLE test1;
+CREATE TABLE test1(a varchar(100)) ENGINE=TIANMU DEFAULT CHARSET=gb18030;
+INSERT INTO test1 VALUES ('hakan%'), ('hakank'), ("ha%an");
+SET @OLD_SQL_MODE12595=@@SQL_MODE, @@SQL_MODE='';
+SHOW LOCAL VARIABLES LIKE 'SQL_MODE';
+Variable_name	Value
+sql_mode	
+SELECT * FROM test1 WHERE a LIKE 'hakan*%' ESCAPE '*';
+a
+hakan%
+SELECT * FROM test1 WHERE a LIKE 'ha|%an' ESCAPE '|';
+a
+ha%an
+SELECT * FROM test1 WHERE a LIKE 'hakan%' ESCAPE '';
+a
+hakan%
+hakank
+SELECT * FROM test1 WHERE a LIKE 'hakan\%' ESCAPE '\\';
+a
+hakan%
+SELECT * FROM test1 WHERE a LIKE 'hakan\n%' ESCAPE '\n';
+a
+hakan%
+SET @@SQL_MODE='NO_BACKSLASH_ESCAPES';
+SHOW LOCAL VARIABLES LIKE 'SQL_MODE';
+Variable_name	Value
+sql_mode	NO_BACKSLASH_ESCAPES
+SELECT * FROM test1 WHERE a LIKE 'hakan%' ESCAPE ' ';
+a
+hakan%
+hakank
+SELECT * FROM test1 WHERE a LIKE 'hakan\n%' ESCAPE 'n';
+a
+SELECT * FROM test1 WHERE a LIKE 'hakan\%' ESCAPE '%';
+a
+SELECT * FROM test1 WHERE a LIKE 'hakan\%' ESCAPE '*';
+a
+SET @OLD_SQL_MODE12595=@@SQL_MODE, @@SQL_MODE='';
+SHOW LOCAL VARIABLES LIKE 'SQL_MODE';
+Variable_name	Value
+sql_mode	
+DROP TABLE test1;
+CREATE TABLE test1(a varchar(100)) ENGINE=TIANMU DEFAULT CHARSET=gb2312;
+INSERT INTO test1 VALUES ('hakan%'), ('hakank'), ("ha%an");
+SET @OLD_SQL_MODE12595=@@SQL_MODE, @@SQL_MODE='';
+SHOW LOCAL VARIABLES LIKE 'SQL_MODE';
+Variable_name	Value
+sql_mode	
+SELECT * FROM test1 WHERE a LIKE 'hakan*%' ESCAPE '*';
+a
+hakan%
+SELECT * FROM test1 WHERE a LIKE 'ha|%an' ESCAPE '|';
+a
+ha%an
+SELECT * FROM test1 WHERE a LIKE 'hakan%' ESCAPE '';
+a
+hakan%
+hakank
+SELECT * FROM test1 WHERE a LIKE 'hakan\%' ESCAPE '\\';
+a
+hakan%
+SELECT * FROM test1 WHERE a LIKE 'hakan\n%' ESCAPE '\n';
+a
+hakan%
+SET @@SQL_MODE='NO_BACKSLASH_ESCAPES';
+SHOW LOCAL VARIABLES LIKE 'SQL_MODE';
+Variable_name	Value
+sql_mode	NO_BACKSLASH_ESCAPES
+SELECT * FROM test1 WHERE a LIKE 'hakan%' ESCAPE ' ';
+a
+hakan%
+hakank
+SELECT * FROM test1 WHERE a LIKE 'hakan\n%' ESCAPE 'n';
+a
+SELECT * FROM test1 WHERE a LIKE 'hakan\%' ESCAPE '%';
+a
+SELECT * FROM test1 WHERE a LIKE 'hakan\%' ESCAPE '*';
+a
+SET @OLD_SQL_MODE12595=@@SQL_MODE, @@SQL_MODE='';
+SHOW LOCAL VARIABLES LIKE 'SQL_MODE';
+Variable_name	Value
+sql_mode	
+DROP TABLE test1;

--- a/mysql-test/suite/tianmu/t/issue271.test
+++ b/mysql-test/suite/tianmu/t/issue271.test
@@ -1,0 +1,251 @@
+--source include/have_tianmu.inc
+
+USE test;
+
+--disable_warnings
+
+# CHARACTER utf8mb4
+
+## DDL
+
+DROP TABLE IF EXISTS test1;
+
+CREATE TABLE test1(a varchar(100)) ENGINE=TIANMU DEFAULT CHARSET=utf8mb4;
+
+## insert data
+
+INSERT INTO test1 VALUES ('hakan%'), ('hakank'), ("ha%an");
+
+## Setting the Default SQL MODE
+
+SET @OLD_SQL_MODE12595=@@SQL_MODE, @@SQL_MODE='';
+
+SHOW LOCAL VARIABLES LIKE 'SQL_MODE';
+
+## query of escape
+
+### issue271
+
+SELECT * FROM test1 WHERE a LIKE 'hakan*%' ESCAPE '*';
+
+### issue272
+
+SELECT * FROM test1 WHERE a LIKE 'ha|%an' ESCAPE '|';
+
+### issue273 but with default SQL MODE
+
+SELECT * FROM test1 WHERE a LIKE 'hakan%' ESCAPE '';
+
+SELECT * FROM test1 WHERE a LIKE 'hakan\%' ESCAPE '\\';
+
+SELECT * FROM test1 WHERE a LIKE 'hakan\n%' ESCAPE '\n';
+
+#### sql mod NO_BACKSLASH_ESCAPES
+
+SET @@SQL_MODE='NO_BACKSLASH_ESCAPES';
+
+SHOW LOCAL VARIABLES LIKE 'SQL_MODE';
+
+#### ESCAPE must be a single character
+
+SELECT * FROM test1 WHERE a LIKE 'hakan%' ESCAPE ' ';
+
+SELECT * FROM test1 WHERE a LIKE 'hakan\n%' ESCAPE 'n';
+
+SELECT * FROM test1 WHERE a LIKE 'hakan\%' ESCAPE '%';
+
+SELECT * FROM test1 WHERE a LIKE 'hakan\%' ESCAPE '*';
+
+## Restoring SQL MODE
+
+SET @OLD_SQL_MODE12595=@@SQL_MODE, @@SQL_MODE='';
+
+SHOW LOCAL VARIABLES LIKE 'SQL_MODE';
+
+## clean test table
+
+DROP TABLE test1;
+
+
+# CHARACTER ascii
+
+## DDL
+
+CREATE TABLE test1(a varchar(100)) ENGINE=TIANMU DEFAULT CHARSET=ascii;
+
+## insert data
+
+INSERT INTO test1 VALUES ('hakan%'), ('hakank'), ("ha%an");
+
+## Setting the Default SQL MODE
+
+SET @OLD_SQL_MODE12595=@@SQL_MODE, @@SQL_MODE='';
+
+SHOW LOCAL VARIABLES LIKE 'SQL_MODE';
+
+## query of escape
+
+### issue271
+
+SELECT * FROM test1 WHERE a LIKE 'hakan*%' ESCAPE '*';
+
+### issue272
+
+SELECT * FROM test1 WHERE a LIKE 'ha|%an' ESCAPE '|';
+
+### issue273 but with default SQL MODE
+
+SELECT * FROM test1 WHERE a LIKE 'hakan%' ESCAPE '';
+
+SELECT * FROM test1 WHERE a LIKE 'hakan\%' ESCAPE '\\';
+
+SELECT * FROM test1 WHERE a LIKE 'hakan\n%' ESCAPE '\n';
+
+#### sql mod NO_BACKSLASH_ESCAPES
+
+SET @@SQL_MODE='NO_BACKSLASH_ESCAPES';
+
+SHOW LOCAL VARIABLES LIKE 'SQL_MODE';
+
+#### ESCAPE must be a single character
+
+SELECT * FROM test1 WHERE a LIKE 'hakan%' ESCAPE ' ';
+
+SELECT * FROM test1 WHERE a LIKE 'hakan\n%' ESCAPE 'n';
+
+SELECT * FROM test1 WHERE a LIKE 'hakan\%' ESCAPE '%';
+
+SELECT * FROM test1 WHERE a LIKE 'hakan\%' ESCAPE '*';
+
+## Restoring SQL MODE
+
+SET @OLD_SQL_MODE12595=@@SQL_MODE, @@SQL_MODE='';
+
+SHOW LOCAL VARIABLES LIKE 'SQL_MODE';
+
+## clean test table
+
+DROP TABLE test1;
+
+
+# CHARACTER gb18030
+
+## DDL
+
+CREATE TABLE test1(a varchar(100)) ENGINE=TIANMU DEFAULT CHARSET=gb18030;
+
+## insert data
+
+INSERT INTO test1 VALUES ('hakan%'), ('hakank'), ("ha%an");
+
+## Setting the Default SQL MODE
+
+SET @OLD_SQL_MODE12595=@@SQL_MODE, @@SQL_MODE='';
+
+SHOW LOCAL VARIABLES LIKE 'SQL_MODE';
+
+## query of escape
+
+### issue271
+
+SELECT * FROM test1 WHERE a LIKE 'hakan*%' ESCAPE '*';
+
+### issue272
+
+SELECT * FROM test1 WHERE a LIKE 'ha|%an' ESCAPE '|';
+
+### issue273 but with default SQL MODE
+
+SELECT * FROM test1 WHERE a LIKE 'hakan%' ESCAPE '';
+
+SELECT * FROM test1 WHERE a LIKE 'hakan\%' ESCAPE '\\';
+
+SELECT * FROM test1 WHERE a LIKE 'hakan\n%' ESCAPE '\n';
+
+#### sql mod NO_BACKSLASH_ESCAPES
+
+SET @@SQL_MODE='NO_BACKSLASH_ESCAPES';
+
+SHOW LOCAL VARIABLES LIKE 'SQL_MODE';
+
+#### ESCAPE must be a single character
+
+SELECT * FROM test1 WHERE a LIKE 'hakan%' ESCAPE ' ';
+
+SELECT * FROM test1 WHERE a LIKE 'hakan\n%' ESCAPE 'n';
+
+SELECT * FROM test1 WHERE a LIKE 'hakan\%' ESCAPE '%';
+
+SELECT * FROM test1 WHERE a LIKE 'hakan\%' ESCAPE '*';
+
+## Restoring SQL MODE
+
+SET @OLD_SQL_MODE12595=@@SQL_MODE, @@SQL_MODE='';
+
+SHOW LOCAL VARIABLES LIKE 'SQL_MODE';
+
+## clean test table
+
+DROP TABLE test1;
+
+
+# CHARACTER gdk
+
+## DDL
+
+CREATE TABLE test1(a varchar(100)) ENGINE=TIANMU DEFAULT CHARSET=gb2312;
+
+## insert data
+
+INSERT INTO test1 VALUES ('hakan%'), ('hakank'), ("ha%an");
+
+## Setting the Default SQL MODE
+
+SET @OLD_SQL_MODE12595=@@SQL_MODE, @@SQL_MODE='';
+
+SHOW LOCAL VARIABLES LIKE 'SQL_MODE';
+
+## query of escape
+
+### issue271
+
+SELECT * FROM test1 WHERE a LIKE 'hakan*%' ESCAPE '*';
+
+### issue272
+
+SELECT * FROM test1 WHERE a LIKE 'ha|%an' ESCAPE '|';
+
+### issue273 but with default SQL MODE
+
+SELECT * FROM test1 WHERE a LIKE 'hakan%' ESCAPE '';
+
+SELECT * FROM test1 WHERE a LIKE 'hakan\%' ESCAPE '\\';
+
+SELECT * FROM test1 WHERE a LIKE 'hakan\n%' ESCAPE '\n';
+
+#### sql mod NO_BACKSLASH_ESCAPES
+
+SET @@SQL_MODE='NO_BACKSLASH_ESCAPES';
+
+SHOW LOCAL VARIABLES LIKE 'SQL_MODE';
+
+#### ESCAPE must be a single character
+
+SELECT * FROM test1 WHERE a LIKE 'hakan%' ESCAPE ' ';
+
+SELECT * FROM test1 WHERE a LIKE 'hakan\n%' ESCAPE 'n';
+
+SELECT * FROM test1 WHERE a LIKE 'hakan\%' ESCAPE '%';
+
+SELECT * FROM test1 WHERE a LIKE 'hakan\%' ESCAPE '*';
+
+## Restoring SQL MODE
+
+SET @OLD_SQL_MODE12595=@@SQL_MODE, @@SQL_MODE='';
+
+SHOW LOCAL VARIABLES LIKE 'SQL_MODE';
+
+## clean test table
+
+DROP TABLE test1;
+

--- a/storage/tianmu/core/tianmu_attr_exqp.cpp
+++ b/storage/tianmu/core/tianmu_attr_exqp.cpp
@@ -524,7 +524,7 @@ void TianmuAttr::EvaluatePack_Like_UTF(MIUpdatingIterator &mit, int dim, Descrip
       else {
         v.MakePersistent();
         int x = common::wildcmp(d.GetCollation(), v.val_, v.val_ + v.len_, pattern.val_, pattern.val_ + pattern.len_,
-                                '\\', '_', '%');
+                                d.like_esc, '_', '%');
         res = (x == 0 ? true : false);
       }
       if (d.op == common::Operator::O_NOT_LIKE)


### PR DESCRIPTION
    Reasons: The escape character is not properly passed to the tianmu blur match handler

<!--

Thank you for contributing to StoneDB!

PR Title Format: <type>(<scope>): description to this pr (#issue_id)
e.g.
fix(util): fix sth..... (#1)

-->

## Summary about this PR
<!--

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".
e.g.:
Issue: close #1

-->

Issue Number: close #271 #272 #273 


## Tests Check List
<!-- At least one of next options must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

## Changelog
<!-- At least one of next options must be included. -->

- [ ] New Feature
- [x] Bug Fix
- [ ] Performance Improvement
- [ ] Build/Testing/CI/CD
- [ ] Documentation
- [ ] Not for changelog (changelog entry is not required)

## Documentation
<!-- At least one of next options must be included. -->

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
