### PR TITLE
feat(tianmu): To support Binlog in mandatory tianmu engine mode (#956)

### DIFF
--- a/mysql-test/suite/tianmu/r/issue819.result
+++ b/mysql-test/suite/tianmu/r/issue819.result
@@ -3,7 +3,7 @@ include/master-slave.inc
 #
 # Test the master-slave function of innodb
 # 
-# connection master
+[on master]
 use test;
 create table ttt(id int primary key,name varchar(5))engine=innodb;
 insert into ttt values(1,'AAA');
@@ -12,15 +12,15 @@ insert into ttt values(1,'aaa');
 select * from ttt;
 id	name
 1	aaa
-# connection slave
+[on slave]
 include/sync_slave_sql_with_master.inc
 select * from ttt;
 id	name
 1	aaa
-# connection master
+[on master]
 drop table ttt;
 include/sync_slave_sql_with_master.inc
-# connection master
+[on master]
 CREATE TABLE t1 (a int not null,b int not null)engine=innodb;
 CREATE TABLE t2 (a int not null, b int not null, primary key (a,b))engine=innodb;
 CREATE TABLE t3 (a int not null, b int not null, primary key (a,b))engine=innodb;
@@ -38,7 +38,7 @@ a	b
 3	3
 select * from t3;
 a	b
-# connection slave
+[on slave]
 include/sync_slave_sql_with_master.inc
 select * from t1;
 a	b
@@ -50,19 +50,19 @@ a	b
 3	3
 select * from t3;
 a	b
-# connection master
+[on master]
 drop table t1,t2,t3;
 include/sync_slave_sql_with_master.inc
-# connection master
+[on master]
 CREATE TABLE t1
 (
-place_id int (10) unsigned NOT NULL,
-shows int(10) unsigned DEFAULT '0' NOT NULL,
-ishows int(10) unsigned DEFAULT '0' NOT NULL,
-ushows int(10) unsigned DEFAULT '0' NOT NULL,
-clicks int(10) unsigned DEFAULT '0' NOT NULL,
-iclicks int(10) unsigned DEFAULT '0' NOT NULL,
-uclicks int(10) unsigned DEFAULT '0' NOT NULL,
+place_id int (10),
+shows int(10),
+ishows int(10),
+ushows int(10),
+clicks int(10),
+iclicks int(10),
+uclicks int(10),
 ts timestamp,
 PRIMARY KEY (place_id,ts)
 )engine=innodb;
@@ -72,18 +72,18 @@ UPDATE t1 SET shows=shows+1,ishows=ishows+1,ushows=ushows+1,clicks=clicks+1,icli
 select place_id,shows from t1;
 place_id	shows
 1	1
-# connection slave
+[on slave]
 include/sync_slave_sql_with_master.inc
 select place_id,shows from t1;
 place_id	shows
 1	1
-# connection master
+[on master]
 drop table t1;
 include/sync_slave_sql_with_master.inc
 #
 # Test the master-slave function of tianmu
 # 
-# connection master
+[on master]
 use test;
 create table ttt(id int primary key,name varchar(5))engine=tianmu;
 insert into ttt values(1,'AAA');
@@ -91,15 +91,15 @@ update ttt set name='hhhh' where id=1;
 select * from ttt;
 id	name
 1	hhhh
-# connection slave
+[on slave]
 include/sync_slave_sql_with_master.inc
 select * from ttt;
 id	name
 1	hhhh
-# connection master
+[on master]
 drop table ttt;
 include/sync_slave_sql_with_master.inc
-# connection master
+[on master]
 create table t1(id int primary key,name varchar(5))engine=tianmu;
 insert into t1 values(1,'AAA');
 delete from t1 where id=1;
@@ -107,12 +107,12 @@ insert into t1 values(1,'aaa');
 select * from t1;
 id	name
 1	aaa
-# connection slave
+[on slave]
 include/sync_slave_sql_with_master.inc
 select * from t1;
 id	name
 1	aaa
-# connection master
+[on master]
 drop table t1;
 CREATE TABLE t1 (a int not null,b int not null)engine=tianmu;
 CREATE TABLE t2 (a int not null, b int not null, primary key (a,b))engine=tianmu;
@@ -131,7 +131,7 @@ a	b
 3	3
 select * from t3;
 a	b
-# connection slave
+[on slave]
 include/sync_slave_sql_with_master.inc
 select * from t1;
 a	b
@@ -143,10 +143,10 @@ a	b
 3	3
 select * from t3;
 a	b
-# connection master
+[on master]
 drop table t1,t2,t3;
 include/sync_slave_sql_with_master.inc
-# connection master
+[on master]
 CREATE TABLE t1
 (
 place_id int (10),
@@ -165,12 +165,12 @@ UPDATE t1 SET shows=shows+1,ishows=ishows+1,ushows=ushows+1,clicks=clicks+1,icli
 select place_id,shows from t1;
 place_id	shows
 1	1
-# connection slave
+[on slave]
 include/sync_slave_sql_with_master.inc
 select place_id,shows from t1;
 place_id	shows
 1	1
-# connection master
+[on master]
 drop table t1;
 create table t1 (s1 int);
 create table t2 (s2 int);
@@ -187,7 +187,7 @@ s1	s2
 2	2
 1	3
 2	3
-# connection slave
+[on slave]
 include/sync_slave_sql_with_master.inc
 select * from v1;
 s1	s2
@@ -199,7 +199,7 @@ s1	s2
 2	2
 1	3
 2	3
-# connection master
+[on master]
 drop view v1;
 drop tables t1, t2;
 create table t1 (col1 int);
@@ -209,12 +209,12 @@ insert into t1 values (null);
 select * from v1;
 count(*)
 2
-# connection slave
+[on slave]
 include/sync_slave_sql_with_master.inc
 select * from v1;
 count(*)
 2
-# connection master
+[on master]
 drop view v1;
 drop table t1;
 create table t1 (a int);
@@ -224,12 +224,12 @@ create view v2 as select a from t2 where a in (select a from v1);
 show create view v2;
 View	Create View	character_set_client	collation_connection
 v2	CREATE ALGORITHM=UNDEFINED DEFINER=`root`@`localhost` SQL SECURITY DEFINER VIEW `v2` AS select `t2`.`a` AS `a` from `t2` where `t2`.`a` in (select `v1`.`a` from `v1`)	latin1	latin1_swedish_ci
-# connection slave
+[on slave]
 include/sync_slave_sql_with_master.inc
 show create view v2;
 View	Create View	character_set_client	collation_connection
 v2	CREATE ALGORITHM=UNDEFINED DEFINER=`root`@`localhost` SQL SECURITY DEFINER VIEW `v2` AS select `t2`.`a` AS `a` from `t2` where `t2`.`a` in (select `v1`.`a` from `v1`)	latin1	latin1_swedish_ci
-# connection master
+[on master]
 drop view v2, v1;
 drop table t1, t2;
 include/sync_slave_sql_with_master.inc

--- a/mysql-test/suite/tianmu/r/issue956.result
+++ b/mysql-test/suite/tianmu/r/issue956.result
@@ -1,0 +1,289 @@
+include/master-slave.inc
+[connection master]
+# 
+# sql_mode='STRICT_TRANS_TABLES,NO_AUTO_CREATE_USER,NO_ENGINE_SUBSTITUTION'
+# default_storage_engine=innodb
+# 
+[on slave]
+include/sync_slave_sql_with_master.inc
+set global default_storage_engine=innodb;
+set global sql_mode='STRICT_TRANS_TABLES,NO_AUTO_CREATE_USER,NO_ENGINE_SUBSTITUTION';
+[on master]
+create table t1(c1 int,c2 varchar(255))engine=InnoDB;
+show create table t1;
+Table	Create Table
+t1	CREATE TABLE `t1` (
+  `c1` int(11) DEFAULT NULL,
+  `c2` varchar(255) DEFAULT NULL
+) ENGINE=InnoDB DEFAULT CHARSET=latin1
+[on slave]
+include/sync_slave_sql_with_master.inc
+show global variables like 'sql_mode';
+Variable_name	Value
+sql_mode	STRICT_TRANS_TABLES,NO_AUTO_CREATE_USER,NO_ENGINE_SUBSTITUTION
+show global variables like '%_engine';
+Variable_name	Value
+default_storage_engine	InnoDB
+default_tmp_storage_engine	InnoDB
+internal_tmp_disk_storage_engine	InnoDB
+show create table t1;
+Table	Create Table
+t1	CREATE TABLE `t1` (
+  `c1` int(11) DEFAULT NULL,
+  `c2` varchar(255) DEFAULT NULL
+) ENGINE=InnoDB DEFAULT CHARSET=latin1
+[on master]
+alter table t1 engine=MyISAM;
+show create table t1;
+Table	Create Table
+t1	CREATE TABLE `t1` (
+  `c1` int(11) DEFAULT NULL,
+  `c2` varchar(255) DEFAULT NULL
+) ENGINE=MyISAM DEFAULT CHARSET=latin1
+[on slave]
+show global variables like 'sql_mode';
+Variable_name	Value
+sql_mode	STRICT_TRANS_TABLES,NO_AUTO_CREATE_USER,NO_ENGINE_SUBSTITUTION
+show global variables like '%_engine';
+Variable_name	Value
+default_storage_engine	InnoDB
+default_tmp_storage_engine	InnoDB
+internal_tmp_disk_storage_engine	InnoDB
+show create table t1;
+Table	Create Table
+t1	CREATE TABLE `t1` (
+  `c1` int(11) DEFAULT NULL,
+  `c2` varchar(255) DEFAULT NULL
+) ENGINE=MyISAM DEFAULT CHARSET=latin1
+[on master]
+drop table t1;
+include/sync_slave_sql_with_master.inc
+# 
+# sql_mode='MANDATORY_TIANMU'
+# default_storage_engine=innodb
+# 
+[on slave]
+set global default_storage_engine=innodb;
+set global sql_mode='STRICT_TRANS_TABLES,NO_AUTO_CREATE_USER,NO_ENGINE_SUBSTITUTION,MANDATORY_TIANMU';
+[on master]
+create table t2(c1 int,c2 varchar(255))engine=InnoDB;
+show create table t2;
+Table	Create Table
+t2	CREATE TABLE `t2` (
+  `c1` int(11) DEFAULT NULL,
+  `c2` varchar(255) DEFAULT NULL
+) ENGINE=InnoDB DEFAULT CHARSET=latin1
+[on slave]
+include/sync_slave_sql_with_master.inc
+show global variables like 'sql_mode';
+Variable_name	Value
+sql_mode	STRICT_TRANS_TABLES,NO_AUTO_CREATE_USER,NO_ENGINE_SUBSTITUTION,MANDATORY_TIANMU
+show global variables like '%_engine';
+Variable_name	Value
+default_storage_engine	InnoDB
+default_tmp_storage_engine	InnoDB
+internal_tmp_disk_storage_engine	InnoDB
+show create table t2;
+Table	Create Table
+t2	CREATE TABLE `t2` (
+  `c1` int(11) DEFAULT NULL,
+  `c2` varchar(255) DEFAULT NULL
+) ENGINE=TIANMU DEFAULT CHARSET=latin1
+[on master]
+alter table t2 engine=MyISAM;
+show create table t2;
+Table	Create Table
+t2	CREATE TABLE `t2` (
+  `c1` int(11) DEFAULT NULL,
+  `c2` varchar(255) DEFAULT NULL
+) ENGINE=MyISAM DEFAULT CHARSET=latin1
+[on slave]
+show global variables like 'sql_mode';
+Variable_name	Value
+sql_mode	STRICT_TRANS_TABLES,NO_AUTO_CREATE_USER,NO_ENGINE_SUBSTITUTION,MANDATORY_TIANMU
+show global variables like '%_engine';
+Variable_name	Value
+default_storage_engine	InnoDB
+default_tmp_storage_engine	InnoDB
+internal_tmp_disk_storage_engine	InnoDB
+show create table t2;
+Table	Create Table
+t2	CREATE TABLE `t2` (
+  `c1` int(11) DEFAULT NULL,
+  `c2` varchar(255) DEFAULT NULL
+) ENGINE=TIANMU DEFAULT CHARSET=latin1
+[on master]
+drop table t2;
+include/sync_slave_sql_with_master.inc
+# 
+# sql_mode='STRICT_TRANS_TABLES,NO_AUTO_CREATE_USER,NO_ENGINE_SUBSTITUTION'
+# default_storage_engine=tianmu
+# 
+[on slave]
+set global default_storage_engine=tianmu;
+set global sql_mode='STRICT_TRANS_TABLES,NO_AUTO_CREATE_USER,NO_ENGINE_SUBSTITUTION';
+[on master]
+create table t3(c1 int,c2 varchar(255))engine=InnoDB;
+show create table t3;
+Table	Create Table
+t3	CREATE TABLE `t3` (
+  `c1` int(11) DEFAULT NULL,
+  `c2` varchar(255) DEFAULT NULL
+) ENGINE=InnoDB DEFAULT CHARSET=latin1
+[on slave]
+include/sync_slave_sql_with_master.inc
+show global variables like 'sql_mode';
+Variable_name	Value
+sql_mode	STRICT_TRANS_TABLES,NO_AUTO_CREATE_USER,NO_ENGINE_SUBSTITUTION
+show global variables like '%_engine';
+Variable_name	Value
+default_storage_engine	TIANMU
+default_tmp_storage_engine	InnoDB
+internal_tmp_disk_storage_engine	InnoDB
+show create table t3;
+Table	Create Table
+t3	CREATE TABLE `t3` (
+  `c1` int(11) DEFAULT NULL,
+  `c2` varchar(255) DEFAULT NULL
+) ENGINE=TIANMU DEFAULT CHARSET=latin1
+[on master]
+alter table t3 engine=MyISAM;
+show create table t3;
+Table	Create Table
+t3	CREATE TABLE `t3` (
+  `c1` int(11) DEFAULT NULL,
+  `c2` varchar(255) DEFAULT NULL
+) ENGINE=MyISAM DEFAULT CHARSET=latin1
+[on slave]
+show global variables like 'sql_mode';
+Variable_name	Value
+sql_mode	STRICT_TRANS_TABLES,NO_AUTO_CREATE_USER,NO_ENGINE_SUBSTITUTION
+show global variables like '%_engine';
+Variable_name	Value
+default_storage_engine	TIANMU
+default_tmp_storage_engine	InnoDB
+internal_tmp_disk_storage_engine	InnoDB
+show create table t3;
+Table	Create Table
+t3	CREATE TABLE `t3` (
+  `c1` int(11) DEFAULT NULL,
+  `c2` varchar(255) DEFAULT NULL
+) ENGINE=TIANMU DEFAULT CHARSET=latin1
+[on master]
+drop table t3;
+include/sync_slave_sql_with_master.inc
+# 
+# sql_mode='STRICT_TRANS_TABLES,NO_AUTO_CREATE_USER,NO_ENGINE_SUBSTITUTION,MANDATORY_TIANMU'
+# default_storage_engine=tianmu
+# 
+[on slave]
+set global default_storage_engine=tianmu;
+set global sql_mode='STRICT_TRANS_TABLES,NO_AUTO_CREATE_USER,NO_ENGINE_SUBSTITUTION,MANDATORY_TIANMU';
+[on master]
+create table t4(c1 int,c2 varchar(255))engine=InnoDB;
+show create table t4;
+Table	Create Table
+t4	CREATE TABLE `t4` (
+  `c1` int(11) DEFAULT NULL,
+  `c2` varchar(255) DEFAULT NULL
+) ENGINE=InnoDB DEFAULT CHARSET=latin1
+[on slave]
+include/sync_slave_sql_with_master.inc
+show global variables like 'sql_mode';
+Variable_name	Value
+sql_mode	STRICT_TRANS_TABLES,NO_AUTO_CREATE_USER,NO_ENGINE_SUBSTITUTION,MANDATORY_TIANMU
+show global variables like '%_engine';
+Variable_name	Value
+default_storage_engine	TIANMU
+default_tmp_storage_engine	InnoDB
+internal_tmp_disk_storage_engine	InnoDB
+show create table t4;
+Table	Create Table
+t4	CREATE TABLE `t4` (
+  `c1` int(11) DEFAULT NULL,
+  `c2` varchar(255) DEFAULT NULL
+) ENGINE=TIANMU DEFAULT CHARSET=latin1
+[on master]
+alter table t4 engine=MyISAM;
+show create table t4;
+Table	Create Table
+t4	CREATE TABLE `t4` (
+  `c1` int(11) DEFAULT NULL,
+  `c2` varchar(255) DEFAULT NULL
+) ENGINE=MyISAM DEFAULT CHARSET=latin1
+[on slave]
+show global variables like 'sql_mode';
+Variable_name	Value
+sql_mode	STRICT_TRANS_TABLES,NO_AUTO_CREATE_USER,NO_ENGINE_SUBSTITUTION,MANDATORY_TIANMU
+show global variables like '%_engine';
+Variable_name	Value
+default_storage_engine	TIANMU
+default_tmp_storage_engine	InnoDB
+internal_tmp_disk_storage_engine	InnoDB
+show create table t4;
+Table	Create Table
+t4	CREATE TABLE `t4` (
+  `c1` int(11) DEFAULT NULL,
+  `c2` varchar(255) DEFAULT NULL
+) ENGINE=TIANMU DEFAULT CHARSET=latin1
+[on master]
+drop table t4;
+include/sync_slave_sql_with_master.inc
+# 
+# sql_mode='STRICT_TRANS_TABLES,NO_AUTO_CREATE_USER,NO_ENGINE_SUBSTITUTION'
+# default_storage_engine=MyISAM
+# 
+[on slave]
+set global default_storage_engine=MyISAM;
+set global sql_mode='STRICT_TRANS_TABLES,NO_AUTO_CREATE_USER,NO_ENGINE_SUBSTITUTION';
+[on master]
+create table t4(c1 int,c2 varchar(255))engine=InnoDB;
+show create table t4;
+Table	Create Table
+t4	CREATE TABLE `t4` (
+  `c1` int(11) DEFAULT NULL,
+  `c2` varchar(255) DEFAULT NULL
+) ENGINE=InnoDB DEFAULT CHARSET=latin1
+[on slave]
+include/sync_slave_sql_with_master.inc
+show global variables like 'sql_mode';
+Variable_name	Value
+sql_mode	STRICT_TRANS_TABLES,NO_AUTO_CREATE_USER,NO_ENGINE_SUBSTITUTION
+show global variables like '%_engine';
+Variable_name	Value
+default_storage_engine	MyISAM
+default_tmp_storage_engine	InnoDB
+internal_tmp_disk_storage_engine	InnoDB
+show create table t4;
+Table	Create Table
+t4	CREATE TABLE `t4` (
+  `c1` int(11) DEFAULT NULL,
+  `c2` varchar(255) DEFAULT NULL
+) ENGINE=InnoDB DEFAULT CHARSET=latin1
+[on master]
+alter table t4 engine=MyISAM;
+show create table t4;
+Table	Create Table
+t4	CREATE TABLE `t4` (
+  `c1` int(11) DEFAULT NULL,
+  `c2` varchar(255) DEFAULT NULL
+) ENGINE=MyISAM DEFAULT CHARSET=latin1
+[on slave]
+show global variables like 'sql_mode';
+Variable_name	Value
+sql_mode	STRICT_TRANS_TABLES,NO_AUTO_CREATE_USER,NO_ENGINE_SUBSTITUTION
+show global variables like '%_engine';
+Variable_name	Value
+default_storage_engine	MyISAM
+default_tmp_storage_engine	InnoDB
+internal_tmp_disk_storage_engine	InnoDB
+show create table t4;
+Table	Create Table
+t4	CREATE TABLE `t4` (
+  `c1` int(11) DEFAULT NULL,
+  `c2` varchar(255) DEFAULT NULL
+) ENGINE=MyISAM DEFAULT CHARSET=latin1
+[on master]
+drop table t4;
+include/sync_slave_sql_with_master.inc
+stop slave;

--- a/mysql-test/suite/tianmu/t/issue819.test
+++ b/mysql-test/suite/tianmu/t/issue819.test
@@ -1,4 +1,5 @@
 -- source include/have_tianmu.inc
+-- source include/have_binlog_format_row.inc
 --disable_warnings
 -- source include/master-slave.inc
 --enable_warnings
@@ -6,7 +7,7 @@
 --echo # Test the master-slave function of innodb
 --echo # 
 
---echo # connection master
+--echo [on master]
 connection master;
 use test;
 create table ttt(id int primary key,name varchar(5))engine=innodb;
@@ -15,17 +16,17 @@ delete from ttt where id=1;
 insert into ttt values(1,'aaa');
 select * from ttt;
 
---echo # connection slave
+--echo [on slave]
 --source include/sync_slave_sql_with_master.inc
 
 select * from ttt;
 
---echo # connection master
+--echo [on master]
 connection master;
 drop table ttt;
 --source include/sync_slave_sql_with_master.inc
 
---echo # connection master
+--echo [on master]
 connection master;
 CREATE TABLE t1 (a int not null,b int not null)engine=innodb;
 CREATE TABLE t2 (a int not null, b int not null, primary key (a,b))engine=innodb;
@@ -39,29 +40,29 @@ select * from t1;
 select * from t2;
 select * from t3;
 
---echo # connection slave
+--echo [on slave]
 --source include/sync_slave_sql_with_master.inc
 
 select * from t1;
 select * from t2;
 select * from t3;
 
---echo # connection master
+--echo [on master]
 connection master;
 drop table t1,t2,t3;
 --source include/sync_slave_sql_with_master.inc
 
---echo # connection master
+--echo [on master]
 connection master;
 CREATE TABLE t1
  (
- place_id int (10) unsigned NOT NULL,
- shows int(10) unsigned DEFAULT '0' NOT NULL,
- ishows int(10) unsigned DEFAULT '0' NOT NULL,
- ushows int(10) unsigned DEFAULT '0' NOT NULL,
- clicks int(10) unsigned DEFAULT '0' NOT NULL,
- iclicks int(10) unsigned DEFAULT '0' NOT NULL,
- uclicks int(10) unsigned DEFAULT '0' NOT NULL,
+ place_id int (10),
+ shows int(10),
+ ishows int(10),
+ ushows int(10),
+ clicks int(10),
+ iclicks int(10),
+ uclicks int(10),
  ts timestamp,
  PRIMARY KEY (place_id,ts)
  )engine=innodb;
@@ -71,11 +72,11 @@ VALUES (1,0,0,0,0,0,0,20000928174434);
 UPDATE t1 SET shows=shows+1,ishows=ishows+1,ushows=ushows+1,clicks=clicks+1,iclicks=iclicks+1,uclicks=uclicks+1 WHERE place_id=1 AND ts>="2000-09-28 00:00:00";
 select place_id,shows from t1;
 
---echo # connection slave
+--echo [on slave]
 --source include/sync_slave_sql_with_master.inc
 select place_id,shows from t1;
 
---echo # connection master
+--echo [on master]
 connection master;
 drop table t1;
 --source include/sync_slave_sql_with_master.inc
@@ -84,7 +85,7 @@ drop table t1;
 --echo # Test the master-slave function of tianmu
 --echo # 
 
---echo # connection master
+--echo [on master]
 connection master;
 use test;
 create table ttt(id int primary key,name varchar(5))engine=tianmu;
@@ -92,17 +93,17 @@ insert into ttt values(1,'AAA');
 update ttt set name='hhhh' where id=1;
 select * from ttt;
 
---echo # connection slave
+--echo [on slave]
 --source include/sync_slave_sql_with_master.inc
 
 select * from ttt;
 
---echo # connection master
+--echo [on master]
 connection master;
 drop table ttt;
 --source include/sync_slave_sql_with_master.inc
 
---echo # connection master
+--echo [on master]
 connection master;
 create table t1(id int primary key,name varchar(5))engine=tianmu;
 insert into t1 values(1,'AAA');
@@ -110,11 +111,11 @@ delete from t1 where id=1;
 insert into t1 values(1,'aaa');
 select * from t1;
 
---echo # connection slave
+--echo [on slave]
 --source include/sync_slave_sql_with_master.inc
 select * from t1;
 
---echo # connection master
+--echo [on master]
 connection master;
 drop table t1;
 
@@ -130,19 +131,19 @@ select * from t1;
 select * from t2;
 select * from t3;
 
---echo # connection slave
+--echo [on slave]
 --source include/sync_slave_sql_with_master.inc
 
 select * from t1;
 select * from t2;
 select * from t3;
 
---echo # connection master
+--echo [on master]
 connection master;
 drop table t1,t2,t3;
 --source include/sync_slave_sql_with_master.inc
 
---echo # connection master
+--echo [on master]
 connection master;
 CREATE TABLE t1
  (
@@ -162,11 +163,11 @@ VALUES (1,0,0,0,0,0,0,20000928174434);
 UPDATE t1 SET shows=shows+1,ishows=ishows+1,ushows=ushows+1,clicks=clicks+1,iclicks=iclicks+1,uclicks=uclicks+1 WHERE place_id=1 AND ts>="2000-09-28 00:00:00";
 select place_id,shows from t1;
 
---echo # connection slave
+--echo [on slave]
 --source include/sync_slave_sql_with_master.inc
 select place_id,shows from t1;
 
---echo # connection master
+--echo [on master]
 connection master;
 drop table t1;
 
@@ -179,10 +180,10 @@ insert into t1 values (1), (2);
 insert into t2 values (2), (3);
 create view v1 as select * from t1,t2 union all select * from t1,t2;
 select * from v1;
---echo # connection slave
+--echo [on slave]
 --source include/sync_slave_sql_with_master.inc
 select * from v1;
---echo # connection master
+--echo [on master]
 connection master;
 drop view v1;
 drop tables t1, t2;
@@ -195,10 +196,10 @@ insert into t1 values (1);
 create view v1 as select count(*) from t1;
 insert into t1 values (null);
 select * from v1;
---echo # connection slave
+--echo [on slave]
 --source include/sync_slave_sql_with_master.inc
 select * from v1;
---echo # connection master
+--echo [on master]
 connection master;
 drop view v1;
 drop table t1;
@@ -211,10 +212,10 @@ create table t2 (a int);
 create view v1 as select a from t1;
 create view v2 as select a from t2 where a in (select a from v1);
 show create view v2;
---echo # connection slave
+--echo [on slave]
 --source include/sync_slave_sql_with_master.inc
 show create view v2;
---echo # connection master
+--echo [on master]
 connection master;
 drop view v2, v1;
 drop table t1, t2;

--- a/mysql-test/suite/tianmu/t/issue956.test
+++ b/mysql-test/suite/tianmu/t/issue956.test
@@ -1,0 +1,182 @@
+-- source include/have_tianmu.inc
+-- source include/have_binlog_format_row.inc
+--disable_warnings
+-- source include/master-slave.inc
+--enable_warnings
+
+--echo # 
+--echo # sql_mode='STRICT_TRANS_TABLES,NO_AUTO_CREATE_USER,NO_ENGINE_SUBSTITUTION'
+--echo # default_storage_engine=innodb
+--echo # 
+--echo [on slave]
+--source include/sync_slave_sql_with_master.inc
+set global default_storage_engine=innodb;
+--disable_warnings
+set global sql_mode='STRICT_TRANS_TABLES,NO_AUTO_CREATE_USER,NO_ENGINE_SUBSTITUTION';
+--enable_warnings
+
+--echo [on master]
+connection master;
+create table t1(c1 int,c2 varchar(255))engine=InnoDB;
+show create table t1;
+--echo [on slave]
+--source include/sync_slave_sql_with_master.inc
+show global variables like 'sql_mode';
+show global variables like '%_engine';
+show create table t1;
+--echo [on master]
+connection master;
+alter table t1 engine=MyISAM;
+show create table t1;
+--echo [on slave]
+connection slave;
+sleep 1;
+show global variables like 'sql_mode';
+show global variables like '%_engine';
+show create table t1;
+--echo [on master]
+connection master;
+drop table t1;
+--source include/sync_slave_sql_with_master.inc
+
+
+--echo # 
+--echo # sql_mode='MANDATORY_TIANMU'
+--echo # default_storage_engine=innodb
+--echo # 
+--echo [on slave]
+set global default_storage_engine=innodb;
+--disable_warnings
+set global sql_mode='STRICT_TRANS_TABLES,NO_AUTO_CREATE_USER,NO_ENGINE_SUBSTITUTION,MANDATORY_TIANMU';
+--enable_warnings
+
+--echo [on master]
+connection master;
+create table t2(c1 int,c2 varchar(255))engine=InnoDB;
+show create table t2;
+--echo [on slave]
+--source include/sync_slave_sql_with_master.inc
+show global variables like 'sql_mode';
+show global variables like '%_engine';
+show create table t2;
+--echo [on master]
+connection master;
+alter table t2 engine=MyISAM;
+show create table t2;
+--echo [on slave]
+connection slave;
+sleep 1;
+show global variables like 'sql_mode';
+show global variables like '%_engine';
+show create table t2;
+--echo [on master]
+connection master;
+drop table t2;
+--source include/sync_slave_sql_with_master.inc
+
+--echo # 
+--echo # sql_mode='STRICT_TRANS_TABLES,NO_AUTO_CREATE_USER,NO_ENGINE_SUBSTITUTION'
+--echo # default_storage_engine=tianmu
+--echo # 
+--echo [on slave]
+set global default_storage_engine=tianmu;
+--disable_warnings
+set global sql_mode='STRICT_TRANS_TABLES,NO_AUTO_CREATE_USER,NO_ENGINE_SUBSTITUTION';
+--enable_warnings
+
+--echo [on master]
+connection master;
+
+create table t3(c1 int,c2 varchar(255))engine=InnoDB;
+show create table t3;
+--echo [on slave]
+--source include/sync_slave_sql_with_master.inc
+show global variables like 'sql_mode';
+show global variables like '%_engine';
+show create table t3;
+--echo [on master]
+connection master;
+alter table t3 engine=MyISAM;
+show create table t3;
+--echo [on slave]
+connection slave;
+sleep 1;
+show global variables like 'sql_mode';
+show global variables like '%_engine';
+show create table t3;
+--echo [on master]
+connection master;
+drop table t3;
+--source include/sync_slave_sql_with_master.inc
+
+--echo # 
+--echo # sql_mode='STRICT_TRANS_TABLES,NO_AUTO_CREATE_USER,NO_ENGINE_SUBSTITUTION,MANDATORY_TIANMU'
+--echo # default_storage_engine=tianmu
+--echo # 
+--echo [on slave]
+set global default_storage_engine=tianmu;
+--disable_warnings
+set global sql_mode='STRICT_TRANS_TABLES,NO_AUTO_CREATE_USER,NO_ENGINE_SUBSTITUTION,MANDATORY_TIANMU';
+--enable_warnings
+
+
+--echo [on master]
+connection master;
+
+create table t4(c1 int,c2 varchar(255))engine=InnoDB;
+show create table t4;
+--echo [on slave]
+--source include/sync_slave_sql_with_master.inc
+show global variables like 'sql_mode';
+show global variables like '%_engine';
+show create table t4;
+--echo [on master]
+connection master;
+alter table t4 engine=MyISAM;
+show create table t4;
+--echo [on slave]
+connection slave;
+sleep 1;
+show global variables like 'sql_mode';
+show global variables like '%_engine';
+show create table t4;
+--echo [on master]
+connection master;
+drop table t4;
+--source include/sync_slave_sql_with_master.inc
+
+--echo # 
+--echo # sql_mode='STRICT_TRANS_TABLES,NO_AUTO_CREATE_USER,NO_ENGINE_SUBSTITUTION'
+--echo # default_storage_engine=MyISAM
+--echo # 
+--echo [on slave]
+set global default_storage_engine=MyISAM;
+--disable_warnings
+set global sql_mode='STRICT_TRANS_TABLES,NO_AUTO_CREATE_USER,NO_ENGINE_SUBSTITUTION';
+--enable_warnings
+
+--echo [on master]
+connection master;
+
+create table t4(c1 int,c2 varchar(255))engine=InnoDB;
+show create table t4;
+--echo [on slave]
+--source include/sync_slave_sql_with_master.inc
+show global variables like 'sql_mode';
+show global variables like '%_engine';
+show create table t4;
+--echo [on master]
+connection master;
+alter table t4 engine=MyISAM;
+show create table t4;
+--echo [on slave]
+connection slave;
+sleep 1;
+show global variables like 'sql_mode';
+show global variables like '%_engine';
+show create table t4;
+--echo [on master]
+connection master;
+drop table t4;
+--source include/sync_slave_sql_with_master.inc
+stop slave;

--- a/sql/sql_class.h
+++ b/sql/sql_class.h
@@ -179,6 +179,8 @@ enum enum_binlog_format {
 #define MODE_HIGH_NOT_PRECEDENCE        (MODE_NO_AUTO_CREATE_USER*2)
 #define MODE_NO_ENGINE_SUBSTITUTION     (MODE_HIGH_NOT_PRECEDENCE*2)
 #define MODE_PAD_CHAR_TO_FULL_LENGTH    (1ULL << 31)
+//Force the engine to be tianmu when acting as a slave library
+#define MODE_MANDATORY_TIANMU    (1ULL << 32)
 
 /*
   Replication uses 8 bytes to store SQL_MODE in the binary log. The day you

--- a/sql/sql_table.cc
+++ b/sql/sql_table.cc
@@ -10761,7 +10761,8 @@ static bool check_engine(THD *thd, const char *db_name,
                                   no_substitution, 1)))
     DBUG_RETURN(true);
 
-  if (req_engine && req_engine != *new_engine)
+  if ((req_engine && req_engine != *new_engine)&& 
+     (create_info->db_type->db_type != DB_TYPE_TIANMU))
   {
     push_warning_printf(thd, Sql_condition::SL_NOTE,
                        ER_WARN_USING_OTHER_HANDLER,

--- a/sql/sys_vars.cc
+++ b/sql/sys_vars.cc
@@ -3904,7 +3904,7 @@ static const char *sql_mode_names[]=
   "STRICT_ALL_TABLES", "NO_ZERO_IN_DATE", "NO_ZERO_DATE",
   "ALLOW_INVALID_DATES", "ERROR_FOR_DIVISION_BY_ZERO", "TRADITIONAL",
   "NO_AUTO_CREATE_USER", "HIGH_NOT_PRECEDENCE", "NO_ENGINE_SUBSTITUTION",
-  "PAD_CHAR_TO_FULL_LENGTH",
+  "PAD_CHAR_TO_FULL_LENGTH", "MANDATORY_TIANMU",
   0
 };
 export bool sql_mode_string_representation(THD *thd, sql_mode_t sql_mode,


### PR DESCRIPTION
The function of forcing the replacement engine to be tianmu only takes effect in the slave library 
Step 1: First, you need to determine whether it is a slave database. This can be determined by whether (thread ->slave_thread) is true According to the configuration of forced replacement: (sql_mode='MANDATORY_TIANMU ') and (default_storage_engine=tianmu)
 Step 2: Determine whether the (sql_mode) and default engine are tianmu, and add (MANDATORY_TIANMU) this (sql_mode) The above conditions can be judged in (mysql_execute_command)

<!--

Thank you for contributing to StoneDB!

PR Title Format: <type>(<scope>): description to this pr (#issue_id)
e.g.
fix(util): fix sth..... (#1)

-->

## Summary about this PR
<!--

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".
e.g.:
Issue: close #1

-->

Issue Number: close #956


## Tests Check List
<!-- At least one of next options must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

## Changelog
<!-- At least one of next options must be included. -->

- [x] New Feature
- [ ] Bug Fix
- [ ] Performance Improvement
- [ ] Build/Testing/CI/CD
- [ ] Documentation
- [ ] Not for changelog (changelog entry is not required)

## Documentation
<!-- At least one of next options must be included. -->

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
