### PR TITLE
fix(tianmu): fix GROUP_CONCAT which refs to subselect(#938)

### DIFF
--- a/mysql-test/suite/tianmu/r/issue938.result
+++ b/mysql-test/suite/tianmu/r/issue938.result
@@ -1,0 +1,6 @@
+SELECT group_concat(d1 ORDER BY d1) FROM (SELECT d1 FROM tb) a1;
+group_concat(d1 ORDER BY d1)
+1234,56789012,1234567890123
+SELECT group_concat(d1 ORDER BY d1) FROM tb;
+group_concat(d1 ORDER BY d1)
+1234,56789012,1234567890123

--- a/mysql-test/suite/tianmu/t/issue938.test
+++ b/mysql-test/suite/tianmu/t/issue938.test
@@ -1,0 +1,19 @@
+--source include/have_tianmu.inc
+
+--disable_query_log
+USE test;
+CREATE TABLE tb (d1 DECIMAL(17)) ENGINE=TIANMU;
+
+INSERT INTO tb VALUES
+    (1234),     
+    (1234567890123),
+    (56789012);
+--enable_query_log
+
+SELECT group_concat(d1 ORDER BY d1) FROM (SELECT d1 FROM tb) a1;
+
+SELECT group_concat(d1 ORDER BY d1) FROM tb;
+
+--disable_query_log
+DROP TABLE tb;
+--enable_query_log

--- a/storage/tianmu/core/query.cpp
+++ b/storage/tianmu/core/query.cpp
@@ -184,7 +184,8 @@ std::pair<int, int> Query::VirtualColumnAlreadyExists(const TabID &tmp_table, co
 }
 
 bool Query::IsFieldItem(Item *item) {
-  return (item->type() == Item::FIELD_ITEM || item->type() == Item_tianmufield::get_tianmuitem_type());
+  return (item->type() == Item::FIELD_ITEM || item->type() == Item::REF_ITEM ||
+          item->type() == Item_tianmufield::get_tianmuitem_type());
 }
 
 bool Query::IsAggregationOverFieldItem(Item *item) {


### PR DESCRIPTION
[summary]
fix GROUP_CONCAT leads to wrong error, which refs to subselect.

<!--

Thank you for contributing to StoneDB!

PR Title Format: <type>(<scope>): description to this pr (#issue_id)
e.g.
fix(util): fix sth..... (#1)

-->

## Summary about this PR
<!--

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".
e.g.:
Issue: close #1

-->

Issue Number: close #938


## Tests Check List
<!-- At least one of next options must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

## Changelog
<!-- At least one of next options must be included. -->

- [ ] New Feature
- [x] Bug Fix
- [ ] Performance Improvement
- [ ] Build/Testing/CI/CD
- [ ] Documentation
- [ ] Not for changelog (changelog entry is not required)

## Documentation
<!-- At least one of next options must be included. -->

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
