### PR TITLE
fix(mtr): mtr suite=tianmu delete timeout after 900 seconds (#1047)

### DIFF
--- a/mysql-test/suite/tianmu/r/delete.result
+++ b/mysql-test/suite/tianmu/r/delete.result
@@ -52,7 +52,7 @@ avg(c_int)
 select sum(c_int) from column_type_test;
 sum(c_int)
 10200000
-delete from column_type_test where c_tinyint=100;
+delete from column_type_test where c_tinyint=100 limit 1000;
 select * from column_type_test limit 10;
 c_tinyint	c_smallint	c_mediumint	c_int	c_bigint	c_float	c_double	c_decimal	c_date	c_datetime	c_timestamp	c_time	c_char	c_varchar	c_blob	c_text	c_longblob
 101	101	101	101	101	5.2	10.88	101.08300	2016-02-25	2016-02-25 10:20:01	1985-08-11 09:10:25	10:20:01	stoneatom	hello	NULL	bcdefghijklmn	NULL
@@ -88,19 +88,19 @@ column_type_test	CREATE TABLE `column_type_test` (
 ) ENGINE=TIANMU DEFAULT CHARSET=latin1
 select count(*) from column_type_test;
 count(*)
-80000
+99000
 select max(c_int) from column_type_test;
 max(c_int)
 104
 select min(c_int) from column_type_test;
 min(c_int)
-101
+100
 select avg(c_int) from column_type_test;
 avg(c_int)
-102.5000
+102.0202
 select sum(c_int) from column_type_test;
 sum(c_int)
-8200000
+10100000
 drop table column_type_test;
 drop table if exists t1,t2,t3,t11,t12;
 CREATE TABLE t1 (a tinyint(3), b tinyint(5))ENGINE=TIANMU;

--- a/mysql-test/suite/tianmu/t/delete.test
+++ b/mysql-test/suite/tianmu/t/delete.test
@@ -38,7 +38,7 @@ select max(c_int) from column_type_test;
 select min(c_int) from column_type_test;
 select avg(c_int) from column_type_test;
 select sum(c_int) from column_type_test;
-delete from column_type_test where c_tinyint=100;
+delete from column_type_test where c_tinyint=100 limit 1000;
 --disable_warnings
 select * from column_type_test limit 10;
 --enable_warnings


### PR DESCRIPTION
The problem is that the test took too long in slow I/O and triggered a test case timeout. 
The number of operations needs to be reduced to shorten the test time.

<!--

Thank you for contributing to StoneDB!

PR Title Format: <type>(<scope>): description to this pr (#issue_id)
e.g.
fix(util): fix sth..... (#1)

-->

## Summary about this PR
<!--

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".
e.g.:
Issue: close #1

-->

Issue Number: close #1047


## Tests Check List
<!-- At least one of next options must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

## Changelog
<!-- At least one of next options must be included. -->

- [ ] New Feature
- [ ] Bug Fix
- [ ] Performance Improvement
- [x] Build/Testing/CI/CD
- [ ] Documentation
- [ ] Not for changelog (changelog entry is not required)

## Documentation
<!-- At least one of next options must be included. -->

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
