### PR TITLE
fix(tianmu): The predicade pushdown failed lead to the table full scan (#1054)

### DIFF
--- a/mysql-test/suite/tianmu/r/issue1054.result
+++ b/mysql-test/suite/tianmu/r/issue1054.result
@@ -1,0 +1,307 @@
+include/master-slave.inc
+[connection master]
+#
+# There are MySQL keywords in the table fields
+# 
+[on master]
+drop table if exists `column_type_test`;
+CREATE TABLE `column_type_test` (
+`usage` tinyint(4) DEFAULT NULL COMMENT 'tinyint',
+`use` smallint(6) DEFAULT NULL COMMENT 'smallint',
+`update` mediumint(9) DEFAULT NULL COMMENT 'mediumint',
+`delete` int(11) DEFAULT NULL COMMENT 'int',
+`select` bigint(20) DEFAULT NULL COMMENT 'bigint',
+`drop` float DEFAULT NULL COMMENT 'float',
+`create` double DEFAULT NULL COMMENT 'double',
+`insert` decimal(10,5) DEFAULT NULL COMMENT 'decimal',
+`database` date DEFAULT NULL COMMENT 'date',
+`where` datetime DEFAULT NULL COMMENT 'datetime',
+`lefe` timestamp NULL DEFAULT NULL COMMENT 'timestamp',
+`join` time DEFAULT NULL COMMENT 'time',
+`engine` char(10) DEFAULT NULL COMMENT 'char',
+`reset` varchar(10) DEFAULT NULL COMMENT 'varchar',
+`into` blob COMMENT 'blob',
+`set` text COMMENT 'text',
+`show` longblob COMMENT 'longblob'
+) engine=tianmu;
+insert into column_type_test 
+values(100,100,100,100,100,5.2,10.88,100.08300,'2016-02-25','2016-02-25 10:20:01',
+'2007-04-23 08:12:49','10:20:01','stoneatom','hello',NULL,'bcdefghijklmn',NULL);
+insert into column_type_test 
+values(101,100,100,100,100,5.2,10.88,100.08300,'2016-02-25','2016-02-25 10:20:01',
+'2007-04-23 08:12:49','10:20:01','stoneatom','hello',NULL,'bcdefghijklmn',NULL);
+insert into column_type_test 
+values(102,100,100,100,100,5.2,10.88,100.08300,'2016-02-25','2016-02-25 10:20:01',
+'2007-04-23 08:12:49','10:20:01','stoneatom','hello',NULL,'bcdefghijklmn',NULL);
+update column_type_test set `use`=200 where `usage`=100;
+select * from column_type_test;
+usage	use	update	delete	select	drop	create	insert	database	where	lefe	join	engine	reset	into	set	show
+100	200	100	100	100	5.2	10.88	100.08300	2016-02-25	2016-02-25 10:20:01	2007-04-23 08:12:49	10:20:01	stoneatom	hello	NULL	bcdefghijklmn	NULL
+101	100	100	100	100	5.2	10.88	100.08300	2016-02-25	2016-02-25 10:20:01	2007-04-23 08:12:49	10:20:01	stoneatom	hello	NULL	bcdefghijklmn	NULL
+102	100	100	100	100	5.2	10.88	100.08300	2016-02-25	2016-02-25 10:20:01	2007-04-23 08:12:49	10:20:01	stoneatom	hello	NULL	bcdefghijklmn	NULL
+[on slave]
+include/sync_slave_sql_with_master.inc
+select * from column_type_test;
+usage	use	update	delete	select	drop	create	insert	database	where	lefe	join	engine	reset	into	set	show
+100	200	100	100	100	5.2	10.88	100.08300	2016-02-25	2016-02-25 10:20:01	2007-04-23 08:12:49	10:20:01	stoneatom	hello	NULL	bcdefghijklmn	NULL
+101	100	100	100	100	5.2	10.88	100.08300	2016-02-25	2016-02-25 10:20:01	2007-04-23 08:12:49	10:20:01	stoneatom	hello	NULL	bcdefghijklmn	NULL
+102	100	100	100	100	5.2	10.88	100.08300	2016-02-25	2016-02-25 10:20:01	2007-04-23 08:12:49	10:20:01	stoneatom	hello	NULL	bcdefghijklmn	NULL
+[on master]
+delete from column_type_test where `usage`=100;
+select * from column_type_test;
+usage	use	update	delete	select	drop	create	insert	database	where	lefe	join	engine	reset	into	set	show
+101	100	100	100	100	5.2	10.88	100.08300	2016-02-25	2016-02-25 10:20:01	2007-04-23 08:12:49	10:20:01	stoneatom	hello	NULL	bcdefghijklmn	NULL
+102	100	100	100	100	5.2	10.88	100.08300	2016-02-25	2016-02-25 10:20:01	2007-04-23 08:12:49	10:20:01	stoneatom	hello	NULL	bcdefghijklmn	NULL
+[on slave]
+include/sync_slave_sql_with_master.inc
+select * from column_type_test;
+usage	use	update	delete	select	drop	create	insert	database	where	lefe	join	engine	reset	into	set	show
+101	100	100	100	100	5.2	10.88	100.08300	2016-02-25	2016-02-25 10:20:01	2007-04-23 08:12:49	10:20:01	stoneatom	hello	NULL	bcdefghijklmn	NULL
+102	100	100	100	100	5.2	10.88	100.08300	2016-02-25	2016-02-25 10:20:01	2007-04-23 08:12:49	10:20:01	stoneatom	hello	NULL	bcdefghijklmn	NULL
+[on master]
+drop table column_type_test;
+include/sync_slave_sql_with_master.inc
+#
+# Have unique constraints
+# 
+[on master]
+CREATE TABLE `column_type_test` (
+`usage` tinyint(4) COMMENT 'tinyint',
+`use` smallint(6) DEFAULT NULL COMMENT 'smallint',
+`update` mediumint(9) DEFAULT NULL COMMENT 'mediumint',
+`delete` int(11) DEFAULT NULL COMMENT 'int',
+`select` bigint(20) DEFAULT NULL COMMENT 'bigint',
+`drop` float DEFAULT NULL COMMENT 'float',
+`create` double DEFAULT NULL COMMENT 'double',
+`insert` decimal(10,5) DEFAULT NULL COMMENT 'decimal',
+`database` date DEFAULT NULL COMMENT 'date',
+`where` datetime DEFAULT NULL COMMENT 'datetime',
+`lefe` timestamp NULL DEFAULT NULL COMMENT 'timestamp',
+`join` time DEFAULT NULL COMMENT 'time',
+`engine` char(10) DEFAULT NULL COMMENT 'char',
+`reset` varchar(10) DEFAULT NULL COMMENT 'varchar',
+`into` blob COMMENT 'blob',
+`set` text COMMENT 'text',
+`show` longblob COMMENT 'longblob',
+UNIQUE (`usage`)
+) engine=tianmu;
+insert into column_type_test 
+values(100,100,100,100,100,5.2,10.88,100.08300,'2016-02-25','2016-02-25 10:20:01',
+'2007-04-23 08:12:49','10:20:01','stoneatom','hello',NULL,'bcdefghijklmn',NULL);
+insert into column_type_test 
+values(101,100,100,100,100,5.2,10.88,100.08300,'2016-02-25','2016-02-25 10:20:01',
+'2007-04-23 08:12:49','10:20:01','stoneatom','hello',NULL,'bcdefghijklmn',NULL);
+insert into column_type_test 
+values(102,100,100,100,100,5.2,10.88,100.08300,'2016-02-25','2016-02-25 10:20:01',
+'2007-04-23 08:12:49','10:20:01','stoneatom','hello',NULL,'bcdefghijklmn',NULL);
+update column_type_test set `use`=200 where `usage`=100;
+select * from column_type_test;
+usage	use	update	delete	select	drop	create	insert	database	where	lefe	join	engine	reset	into	set	show
+100	200	100	100	100	5.2	10.88	100.08300	2016-02-25	2016-02-25 10:20:01	2007-04-23 08:12:49	10:20:01	stoneatom	hello	NULL	bcdefghijklmn	NULL
+101	100	100	100	100	5.2	10.88	100.08300	2016-02-25	2016-02-25 10:20:01	2007-04-23 08:12:49	10:20:01	stoneatom	hello	NULL	bcdefghijklmn	NULL
+102	100	100	100	100	5.2	10.88	100.08300	2016-02-25	2016-02-25 10:20:01	2007-04-23 08:12:49	10:20:01	stoneatom	hello	NULL	bcdefghijklmn	NULL
+[on slave]
+include/sync_slave_sql_with_master.inc
+select * from column_type_test;
+usage	use	update	delete	select	drop	create	insert	database	where	lefe	join	engine	reset	into	set	show
+100	200	100	100	100	5.2	10.88	100.08300	2016-02-25	2016-02-25 10:20:01	2007-04-23 08:12:49	10:20:01	stoneatom	hello	NULL	bcdefghijklmn	NULL
+101	100	100	100	100	5.2	10.88	100.08300	2016-02-25	2016-02-25 10:20:01	2007-04-23 08:12:49	10:20:01	stoneatom	hello	NULL	bcdefghijklmn	NULL
+102	100	100	100	100	5.2	10.88	100.08300	2016-02-25	2016-02-25 10:20:01	2007-04-23 08:12:49	10:20:01	stoneatom	hello	NULL	bcdefghijklmn	NULL
+[on master]
+delete from column_type_test where `usage`=100;
+select * from column_type_test;
+usage	use	update	delete	select	drop	create	insert	database	where	lefe	join	engine	reset	into	set	show
+101	100	100	100	100	5.2	10.88	100.08300	2016-02-25	2016-02-25 10:20:01	2007-04-23 08:12:49	10:20:01	stoneatom	hello	NULL	bcdefghijklmn	NULL
+102	100	100	100	100	5.2	10.88	100.08300	2016-02-25	2016-02-25 10:20:01	2007-04-23 08:12:49	10:20:01	stoneatom	hello	NULL	bcdefghijklmn	NULL
+[on slave]
+include/sync_slave_sql_with_master.inc
+select * from column_type_test;
+usage	use	update	delete	select	drop	create	insert	database	where	lefe	join	engine	reset	into	set	show
+101	100	100	100	100	5.2	10.88	100.08300	2016-02-25	2016-02-25 10:20:01	2007-04-23 08:12:49	10:20:01	stoneatom	hello	NULL	bcdefghijklmn	NULL
+102	100	100	100	100	5.2	10.88	100.08300	2016-02-25	2016-02-25 10:20:01	2007-04-23 08:12:49	10:20:01	stoneatom	hello	NULL	bcdefghijklmn	NULL
+[on master]
+drop table column_type_test;
+include/sync_slave_sql_with_master.inc
+#
+# Has primary key
+# 
+[on master]
+CREATE TABLE `column_type_test` (
+`usage` tinyint(4) COMMENT 'tinyint',
+`use` smallint(6) DEFAULT NULL COMMENT 'smallint',
+`update` mediumint(9) DEFAULT NULL COMMENT 'mediumint',
+`delete` int(11) DEFAULT NULL COMMENT 'int',
+`select` bigint(20) DEFAULT NULL COMMENT 'bigint',
+`drop` float DEFAULT NULL COMMENT 'float',
+`create` double DEFAULT NULL COMMENT 'double',
+`insert` decimal(10,5) DEFAULT NULL COMMENT 'decimal',
+`database` date DEFAULT NULL COMMENT 'date',
+`where` datetime DEFAULT NULL COMMENT 'datetime',
+`lefe` timestamp NULL DEFAULT NULL COMMENT 'timestamp',
+`join` time DEFAULT NULL COMMENT 'time',
+`engine` char(10) DEFAULT NULL COMMENT 'char',
+`reset` varchar(10) DEFAULT NULL COMMENT 'varchar',
+`into` blob COMMENT 'blob',
+`set` text COMMENT 'text',
+`show` longblob COMMENT 'longblob',
+primary key(`usage`)
+) engine=tianmu;
+insert into column_type_test 
+values(100,100,100,100,100,5.2,10.88,100.08300,'2016-02-25','2016-02-25 10:20:01',
+'2007-04-23 08:12:49','10:20:01','stoneatom','hello',NULL,'bcdefghijklmn',NULL);
+insert into column_type_test 
+values(101,100,100,100,100,5.2,10.88,100.08300,'2016-02-25','2016-02-25 10:20:01',
+'2007-04-23 08:12:49','10:20:01','stoneatom','hello',NULL,'bcdefghijklmn',NULL);
+insert into column_type_test 
+values(102,100,100,100,100,5.2,10.88,100.08300,'2016-02-25','2016-02-25 10:20:01',
+'2007-04-23 08:12:49','10:20:01','stoneatom','hello',NULL,'bcdefghijklmn',NULL);
+update column_type_test set `use`=200 where `usage`=100;
+select * from column_type_test;
+usage	use	update	delete	select	drop	create	insert	database	where	lefe	join	engine	reset	into	set	show
+100	200	100	100	100	5.2	10.88	100.08300	2016-02-25	2016-02-25 10:20:01	2007-04-23 08:12:49	10:20:01	stoneatom	hello	NULL	bcdefghijklmn	NULL
+101	100	100	100	100	5.2	10.88	100.08300	2016-02-25	2016-02-25 10:20:01	2007-04-23 08:12:49	10:20:01	stoneatom	hello	NULL	bcdefghijklmn	NULL
+102	100	100	100	100	5.2	10.88	100.08300	2016-02-25	2016-02-25 10:20:01	2007-04-23 08:12:49	10:20:01	stoneatom	hello	NULL	bcdefghijklmn	NULL
+[on slave]
+include/sync_slave_sql_with_master.inc
+select * from column_type_test;
+usage	use	update	delete	select	drop	create	insert	database	where	lefe	join	engine	reset	into	set	show
+100	200	100	100	100	5.2	10.88	100.08300	2016-02-25	2016-02-25 10:20:01	2007-04-23 08:12:49	10:20:01	stoneatom	hello	NULL	bcdefghijklmn	NULL
+101	100	100	100	100	5.2	10.88	100.08300	2016-02-25	2016-02-25 10:20:01	2007-04-23 08:12:49	10:20:01	stoneatom	hello	NULL	bcdefghijklmn	NULL
+102	100	100	100	100	5.2	10.88	100.08300	2016-02-25	2016-02-25 10:20:01	2007-04-23 08:12:49	10:20:01	stoneatom	hello	NULL	bcdefghijklmn	NULL
+[on master]
+delete from column_type_test where `usage`=100;
+select * from column_type_test;
+usage	use	update	delete	select	drop	create	insert	database	where	lefe	join	engine	reset	into	set	show
+101	100	100	100	100	5.2	10.88	100.08300	2016-02-25	2016-02-25 10:20:01	2007-04-23 08:12:49	10:20:01	stoneatom	hello	NULL	bcdefghijklmn	NULL
+102	100	100	100	100	5.2	10.88	100.08300	2016-02-25	2016-02-25 10:20:01	2007-04-23 08:12:49	10:20:01	stoneatom	hello	NULL	bcdefghijklmn	NULL
+[on slave]
+include/sync_slave_sql_with_master.inc
+select * from column_type_test;
+usage	use	update	delete	select	drop	create	insert	database	where	lefe	join	engine	reset	into	set	show
+101	100	100	100	100	5.2	10.88	100.08300	2016-02-25	2016-02-25 10:20:01	2007-04-23 08:12:49	10:20:01	stoneatom	hello	NULL	bcdefghijklmn	NULL
+102	100	100	100	100	5.2	10.88	100.08300	2016-02-25	2016-02-25 10:20:01	2007-04-23 08:12:49	10:20:01	stoneatom	hello	NULL	bcdefghijklmn	NULL
+[on master]
+drop table column_type_test;
+include/sync_slave_sql_with_master.inc
+#
+# Validate scenarios where push down fails
+# 
+[on master]
+CREATE TABLE `column_type_test` (
+`usage` tinyint(4) COMMENT 'tinyint',
+`use` smallint(6) DEFAULT NULL COMMENT 'smallint',
+`update` mediumint(9) DEFAULT NULL COMMENT 'mediumint',
+`delete` int(11) DEFAULT NULL COMMENT 'int',
+`select` bigint(20) DEFAULT NULL COMMENT 'bigint',
+`drop` float DEFAULT NULL COMMENT 'float',
+`create` double DEFAULT NULL COMMENT 'double',
+`insert` decimal(10,5) DEFAULT NULL COMMENT 'decimal',
+`database` date DEFAULT NULL COMMENT 'date',
+`where` datetime DEFAULT NULL COMMENT 'datetime',
+`lefe` timestamp NULL DEFAULT NULL COMMENT 'timestamp',
+`join` time DEFAULT NULL COMMENT 'time',
+`engine` char(10) DEFAULT NULL COMMENT 'char',
+`reset` varchar(10) DEFAULT NULL COMMENT 'varchar',
+`into` blob COMMENT 'blob',
+`set` text COMMENT 'text',
+`show` longblob COMMENT 'longblob',
+primary key(`usage`)
+) engine=tianmu;
+insert into column_type_test 
+values(100,100,100,100,100,5.2,10.88,100.08300,'2016-02-25','2016-02-25 10:20:01',
+'2007-04-23 08:12:49','10:20:01','stoneatom','hello',NULL,'bcdefghijklmn',NULL);
+insert into column_type_test 
+values(101,100,100,100,100,5.2,10.88,100.08300,'2016-02-25','2016-02-25 10:20:01',
+'2007-04-23 08:12:49','10:20:01','stoneatom','hello',NULL,'bcdefghijklmn',NULL);
+insert into column_type_test 
+values(102,100,100,100,100,5.2,10.88,100.08300,'2016-02-25','2016-02-25 10:20:01',
+'2007-04-23 08:12:49','10:20:01','stoneatom','hello',NULL,'bcdefghijklmn',NULL);
+update column_type_test set `use`=200 where `usage`=100;
+select * from column_type_test;
+usage	use	update	delete	select	drop	create	insert	database	where	lefe	join	engine	reset	into	set	show
+100	200	100	100	100	5.2	10.88	100.08300	2016-02-25	2016-02-25 10:20:01	2007-04-23 08:12:49	10:20:01	stoneatom	hello	NULL	bcdefghijklmn	NULL
+101	100	100	100	100	5.2	10.88	100.08300	2016-02-25	2016-02-25 10:20:01	2007-04-23 08:12:49	10:20:01	stoneatom	hello	NULL	bcdefghijklmn	NULL
+102	100	100	100	100	5.2	10.88	100.08300	2016-02-25	2016-02-25 10:20:01	2007-04-23 08:12:49	10:20:01	stoneatom	hello	NULL	bcdefghijklmn	NULL
+[on slave]
+include/sync_slave_sql_with_master.inc
+select * from column_type_test;
+usage	use	update	delete	select	drop	create	insert	database	where	lefe	join	engine	reset	into	set	show
+100	200	100	100	100	5.2	10.88	100.08300	2016-02-25	2016-02-25 10:20:01	2007-04-23 08:12:49	10:20:01	stoneatom	hello	NULL	bcdefghijklmn	NULL
+101	100	100	100	100	5.2	10.88	100.08300	2016-02-25	2016-02-25 10:20:01	2007-04-23 08:12:49	10:20:01	stoneatom	hello	NULL	bcdefghijklmn	NULL
+102	100	100	100	100	5.2	10.88	100.08300	2016-02-25	2016-02-25 10:20:01	2007-04-23 08:12:49	10:20:01	stoneatom	hello	NULL	bcdefghijklmn	NULL
+[on master]
+delete from column_type_test where `usage`=100;
+select * from column_type_test;
+usage	use	update	delete	select	drop	create	insert	database	where	lefe	join	engine	reset	into	set	show
+101	100	100	100	100	5.2	10.88	100.08300	2016-02-25	2016-02-25 10:20:01	2007-04-23 08:12:49	10:20:01	stoneatom	hello	NULL	bcdefghijklmn	NULL
+102	100	100	100	100	5.2	10.88	100.08300	2016-02-25	2016-02-25 10:20:01	2007-04-23 08:12:49	10:20:01	stoneatom	hello	NULL	bcdefghijklmn	NULL
+[on slave]
+include/sync_slave_sql_with_master.inc
+select * from column_type_test;
+usage	use	update	delete	select	drop	create	insert	database	where	lefe	join	engine	reset	into	set	show
+101	100	100	100	100	5.2	10.88	100.08300	2016-02-25	2016-02-25 10:20:01	2007-04-23 08:12:49	10:20:01	stoneatom	hello	NULL	bcdefghijklmn	NULL
+102	100	100	100	100	5.2	10.88	100.08300	2016-02-25	2016-02-25 10:20:01	2007-04-23 08:12:49	10:20:01	stoneatom	hello	NULL	bcdefghijklmn	NULL
+[on master]
+drop table column_type_test;
+include/sync_slave_sql_with_master.inc
+#
+# Adds some test cases for unicode.
+# 
+[on master]
+CREATE TABLE `column_type_test` (
+`abc def` tinyint(4) COMMENT 'tinyint',
+`пусто` smallint(6) DEFAULT NULL COMMENT 'smallint',
+`новое` mediumint(9) DEFAULT NULL COMMENT 'mediumint',
+`你好` int(11) DEFAULT NULL COMMENT 'int',
+`to-to0` bigint(20) DEFAULT NULL COMMENT 'bigint',
+`dr(op` float DEFAULT NULL COMMENT 'float',
+`cr+eate` double DEFAULT NULL COMMENT 'double',
+`ins=ert` decimal(10,5) DEFAULT NULL COMMENT 'decimal',
+`data.base` date DEFAULT NULL COMMENT 'date',
+`whe]re` datetime DEFAULT NULL COMMENT 'datetime',
+`lef[e` timestamp NULL DEFAULT NULL COMMENT 'timestamp',
+`joi)n` time DEFAULT NULL COMMENT 'time',
+`eng<ine` char(10) DEFAULT NULL COMMENT 'char',
+`rese>&t` varchar(10) DEFAULT NULL COMMENT 'varchar',
+`into#` blob COMMENT 'blob',
+`set@` text COMMENT 'text',
+`sho*w` longblob COMMENT 'longblob'
+) engine=innodb;
+insert into column_type_test 
+values(100,100,100,100,100,5.2,10.88,100.08300,'2016-02-25','2016-02-25 10:20:01',
+'2007-04-23 08:12:49','10:20:01','stoneatom','hello',NULL,'bcdefghijklmn',NULL);
+insert into column_type_test 
+values(101,100,100,100,100,5.2,10.88,100.08300,'2016-02-25','2016-02-25 10:20:01',
+'2007-04-23 08:12:49','10:20:01','stoneatom','hello',NULL,'bcdefghijklmn',NULL);
+insert into column_type_test 
+values(102,100,100,100,100,5.2,10.88,100.08300,'2016-02-25','2016-02-25 10:20:01',
+'2007-04-23 08:12:49','10:20:01','stoneatom','hello',NULL,'bcdefghijklmn',NULL);
+update column_type_test set `пусто`=200 where `abc def`=100;
+select * from column_type_test;
+abc def	пусто	новое	你好	to-to0	dr(op	cr+eate	ins=ert	data.base	whe]re	lef[e	joi)n	eng<ine	rese>&t	into#	set@	sho*w
+100	200	100	100	100	5.2	10.88	100.08300	2016-02-25	2016-02-25 10:20:01	2007-04-23 08:12:49	10:20:01	stoneatom	hello	NULL	bcdefghijklmn	NULL
+101	100	100	100	100	5.2	10.88	100.08300	2016-02-25	2016-02-25 10:20:01	2007-04-23 08:12:49	10:20:01	stoneatom	hello	NULL	bcdefghijklmn	NULL
+102	100	100	100	100	5.2	10.88	100.08300	2016-02-25	2016-02-25 10:20:01	2007-04-23 08:12:49	10:20:01	stoneatom	hello	NULL	bcdefghijklmn	NULL
+[on slave]
+include/sync_slave_sql_with_master.inc
+select * from column_type_test;
+abc def	пусто	новое	你好	to-to0	dr(op	cr+eate	ins=ert	data.base	whe]re	lef[e	joi)n	eng<ine	rese>&t	into#	set@	sho*w
+100	200	100	100	100	5.2	10.88	100.08300	2016-02-25	2016-02-25 10:20:01	2007-04-23 08:12:49	10:20:01	stoneatom	hello	NULL	bcdefghijklmn	NULL
+101	100	100	100	100	5.2	10.88	100.08300	2016-02-25	2016-02-25 10:20:01	2007-04-23 08:12:49	10:20:01	stoneatom	hello	NULL	bcdefghijklmn	NULL
+102	100	100	100	100	5.2	10.88	100.08300	2016-02-25	2016-02-25 10:20:01	2007-04-23 08:12:49	10:20:01	stoneatom	hello	NULL	bcdefghijklmn	NULL
+[on master]
+delete from column_type_test where `abc def`=100;
+select * from column_type_test;
+abc def	пусто	новое	你好	to-to0	dr(op	cr+eate	ins=ert	data.base	whe]re	lef[e	joi)n	eng<ine	rese>&t	into#	set@	sho*w
+101	100	100	100	100	5.2	10.88	100.08300	2016-02-25	2016-02-25 10:20:01	2007-04-23 08:12:49	10:20:01	stoneatom	hello	NULL	bcdefghijklmn	NULL
+102	100	100	100	100	5.2	10.88	100.08300	2016-02-25	2016-02-25 10:20:01	2007-04-23 08:12:49	10:20:01	stoneatom	hello	NULL	bcdefghijklmn	NULL
+[on slave]
+include/sync_slave_sql_with_master.inc
+select * from column_type_test;
+abc def	пусто	новое	你好	to-to0	dr(op	cr+eate	ins=ert	data.base	whe]re	lef[e	joi)n	eng<ine	rese>&t	into#	set@	sho*w
+101	100	100	100	100	5.2	10.88	100.08300	2016-02-25	2016-02-25 10:20:01	2007-04-23 08:12:49	10:20:01	stoneatom	hello	NULL	bcdefghijklmn	NULL
+102	100	100	100	100	5.2	10.88	100.08300	2016-02-25	2016-02-25 10:20:01	2007-04-23 08:12:49	10:20:01	stoneatom	hello	NULL	bcdefghijklmn	NULL
+[on master]
+drop table column_type_test;
+include/sync_slave_sql_with_master.inc
+stop slave;

--- a/mysql-test/suite/tianmu/r/issue1065.result
+++ b/mysql-test/suite/tianmu/r/issue1065.result
@@ -1,5 +1,6 @@
 USE test;
 set sql_mode='STRICT_TRANS_TABLES,NO_AUTO_CREATE_USER,NO_ENGINE_SUBSTITUTION';
+drop table if exists t_test;
 CREATE TABLE t_test(
 id INT NOT NULL AUTO_INCREMENT,
 first_name VARCHAR(10) NOT NULL,

--- a/mysql-test/suite/tianmu/r/issue228.result
+++ b/mysql-test/suite/tianmu/r/issue228.result
@@ -1,4 +1,5 @@
 use test;
+drop table if exists t1;
 create table t1 (a varchar(112) charset utf8 collate utf8_bin not null,primary key (a)) select 'test' as a ;
 select a from t1;
 a

--- a/mysql-test/suite/tianmu/r/issue301.result
+++ b/mysql-test/suite/tianmu/r/issue301.result
@@ -1,4 +1,5 @@
 use test;
+drop table if exists t1;
 CREATE TABLE t1 (a INT NOT NULL, b INT)engine=tianmu;
 INSERT INTO t1 VALUES (1, 1),(1,2),(1,3);
 select * from t1 where 1=1 and 1=1 or b>2;

--- a/mysql-test/suite/tianmu/t/issue1054.test
+++ b/mysql-test/suite/tianmu/t/issue1054.test
@@ -1,0 +1,297 @@
+-- source include/have_tianmu.inc
+--disable_warnings
+-- source include/master-slave.inc
+--enable_warnings
+--echo #
+--echo # There are MySQL keywords in the table fields
+--echo # 
+
+--echo [on master]
+connection master;
+--disable_warnings
+drop table if exists `column_type_test`;
+--enable_warnings
+
+CREATE TABLE `column_type_test` (
+`usage` tinyint(4) DEFAULT NULL COMMENT 'tinyint',
+`use` smallint(6) DEFAULT NULL COMMENT 'smallint',
+`update` mediumint(9) DEFAULT NULL COMMENT 'mediumint',
+`delete` int(11) DEFAULT NULL COMMENT 'int',
+`select` bigint(20) DEFAULT NULL COMMENT 'bigint',
+`drop` float DEFAULT NULL COMMENT 'float',
+`create` double DEFAULT NULL COMMENT 'double',
+`insert` decimal(10,5) DEFAULT NULL COMMENT 'decimal',
+`database` date DEFAULT NULL COMMENT 'date',
+`where` datetime DEFAULT NULL COMMENT 'datetime',
+`lefe` timestamp NULL DEFAULT NULL COMMENT 'timestamp',
+`join` time DEFAULT NULL COMMENT 'time',
+`engine` char(10) DEFAULT NULL COMMENT 'char',
+`reset` varchar(10) DEFAULT NULL COMMENT 'varchar',
+`into` blob COMMENT 'blob',
+`set` text COMMENT 'text',
+`show` longblob COMMENT 'longblob'
+) engine=tianmu;
+
+insert into column_type_test 
+values(100,100,100,100,100,5.2,10.88,100.08300,'2016-02-25','2016-02-25 10:20:01',
+'2007-04-23 08:12:49','10:20:01','stoneatom','hello',NULL,'bcdefghijklmn',NULL);
+insert into column_type_test 
+values(101,100,100,100,100,5.2,10.88,100.08300,'2016-02-25','2016-02-25 10:20:01',
+'2007-04-23 08:12:49','10:20:01','stoneatom','hello',NULL,'bcdefghijklmn',NULL);
+insert into column_type_test 
+values(102,100,100,100,100,5.2,10.88,100.08300,'2016-02-25','2016-02-25 10:20:01',
+'2007-04-23 08:12:49','10:20:01','stoneatom','hello',NULL,'bcdefghijklmn',NULL);
+
+update column_type_test set `use`=200 where `usage`=100;
+select * from column_type_test;
+--echo [on slave]
+--source include/sync_slave_sql_with_master.inc
+select * from column_type_test;
+--echo [on master]
+connection master;
+delete from column_type_test where `usage`=100;
+select * from column_type_test;
+--echo [on slave]
+--source include/sync_slave_sql_with_master.inc
+select * from column_type_test;
+
+--echo [on master]
+connection master;
+drop table column_type_test;
+--source include/sync_slave_sql_with_master.inc
+
+
+
+--echo #
+--echo # Have unique constraints
+--echo # 
+
+--echo [on master]
+connection master;
+
+CREATE TABLE `column_type_test` (
+`usage` tinyint(4) COMMENT 'tinyint',
+`use` smallint(6) DEFAULT NULL COMMENT 'smallint',
+`update` mediumint(9) DEFAULT NULL COMMENT 'mediumint',
+`delete` int(11) DEFAULT NULL COMMENT 'int',
+`select` bigint(20) DEFAULT NULL COMMENT 'bigint',
+`drop` float DEFAULT NULL COMMENT 'float',
+`create` double DEFAULT NULL COMMENT 'double',
+`insert` decimal(10,5) DEFAULT NULL COMMENT 'decimal',
+`database` date DEFAULT NULL COMMENT 'date',
+`where` datetime DEFAULT NULL COMMENT 'datetime',
+`lefe` timestamp NULL DEFAULT NULL COMMENT 'timestamp',
+`join` time DEFAULT NULL COMMENT 'time',
+`engine` char(10) DEFAULT NULL COMMENT 'char',
+`reset` varchar(10) DEFAULT NULL COMMENT 'varchar',
+`into` blob COMMENT 'blob',
+`set` text COMMENT 'text',
+`show` longblob COMMENT 'longblob',
+UNIQUE (`usage`)
+) engine=tianmu;
+
+insert into column_type_test 
+values(100,100,100,100,100,5.2,10.88,100.08300,'2016-02-25','2016-02-25 10:20:01',
+'2007-04-23 08:12:49','10:20:01','stoneatom','hello',NULL,'bcdefghijklmn',NULL);
+insert into column_type_test 
+values(101,100,100,100,100,5.2,10.88,100.08300,'2016-02-25','2016-02-25 10:20:01',
+'2007-04-23 08:12:49','10:20:01','stoneatom','hello',NULL,'bcdefghijklmn',NULL);
+insert into column_type_test 
+values(102,100,100,100,100,5.2,10.88,100.08300,'2016-02-25','2016-02-25 10:20:01',
+'2007-04-23 08:12:49','10:20:01','stoneatom','hello',NULL,'bcdefghijklmn',NULL);
+
+update column_type_test set `use`=200 where `usage`=100;
+select * from column_type_test;
+--echo [on slave]
+--source include/sync_slave_sql_with_master.inc
+select * from column_type_test;
+--echo [on master]
+connection master;
+delete from column_type_test where `usage`=100;
+select * from column_type_test;
+--echo [on slave]
+--source include/sync_slave_sql_with_master.inc
+select * from column_type_test;
+
+--echo [on master]
+connection master;
+drop table column_type_test;
+--source include/sync_slave_sql_with_master.inc
+
+
+--echo #
+--echo # Has primary key
+--echo # 
+
+--echo [on master]
+connection master;
+
+CREATE TABLE `column_type_test` (
+`usage` tinyint(4) COMMENT 'tinyint',
+`use` smallint(6) DEFAULT NULL COMMENT 'smallint',
+`update` mediumint(9) DEFAULT NULL COMMENT 'mediumint',
+`delete` int(11) DEFAULT NULL COMMENT 'int',
+`select` bigint(20) DEFAULT NULL COMMENT 'bigint',
+`drop` float DEFAULT NULL COMMENT 'float',
+`create` double DEFAULT NULL COMMENT 'double',
+`insert` decimal(10,5) DEFAULT NULL COMMENT 'decimal',
+`database` date DEFAULT NULL COMMENT 'date',
+`where` datetime DEFAULT NULL COMMENT 'datetime',
+`lefe` timestamp NULL DEFAULT NULL COMMENT 'timestamp',
+`join` time DEFAULT NULL COMMENT 'time',
+`engine` char(10) DEFAULT NULL COMMENT 'char',
+`reset` varchar(10) DEFAULT NULL COMMENT 'varchar',
+`into` blob COMMENT 'blob',
+`set` text COMMENT 'text',
+`show` longblob COMMENT 'longblob',
+primary key(`usage`)
+) engine=tianmu;
+
+insert into column_type_test 
+values(100,100,100,100,100,5.2,10.88,100.08300,'2016-02-25','2016-02-25 10:20:01',
+'2007-04-23 08:12:49','10:20:01','stoneatom','hello',NULL,'bcdefghijklmn',NULL);
+insert into column_type_test 
+values(101,100,100,100,100,5.2,10.88,100.08300,'2016-02-25','2016-02-25 10:20:01',
+'2007-04-23 08:12:49','10:20:01','stoneatom','hello',NULL,'bcdefghijklmn',NULL);
+insert into column_type_test 
+values(102,100,100,100,100,5.2,10.88,100.08300,'2016-02-25','2016-02-25 10:20:01',
+'2007-04-23 08:12:49','10:20:01','stoneatom','hello',NULL,'bcdefghijklmn',NULL);
+
+update column_type_test set `use`=200 where `usage`=100;
+select * from column_type_test;
+--echo [on slave]
+--source include/sync_slave_sql_with_master.inc
+select * from column_type_test;
+--echo [on master]
+connection master;
+delete from column_type_test where `usage`=100;
+select * from column_type_test;
+--echo [on slave]
+--source include/sync_slave_sql_with_master.inc
+select * from column_type_test;
+
+--echo [on master]
+connection master;
+drop table column_type_test;
+--source include/sync_slave_sql_with_master.inc
+
+--echo #
+--echo # Validate scenarios where push down fails
+--echo # 
+
+--disable_query_log
+if (`show variables like "debug"`)
+{
+    SET @save_debug=@@global.debug;
+    SET GLOBAL DEBUG='+d,tianmu_can_push_down_falied';
+}
+--enable_query_log
+
+--echo [on master]
+connection master;
+
+CREATE TABLE `column_type_test` (
+`usage` tinyint(4) COMMENT 'tinyint',
+`use` smallint(6) DEFAULT NULL COMMENT 'smallint',
+`update` mediumint(9) DEFAULT NULL COMMENT 'mediumint',
+`delete` int(11) DEFAULT NULL COMMENT 'int',
+`select` bigint(20) DEFAULT NULL COMMENT 'bigint',
+`drop` float DEFAULT NULL COMMENT 'float',
+`create` double DEFAULT NULL COMMENT 'double',
+`insert` decimal(10,5) DEFAULT NULL COMMENT 'decimal',
+`database` date DEFAULT NULL COMMENT 'date',
+`where` datetime DEFAULT NULL COMMENT 'datetime',
+`lefe` timestamp NULL DEFAULT NULL COMMENT 'timestamp',
+`join` time DEFAULT NULL COMMENT 'time',
+`engine` char(10) DEFAULT NULL COMMENT 'char',
+`reset` varchar(10) DEFAULT NULL COMMENT 'varchar',
+`into` blob COMMENT 'blob',
+`set` text COMMENT 'text',
+`show` longblob COMMENT 'longblob',
+primary key(`usage`)
+) engine=tianmu;
+
+insert into column_type_test 
+values(100,100,100,100,100,5.2,10.88,100.08300,'2016-02-25','2016-02-25 10:20:01',
+'2007-04-23 08:12:49','10:20:01','stoneatom','hello',NULL,'bcdefghijklmn',NULL);
+insert into column_type_test 
+values(101,100,100,100,100,5.2,10.88,100.08300,'2016-02-25','2016-02-25 10:20:01',
+'2007-04-23 08:12:49','10:20:01','stoneatom','hello',NULL,'bcdefghijklmn',NULL);
+insert into column_type_test 
+values(102,100,100,100,100,5.2,10.88,100.08300,'2016-02-25','2016-02-25 10:20:01',
+'2007-04-23 08:12:49','10:20:01','stoneatom','hello',NULL,'bcdefghijklmn',NULL);
+
+update column_type_test set `use`=200 where `usage`=100;
+select * from column_type_test;
+--echo [on slave]
+--source include/sync_slave_sql_with_master.inc
+select * from column_type_test;
+--echo [on master]
+connection master;
+delete from column_type_test where `usage`=100;
+select * from column_type_test;
+--echo [on slave]
+--source include/sync_slave_sql_with_master.inc
+select * from column_type_test;
+
+--echo [on master]
+connection master;
+drop table column_type_test;
+--source include/sync_slave_sql_with_master.inc
+
+--echo #
+--echo # Adds some test cases for unicode.
+--echo # 
+
+--echo [on master]
+connection master;
+
+CREATE TABLE `column_type_test` (
+`abc def` tinyint(4) COMMENT 'tinyint',
+`пусто` smallint(6) DEFAULT NULL COMMENT 'smallint',
+`новое` mediumint(9) DEFAULT NULL COMMENT 'mediumint',
+`你好` int(11) DEFAULT NULL COMMENT 'int',
+`to-to0` bigint(20) DEFAULT NULL COMMENT 'bigint',
+`dr(op` float DEFAULT NULL COMMENT 'float',
+`cr+eate` double DEFAULT NULL COMMENT 'double',
+`ins=ert` decimal(10,5) DEFAULT NULL COMMENT 'decimal',
+`data.base` date DEFAULT NULL COMMENT 'date',
+`whe]re` datetime DEFAULT NULL COMMENT 'datetime',
+`lef[e` timestamp NULL DEFAULT NULL COMMENT 'timestamp',
+`joi)n` time DEFAULT NULL COMMENT 'time',
+`eng<ine` char(10) DEFAULT NULL COMMENT 'char',
+`rese>&t` varchar(10) DEFAULT NULL COMMENT 'varchar',
+`into#` blob COMMENT 'blob',
+`set@` text COMMENT 'text',
+`sho*w` longblob COMMENT 'longblob'
+) engine=innodb;
+
+insert into column_type_test 
+values(100,100,100,100,100,5.2,10.88,100.08300,'2016-02-25','2016-02-25 10:20:01',
+'2007-04-23 08:12:49','10:20:01','stoneatom','hello',NULL,'bcdefghijklmn',NULL);
+insert into column_type_test 
+values(101,100,100,100,100,5.2,10.88,100.08300,'2016-02-25','2016-02-25 10:20:01',
+'2007-04-23 08:12:49','10:20:01','stoneatom','hello',NULL,'bcdefghijklmn',NULL);
+insert into column_type_test 
+values(102,100,100,100,100,5.2,10.88,100.08300,'2016-02-25','2016-02-25 10:20:01',
+'2007-04-23 08:12:49','10:20:01','stoneatom','hello',NULL,'bcdefghijklmn',NULL);
+
+update column_type_test set `пусто`=200 where `abc def`=100;
+select * from column_type_test;
+--echo [on slave]
+--source include/sync_slave_sql_with_master.inc
+select * from column_type_test;
+--echo [on master]
+connection master;
+delete from column_type_test where `abc def`=100;
+select * from column_type_test;
+--echo [on slave]
+--source include/sync_slave_sql_with_master.inc
+select * from column_type_test;
+
+--echo [on master]
+connection master;
+drop table column_type_test;
+--source include/sync_slave_sql_with_master.inc
+
+stop slave;

--- a/mysql-test/suite/tianmu/t/issue1065.test
+++ b/mysql-test/suite/tianmu/t/issue1065.test
@@ -4,6 +4,10 @@ USE test;
 --disable_warnings
 set sql_mode='STRICT_TRANS_TABLES,NO_AUTO_CREATE_USER,NO_ENGINE_SUBSTITUTION';
 --enable_warnings
+--disable_warnings
+drop table if exists t_test; 
+--enable_warnings
+
 CREATE TABLE t_test(
   id INT NOT NULL AUTO_INCREMENT,
   first_name VARCHAR(10) NOT NULL,

--- a/mysql-test/suite/tianmu/t/issue228.test
+++ b/mysql-test/suite/tianmu/t/issue228.test
@@ -1,4 +1,9 @@
 use test;
+
+--disable_warnings
+drop table if exists t1;
+--enable_warnings
+
 create table t1 (a varchar(112) charset utf8 collate utf8_bin not null,primary key (a)) select 'test' as a ;
 select a from t1;
 drop table t1;

--- a/mysql-test/suite/tianmu/t/issue301.test
+++ b/mysql-test/suite/tianmu/t/issue301.test
@@ -1,5 +1,9 @@
 use test;
 
+--disable_warnings
+drop table if exists t1;
+--enable_warnings
+
 CREATE TABLE t1 (a INT NOT NULL, b INT)engine=tianmu;
 INSERT INTO t1 VALUES (1, 1),(1,2),(1,3);
 select * from t1 where 1=1 and 1=1 or b>2;

--- a/sql/log_event.cc
+++ b/sql/log_event.cc
@@ -10851,7 +10851,7 @@ int Rows_log_event::do_table_scan_and_update(Relay_log_info const *rli)
 
     int restart_count= 0; // Number of times scanning has restarted from top
 
-    bool push_result = can_push_donw();
+    bool push_result = can_push_down();
     if (!push_result && (error= m_table->file->ha_rnd_init(1)))
     {
       DBUG_PRINT("info",("error initializing table scan"

--- a/sql/log_event.h
+++ b/sql/log_event.h
@@ -3297,14 +3297,13 @@ private:
 
   /*column information to conditions,Prepare for conditional push*/
   bool column_information_to_conditions(std::string &sql_statemens, 
-                                                      MY_BITMAP *cols_bitmap, 
                                                       std::string &prefix);
 
   /*
     Push down the execution conditions for the engine 
     if necessary to reduce the number of rows to be iterated
   */
-  bool can_push_donw();
+  bool can_push_down();
 
   /*
     Convert log in row format to sql statement

--- a/sql/log_event_push_cond.cc
+++ b/sql/log_event_push_cond.cc
@@ -146,20 +146,23 @@ static double PowOfTen(int exponent) { return std::pow((double)10, exponent); }
 /**
  Conversion conditions of column data
   
-  @param[in] file              IO cache
-  @param[in] ptr               Pointer to string
-  @param[in] type              Column type
-  @param[in] meta              Column meta information
+  @param[std::string] str_condition       condition cache
+  @param[Field *] f                       Column Properties
+  @param[in] meta                         Column meta information
+  @param[bool] unwanted_str               Whether string condition is required
   
   @retval   - number of bytes scanned from ptr.
 */
 static size_t
-filed_str_to_sql_conditions(std::string &str_condition, const uchar *ptr,
-                            uint type, uint meta, Field *f)
+filed_str_to_sql_conditions(std::string &str_condition, Field *f , uint meta, bool unwanted_str)
 {
+  const uchar *ptr = f->is_null() ? nullptr:f->ptr;
+  if(!ptr){
+    return 0;
+  }
   uint32 length= 0;
   uint32 ASC_max = 255;
-  if (type == MYSQL_TYPE_STRING)
+  if (f->type() == MYSQL_TYPE_STRING)
   {
     if (meta > ASC_max)
     {
@@ -178,16 +181,13 @@ filed_str_to_sql_conditions(std::string &str_condition, const uchar *ptr,
       length= meta;
   }
 
-  switch (type) {
+  switch (f->type()) {
   case MYSQL_TYPE_LONG:
   case MYSQL_TYPE_TINY:
   case MYSQL_TYPE_INT24:
   case MYSQL_TYPE_SHORT:
   case MYSQL_TYPE_LONGLONG:
     {
-      if(!ptr){
-        return 0;
-      }
       int64_t v = f->val_int();
       str_condition = std::to_string(v);
       return 4;
@@ -196,9 +196,6 @@ filed_str_to_sql_conditions(std::string &str_condition, const uchar *ptr,
   //case MYSQL_TYPE_FLOAT:
   case MYSQL_TYPE_DOUBLE:
     {
-      if(!ptr){
-        return 0;
-      }
       double v = f->val_real();
       str_condition = std::to_string(v);
       return 4;
@@ -207,9 +204,6 @@ filed_str_to_sql_conditions(std::string &str_condition, const uchar *ptr,
     {
       /* Meta-data: bit_len, bytes_in_rec, 2 bytes */
       uint nbits= ((meta >> 8) * 8) + (meta & 0xFF);
-      if(!ptr){
-        return 0;
-      }
       length= (nbits + 7) / 8;
       char tmp[120] = {0};
       my_b_write_bit(tmp, ptr, nbits);
@@ -221,9 +215,6 @@ filed_str_to_sql_conditions(std::string &str_condition, const uchar *ptr,
   case MYSQL_TYPE_DATETIME:
   case MYSQL_TYPE_DATETIME2:
   {
-      if(!ptr){
-        return 0;
-      }
       MYSQL_TIME my_time;
       std::memset(&my_time, 0, sizeof(my_time));
       f->get_time(&my_time);
@@ -237,9 +228,6 @@ filed_str_to_sql_conditions(std::string &str_condition, const uchar *ptr,
   case MYSQL_TYPE_TIME:
   case MYSQL_TYPE_TIME2:
     {
-      if(!ptr){
-        return 0;
-      }
       MYSQL_TIME my_time;
       std::memset(&my_time, 0, sizeof(my_time));
       f->get_time(&my_time);
@@ -252,9 +240,6 @@ filed_str_to_sql_conditions(std::string &str_condition, const uchar *ptr,
   case MYSQL_TYPE_DATE:
   case MYSQL_TYPE_NEWDATE:
     {
-      if(!ptr){
-        return 0;
-      }
       MYSQL_TIME my_time;
       std::memset(&my_time, 0, sizeof(my_time));
       f->get_time(&my_time);
@@ -266,9 +251,6 @@ filed_str_to_sql_conditions(std::string &str_condition, const uchar *ptr,
 
   case MYSQL_TYPE_YEAR:
     {
-      if(!ptr){
-        return 0;
-      }
       MYSQL_TIME my_time;
       std::memset(&my_time, 0, sizeof(my_time));
       f->get_time(&my_time);
@@ -282,18 +264,12 @@ filed_str_to_sql_conditions(std::string &str_condition, const uchar *ptr,
     switch (meta & 0xFF) {
     case 1:
     {
-      if(!ptr){
-        return 0;
-      }
       int64_t v = f->val_int();
       str_condition = std::to_string(v);
       return 1;
     }
     case 2:
     {
-      if(!ptr){
-        return 0;
-      }
       int32 i32= uint2korr(ptr);
       char tmp[64] = {0};
       sprintf(tmp, "%d", i32);
@@ -307,9 +283,6 @@ filed_str_to_sql_conditions(std::string &str_condition, const uchar *ptr,
     
   case MYSQL_TYPE_SET:
   {
-    if(!ptr){
-        return 0;
-      }
     char tmp[64] = {0};
     my_b_write_bit(tmp, ptr , (meta & 0xFF) * 8);
     str_condition = tmp;
@@ -321,7 +294,7 @@ filed_str_to_sql_conditions(std::string &str_condition, const uchar *ptr,
   case MYSQL_TYPE_STRING:
   case MYSQL_TYPE_JSON:
   {
-    if(!ptr){
+    if(unwanted_str){
         return 0;
       }
     String str;
@@ -336,36 +309,95 @@ filed_str_to_sql_conditions(std::string &str_condition, const uchar *ptr,
   return 0;
 }
 
+//Check whether there are numbers or time types in the table
+static bool checklist_have_number_or_time(Field **field, uint field_num)
+{
+  if(!field) return false;
+  for (uint col_id = 0; col_id < field_num; col_id++) {
+    Field *f = field[col_id];
+    switch (f->type()) {
+      case MYSQL_TYPE_LONG:
+      case MYSQL_TYPE_TINY:
+      case MYSQL_TYPE_INT24:
+      case MYSQL_TYPE_SHORT:
+      case MYSQL_TYPE_LONGLONG:
+      case MYSQL_TYPE_DOUBLE:
+      case MYSQL_TYPE_TIMESTAMP:
+      case MYSQL_TYPE_TIMESTAMP2:
+      case MYSQL_TYPE_DATETIME:
+      case MYSQL_TYPE_DATETIME2:
+      case MYSQL_TYPE_YEAR:
+      case MYSQL_TYPE_DATE:
+      case MYSQL_TYPE_NEWDATE:
+      case MYSQL_TYPE_TIME:
+      case MYSQL_TYPE_TIME2:
+      {
+        return true;
+      }
+      default:
+        break;
+    } 
+  }
+  return false;
+}
+
 
 bool Rows_log_event::column_information_to_conditions(std::string &sql_statemens, 
-                                                      MY_BITMAP *cols_bitmap, 
                                                       std::string &prefix)
 {
-  /*
-    Skip metadata bytes which gives the information about nullabity of master
-    columns. Master writes one bit for each affected column.
-   */
-  bitmap_bits_set(cols_bitmap);
   sql_statemens += prefix;
   Field **field = m_table->field;
-  MYSQL_TIME my_time;
-  std::memset(&my_time, 0, sizeof(my_time));
+  if(!field) return false;
+  /*
+    If there is a unique constraint, 
+    use the field of the unique constraint as the push down condition
+  */
+  std::string key_field_name;
+  if(m_table->s->key_info && 
+    m_table->s->key_info->key_part &&
+    m_table->s->key_info->key_part->field)
+  {
+    key_field_name = m_table->s->key_info->key_part->field->field_name;
+  }
   int cond_num = 0;
+  bool unwanted_str = false;
+  /*
+    If there is a number or time type in the table, 
+    the string type value is not used as the push down condition.
+  */
+  if(checklist_have_number_or_time(field, m_table->s->fields)) unwanted_str = true;
+
   for (uint col_id = 0; col_id < m_table->s->fields; col_id++) {
     Field *f = field[col_id];
-    if (bitmap_is_set(cols_bitmap, col_id) == 0)
-      continue;
     uint16 meta;
     f->save_field_metadata((uchar*)&meta);
     std::string str_cond;
-    size_t size = filed_str_to_sql_conditions(str_cond, (f->is_null() ? NULL: f->ptr), f->type(), meta, f);
-    if(str_cond.empty())
-    {
+
+    if(!key_field_name.empty()) {
+      
+      if(key_field_name.compare(f->field_name) != 0) {
+        continue;
+      }
+
+      filed_str_to_sql_conditions(str_cond, f, meta, false);
+      if(str_cond.empty()) {
+        col_id = 0;
+        key_field_name = "";
+        continue;
+      }
+
+      sql_statemens += "`" + std::string(f->field_name) + "`=" + str_cond;
+      sql_statemens.push_back('\0');
+      return true;
+    }
+
+    filed_str_to_sql_conditions(str_cond, f, meta, unwanted_str);
+    if(str_cond.empty()){
       continue;
     }
     if(cond_num > 0 )
       sql_statemens += " and ";
-    sql_statemens += std::string(f->field_name) + "=" + str_cond;
+    sql_statemens += "`" + std::string(f->field_name) + "`=" + str_cond;
     cond_num ++;
   }
   sql_statemens.push_back('\0');
@@ -384,17 +416,17 @@ bool Rows_log_event::row_event_to_statement(LEX_CSTRING &lex_str, std::string &s
     regardless of the SQL type,
     The syntax of select is simple, so select statements are used here to compile conditions
   */
-  std::string sql_command = "SELECT * FROM ", sql_clause = " WHERE ";
+  std::string sql_command = "SELECT * FROM `", sql_clause = " WHERE ";
 
-  sql_statement = sql_command + m_table->s->db.str + "." + m_table->s->table_name.str;
-  if (!column_information_to_conditions(sql_statement, &m_cols, sql_clause))
+  sql_statement = sql_command + m_table->s->db.str + "`.`" + m_table->s->table_name.str +"`";
+  if (!column_information_to_conditions(sql_statement, sql_clause))
     return false;
   lex_str.str = sql_statement.c_str();
   lex_str.length = sql_statement.length();
   return true;
 }
 
-bool Rows_log_event::can_push_donw()
+bool Rows_log_event::can_push_down()
 {
   //Judge whether it is a tianmu engine
   if(!(m_table && m_table->s && 
@@ -421,6 +453,10 @@ bool Rows_log_event::can_push_donw()
     goto error;
   thd->set_query(lex_str);
   thd->set_query_id(next_query_id());
+  DBUG_EXECUTE_IF("tianmu_can_push_down_falied",
+    {
+      goto error;
+    });
 
   //Parse statement
   if (parser_state.init(thd, thd->query().str, thd->query().length))
@@ -484,7 +520,7 @@ bool Rows_log_event::can_push_donw()
 end:
   return true; 
 error:
-  sql_print_information("can_push_donw : error");
+  sql_print_information("can_push_down : falied");
   sql_print_information(lex_str.str);
   return false;
 }


### PR DESCRIPTION

1. Optimize scenarios with keywords in the table.
2. Scenarios with unique constraints in the optimization table, If there is a unique constraint, only the unique constraint is used as the push down condition.
3. The optimization table contains a number or time type scenario. If there are two types, no word is used String type as pushdown condition

<!--

Thank you for contributing to StoneDB!

PR Title Format: <type>(<scope>): description to this pr (#issue_id)
e.g.
fix(util): fix sth..... (#1)

-->

## Summary about this PR
<!--

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".
e.g.:
Issue: close #1

-->

Issue Number: close #1054


## Tests Check List
<!-- At least one of next options must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

## Changelog
<!-- At least one of next options must be included. -->

- [ ] New Feature
- [x] Bug Fix
- [ ] Performance Improvement
- [ ] Build/Testing/CI/CD
- [ ] Documentation
- [ ] Not for changelog (changelog entry is not required)

## Documentation
<!-- At least one of next options must be included. -->

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
