### PR TITLE
feat(tianmu):Master slave synchronization - Row format supports primary key scanning(#1111)

### DIFF
--- a/mysql-test/suite/tianmu/r/issue1111.result
+++ b/mysql-test/suite/tianmu/r/issue1111.result
@@ -1,0 +1,287 @@
+use test;
+drop table if exists `ttt`;
+drop table if exists `t3`;
+include/master-slave.inc
+[connection master]
+#
+# Has primary key
+# 
+[on master]
+create table ttt(id int primary key,name varchar(64))engine=innodb;
+insert into ttt values(111,'你好');
+insert into ttt values(11,'aaa');
+insert into ttt values(3,'hhhb');
+insert into ttt values(2,'hhhb');
+insert into ttt values(1,'hhhb');
+insert into ttt values(31,'hhhb');
+insert into ttt values(32,'zzz');
+insert into ttt values(4,'hhhb');
+insert into ttt values(5,'zzz');
+insert into ttt values(6,'hhhb');
+insert into ttt values(7,'zzz');
+insert into ttt values(88,'hhhb');
+insert into ttt values(98,'zzz');
+update ttt set name='lllll' where id in(1,3,2);
+select * from ttt where id in(1,3,2) order by id desc;
+id	name
+3	lllll
+2	lllll
+1	lllll
+[on slave]
+include/sync_slave_sql_with_master.inc
+select * from ttt where id in(1,3,2) order by id desc;
+id	name
+3	lllll
+2	lllll
+1	lllll
+[on master]
+delete from ttt where id=1;
+delete from ttt where name='zzz';
+select * from ttt order by id desc;
+id	name
+111	你好
+88	hhhb
+31	hhhb
+11	aaa
+6	hhhb
+4	hhhb
+3	lllll
+2	lllll
+[on slave]
+include/sync_slave_sql_with_master.inc
+select * from ttt order by id desc;
+id	name
+111	你好
+88	hhhb
+31	hhhb
+11	aaa
+6	hhhb
+4	hhhb
+3	lllll
+2	lllll
+[on master]
+drop table ttt;
+CREATE TABLE t3 (a int not null, b int not null, primary key (a,b))engine=innodb;
+insert into t3 values (1,1),(2,1),(1,3),(4,5),(6,7),(8,9);
+delete from t3 where a in (4,6,1);
+select * from t3 order by a desc;
+a	b
+8	9
+2	1
+[on slave]
+include/sync_slave_sql_with_master.inc
+select * from t3 order by a desc;
+a	b
+8	9
+2	1
+[on master]
+drop table t3;
+include/sync_slave_sql_with_master.inc
+#
+# Have unique constraints
+# 
+[on master]
+create table ttt(id int NOT NULL UNIQUE,name varchar(64))engine=innodb;
+insert into ttt values(111,'你好');
+insert into ttt values(11,'aaa');
+insert into ttt values(3,'hhhb');
+insert into ttt values(2,'hhhb');
+insert into ttt values(1,'hhhb');
+insert into ttt values(31,'hhhb');
+insert into ttt values(32,'zzz');
+insert into ttt values(4,'hhhb');
+insert into ttt values(5,'zzz');
+insert into ttt values(6,'hhhb');
+insert into ttt values(7,'zzz');
+insert into ttt values(88,'hhhb');
+insert into ttt values(98,'zzz');
+update ttt set name='lllll' where id in(1,3,2);
+select * from ttt where id in(1,3,2) order by id desc;
+id	name
+3	lllll
+2	lllll
+1	lllll
+[on slave]
+include/sync_slave_sql_with_master.inc
+select * from ttt where id in(1,3,2) order by id desc;
+id	name
+3	lllll
+2	lllll
+1	lllll
+[on master]
+delete from ttt where id=1;
+delete from ttt where name='zzz';
+select * from ttt order by id desc;
+id	name
+111	你好
+88	hhhb
+31	hhhb
+11	aaa
+6	hhhb
+4	hhhb
+3	lllll
+2	lllll
+[on slave]
+include/sync_slave_sql_with_master.inc
+select * from ttt order by id desc;
+id	name
+111	你好
+88	hhhb
+31	hhhb
+11	aaa
+6	hhhb
+4	hhhb
+3	lllll
+2	lllll
+[on master]
+drop table ttt;
+CREATE TABLE t3 (a int not null, b int not null, UNIQUE(a,b))engine=innodb;
+insert into t3 values (1,1),(2,1),(1,3),(4,5),(6,7),(8,9);
+delete from t3 where a in (4,6,1);
+select * from t3 order by a desc;
+a	b
+8	9
+2	1
+[on slave]
+include/sync_slave_sql_with_master.inc
+select * from t3 order by a desc;
+a	b
+8	9
+2	1
+[on master]
+drop table t3;
+include/sync_slave_sql_with_master.inc
+#
+# With secondary index
+# 
+[on master]
+create table ttt(id int not null,name varchar(64),index(id))engine=innodb;
+insert into ttt values(111,'你好');
+insert into ttt values(11,'aaa');
+insert into ttt values(3,'hhhb');
+insert into ttt values(2,'hhhb');
+insert into ttt values(1,'hhhb');
+insert into ttt values(31,'hhhb');
+insert into ttt values(32,'zzz');
+insert into ttt values(4,'hhhb');
+insert into ttt values(5,'zzz');
+insert into ttt values(6,'hhhb');
+insert into ttt values(7,'zzz');
+insert into ttt values(88,'hhhb');
+insert into ttt values(98,'zzz');
+update ttt set name='lllll' where id in(1,3,2);
+select * from ttt where id in(1,3,2) order by id desc;
+id	name
+3	lllll
+2	lllll
+1	lllll
+[on slave]
+include/sync_slave_sql_with_master.inc
+select * from ttt where id in(1,3,2) order by id desc;
+id	name
+3	lllll
+2	lllll
+1	lllll
+[on master]
+delete from ttt where id=1;
+delete from ttt where name='zzz';
+select * from ttt order by id desc;
+id	name
+111	你好
+88	hhhb
+31	hhhb
+11	aaa
+6	hhhb
+4	hhhb
+3	lllll
+2	lllll
+[on slave]
+include/sync_slave_sql_with_master.inc
+select * from ttt order by id desc;
+id	name
+111	你好
+88	hhhb
+31	hhhb
+11	aaa
+6	hhhb
+4	hhhb
+3	lllll
+2	lllll
+[on master]
+drop table ttt;
+CREATE TABLE t3 (a int not null, b int not null, index(a,b))engine=innodb;
+insert into t3 values (1,1),(2,1),(1,3),(4,5),(6,7),(8,9);
+delete from t3 where a in (4,6,1);
+select * from t3 order by a desc;
+a	b
+8	9
+2	1
+[on slave]
+include/sync_slave_sql_with_master.inc
+select * from t3 order by a desc;
+a	b
+8	9
+2	1
+[on master]
+drop table t3;
+include/sync_slave_sql_with_master.inc
+#
+# common
+# 
+[on master]
+create table ttt(id int , name varchar(64))engine=innodb;
+insert into ttt values(111,'你好');
+insert into ttt values(11,'aaa');
+insert into ttt values(3,'hhhb');
+insert into ttt values(2,'hhhb');
+insert into ttt values(1,'hhhb');
+insert into ttt values(31,'hhhb');
+insert into ttt values(32,'zzz');
+insert into ttt values(4,'hhhb');
+insert into ttt values(5,'zzz');
+insert into ttt values(6,'hhhb');
+insert into ttt values(7,'zzz');
+insert into ttt values(88,'hhhb');
+insert into ttt values(98,'zzz');
+update ttt set name='lllll' where id in(1,3,2);
+select * from ttt where id in(1,3,2) order by id desc;
+id	name
+3	lllll
+2	lllll
+1	lllll
+[on slave]
+include/sync_slave_sql_with_master.inc
+select * from ttt where id in(1,3,2) order by id desc;
+id	name
+3	lllll
+2	lllll
+1	lllll
+[on master]
+delete from ttt where id=1;
+delete from ttt where name='zzz';
+select * from ttt order by id desc;
+id	name
+111	你好
+88	hhhb
+31	hhhb
+11	aaa
+6	hhhb
+4	hhhb
+3	lllll
+2	lllll
+[on slave]
+include/sync_slave_sql_with_master.inc
+select * from ttt order by id desc;
+id	name
+111	你好
+88	hhhb
+31	hhhb
+11	aaa
+6	hhhb
+4	hhhb
+3	lllll
+2	lllll
+[on master]
+drop table ttt;
+include/sync_slave_sql_with_master.inc
+stop slave;

--- a/mysql-test/suite/tianmu/t/issue1111.test
+++ b/mysql-test/suite/tianmu/t/issue1111.test
@@ -1,0 +1,192 @@
+-- source include/have_tianmu.inc
+
+use test;
+--disable_warnings
+drop table if exists `ttt`;
+drop table if exists `t3`;
+--enable_warnings
+
+--disable_warnings
+-- source include/master-slave.inc
+--enable_warnings
+
+
+--echo #
+--echo # Has primary key
+--echo # 
+--echo [on master]
+connection master;
+create table ttt(id int primary key,name varchar(64))engine=innodb;
+insert into ttt values(111,'你好');
+insert into ttt values(11,'aaa');
+insert into ttt values(3,'hhhb');
+insert into ttt values(2,'hhhb');
+insert into ttt values(1,'hhhb');
+insert into ttt values(31,'hhhb');
+insert into ttt values(32,'zzz');
+insert into ttt values(4,'hhhb');
+insert into ttt values(5,'zzz');
+insert into ttt values(6,'hhhb');
+insert into ttt values(7,'zzz');
+insert into ttt values(88,'hhhb');
+insert into ttt values(98,'zzz');
+update ttt set name='lllll' where id in(1,3,2);
+select * from ttt where id in(1,3,2) order by id desc;
+--echo [on slave]
+--source include/sync_slave_sql_with_master.inc
+select * from ttt where id in(1,3,2) order by id desc;
+--echo [on master]
+connection master;
+delete from ttt where id=1;
+delete from ttt where name='zzz';
+select * from ttt order by id desc;
+--echo [on slave]
+--source include/sync_slave_sql_with_master.inc
+select * from ttt order by id desc;
+--echo [on master]
+connection master;
+drop table ttt;
+CREATE TABLE t3 (a int not null, b int not null, primary key (a,b))engine=innodb;
+insert into t3 values (1,1),(2,1),(1,3),(4,5),(6,7),(8,9);
+delete from t3 where a in (4,6,1);
+select * from t3 order by a desc;
+--echo [on slave]
+--source include/sync_slave_sql_with_master.inc
+select * from t3 order by a desc;
+--echo [on master]
+connection master;
+drop table t3;
+--source include/sync_slave_sql_with_master.inc
+
+--echo #
+--echo # Have unique constraints
+--echo # 
+--echo [on master]
+connection master;
+create table ttt(id int NOT NULL UNIQUE,name varchar(64))engine=innodb;
+insert into ttt values(111,'你好');
+insert into ttt values(11,'aaa');
+insert into ttt values(3,'hhhb');
+insert into ttt values(2,'hhhb');
+insert into ttt values(1,'hhhb');
+insert into ttt values(31,'hhhb');
+insert into ttt values(32,'zzz');
+insert into ttt values(4,'hhhb');
+insert into ttt values(5,'zzz');
+insert into ttt values(6,'hhhb');
+insert into ttt values(7,'zzz');
+insert into ttt values(88,'hhhb');
+insert into ttt values(98,'zzz');
+update ttt set name='lllll' where id in(1,3,2);
+select * from ttt where id in(1,3,2) order by id desc;
+--echo [on slave]
+--source include/sync_slave_sql_with_master.inc
+select * from ttt where id in(1,3,2) order by id desc;
+--echo [on master]
+connection master;
+delete from ttt where id=1;
+delete from ttt where name='zzz';
+select * from ttt order by id desc;
+--echo [on slave]
+--source include/sync_slave_sql_with_master.inc
+select * from ttt order by id desc;
+--echo [on master]
+connection master;
+drop table ttt;
+CREATE TABLE t3 (a int not null, b int not null, UNIQUE(a,b))engine=innodb;
+insert into t3 values (1,1),(2,1),(1,3),(4,5),(6,7),(8,9);
+delete from t3 where a in (4,6,1);
+select * from t3 order by a desc;
+--echo [on slave]
+--source include/sync_slave_sql_with_master.inc
+select * from t3 order by a desc;
+--echo [on master]
+connection master;
+drop table t3;
+--source include/sync_slave_sql_with_master.inc
+
+--echo #
+--echo # With secondary index
+--echo # 
+--echo [on master]
+connection master;
+create table ttt(id int not null,name varchar(64),index(id))engine=innodb;
+insert into ttt values(111,'你好');
+insert into ttt values(11,'aaa');
+insert into ttt values(3,'hhhb');
+insert into ttt values(2,'hhhb');
+insert into ttt values(1,'hhhb');
+insert into ttt values(31,'hhhb');
+insert into ttt values(32,'zzz');
+insert into ttt values(4,'hhhb');
+insert into ttt values(5,'zzz');
+insert into ttt values(6,'hhhb');
+insert into ttt values(7,'zzz');
+insert into ttt values(88,'hhhb');
+insert into ttt values(98,'zzz');
+update ttt set name='lllll' where id in(1,3,2);
+select * from ttt where id in(1,3,2) order by id desc;
+--echo [on slave]
+--source include/sync_slave_sql_with_master.inc
+select * from ttt where id in(1,3,2) order by id desc;
+--echo [on master]
+connection master;
+delete from ttt where id=1;
+delete from ttt where name='zzz';
+select * from ttt order by id desc;
+--echo [on slave]
+--source include/sync_slave_sql_with_master.inc
+select * from ttt order by id desc;
+--echo [on master]
+connection master;
+drop table ttt;
+CREATE TABLE t3 (a int not null, b int not null, index(a,b))engine=innodb;
+insert into t3 values (1,1),(2,1),(1,3),(4,5),(6,7),(8,9);
+delete from t3 where a in (4,6,1);
+select * from t3 order by a desc;
+--echo [on slave]
+--source include/sync_slave_sql_with_master.inc
+select * from t3 order by a desc;
+--echo [on master]
+connection master;
+drop table t3;
+--source include/sync_slave_sql_with_master.inc
+
+--echo #
+--echo # common
+--echo # 
+--echo [on master]
+connection master;
+create table ttt(id int , name varchar(64))engine=innodb;
+insert into ttt values(111,'你好');
+insert into ttt values(11,'aaa');
+insert into ttt values(3,'hhhb');
+insert into ttt values(2,'hhhb');
+insert into ttt values(1,'hhhb');
+insert into ttt values(31,'hhhb');
+insert into ttt values(32,'zzz');
+insert into ttt values(4,'hhhb');
+insert into ttt values(5,'zzz');
+insert into ttt values(6,'hhhb');
+insert into ttt values(7,'zzz');
+insert into ttt values(88,'hhhb');
+insert into ttt values(98,'zzz');
+update ttt set name='lllll' where id in(1,3,2);
+select * from ttt where id in(1,3,2) order by id desc;
+--echo [on slave]
+--source include/sync_slave_sql_with_master.inc
+select * from ttt where id in(1,3,2) order by id desc;
+--echo [on master]
+connection master;
+delete from ttt where id=1;
+delete from ttt where name='zzz';
+select * from ttt order by id desc;
+--echo [on slave]
+--source include/sync_slave_sql_with_master.inc
+select * from ttt order by id desc;
+--echo [on master]
+connection master;
+drop table ttt;
+--source include/sync_slave_sql_with_master.inc
+
+stop slave;

--- a/sql/log_event.cc
+++ b/sql/log_event.cc
@@ -9681,8 +9681,19 @@ search_key_in_table(TABLE *table, MY_BITMAP *bi_cols, uint key_type)
   KEY *keyinfo;
   uint res= MAX_KEY;
   uint key;
+  
+  if (key_type & PRI_KEY_FLAG &&
+      (table->s->primary_key < MAX_KEY))
+  {
+    DBUG_PRINT("debug", ("Searching for PK"));
+    keyinfo= table->s->key_info + table->s->primary_key;
+    if (are_all_columns_signaled_for_key(keyinfo, bi_cols))
+      DBUG_RETURN(table->s->primary_key);
+  }
   /*
-    PK has bugs, not support
+    The tianmu engine only supports primary keys, 
+    and unique constraints and secondary indexes are not supported,
+    Therefore, only scanning with primary key scenarios is allowed here.
   */
   bool check_if_tianmu_engine = table && table->s && 
                       (table->s->db_type() ? (table->s->db_type()->db_type == DB_TYPE_TIANMU): false);
@@ -9693,14 +9704,6 @@ search_key_in_table(TABLE *table, MY_BITMAP *bi_cols, uint key_type)
                         (sql_command == SQLCOM_UPDATE) ||
                         (sql_command == SQLCOM_UPDATE_MULTI))){
     DBUG_RETURN(res);
-  }
-  if (key_type & PRI_KEY_FLAG &&
-      (table->s->primary_key < MAX_KEY))
-  {
-    DBUG_PRINT("debug", ("Searching for PK"));
-    keyinfo= table->s->key_info + table->s->primary_key;
-    if (are_all_columns_signaled_for_key(keyinfo, bi_cols))
-      DBUG_RETURN(table->s->primary_key);
   }
 
   if (key_type & UNIQUE_KEY_FLAG)


### PR DESCRIPTION

1.Repair the (ha_tianmu:: index_read) interface
2.Repair the (ha_tianmu:: position) interface
3.Repair the (ha_tianmu::rnd_pos) interface

The tianmu engine only supports primary keys,
and unique constraints and secondary indexes are not supported, 
Therefore, only scanning with primary key scenarios is allowed here.

<!--

Thank you for contributing to StoneDB!

PR Title Format: <type>(<scope>): description to this pr (#issue_id)
e.g.
fix(util): fix sth..... (#1)

-->

## Summary about this PR
<!--

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".
e.g.:
Issue: close #1

-->

Issue Number: close #issue_number_you_created


## Tests Check List
<!-- At least one of next options must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

## Changelog
<!-- At least one of next options must be included. -->

- [x] New Feature
- [ ] Bug Fix
- [ ] Performance Improvement
- [ ] Build/Testing/CI/CD
- [ ] Documentation
- [ ] Not for changelog (changelog entry is not required)

## Documentation
<!-- At least one of next options must be included. -->

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
