### PR TITLE
fix(tianmu): mysqld server crash when large amount hash join (#1110)

### DIFF
--- a/storage/tianmu/core/index_table.cpp
+++ b/storage/tianmu/core/index_table.cpp
@@ -121,15 +121,15 @@ void IndexTable::LoadBlock(int b) {
   block_changed = false;
 }
 
-void IndexTable::ExpandTo(int64_t new_size) {
+void IndexTable::ExpandTo(uint64_t new_size) {
   DEBUG_ASSERT(IsLocked());
-  if (new_size <= (int64_t)size)
+  if (new_size <= (uint64_t)size)
     return;
   if (size * bytes_per_value == buffer_size_in_bytes) {  // the whole table was in one buffer
     if (buffer_size_in_bytes < 32_MB && size_t(new_size * bytes_per_value) > 32_MB) {
       max_buffer_size_in_bytes =
-          int(mm::TraceableObject::MaxBufferSize(-1));   // recalculate, as it might not be done earlier
-      CI_SetDefaultSize((int)max_buffer_size_in_bytes);  // redefine disk block sized
+          uint64_t(mm::TraceableObject::MaxBufferSize(-1));   // recalculate, as it might not be done earlier
+      CI_SetDefaultSize((uint64_t)max_buffer_size_in_bytes);  // redefine disk block sized
       uint values_per_block = uint(max_buffer_size_in_bytes / bytes_per_value);
       block_shift =
           CalculateBinSize(values_per_block) - 1;  // e.g. BinSize(16)==5, but shift by 4. WARNING: should it be
@@ -137,9 +137,9 @@ void IndexTable::ExpandTo(int64_t new_size) {
       block_mask = (uint64_t(1) << block_shift) - 1;
     }
 
-    int new_buffer_size_in_bytes;
-    if (new_size * bytes_per_value < (int64_t)max_buffer_size_in_bytes)
-      new_buffer_size_in_bytes = int(new_size * bytes_per_value);
+    uint64_t new_buffer_size_in_bytes;
+    if (new_size * bytes_per_value < (uint64_t)max_buffer_size_in_bytes)
+      new_buffer_size_in_bytes = uint64_t(new_size * bytes_per_value);
     else
       new_buffer_size_in_bytes = max_buffer_size_in_bytes;
     // TODO: check the rc_alloc status

--- a/storage/tianmu/core/index_table.h
+++ b/storage/tianmu/core/index_table.h
@@ -108,7 +108,7 @@ class IndexTable : private system::CacheableItem, public mm::TraceableObject {
                                             // which may occur in table
   uint64_t N() { return size; }             // note: this is the upper size, the table can be used partially!
   int BlockShift() { return block_shift; }  // block = int( tuple >> block_shift )
-  void ExpandTo(int64_t new_size);
+  void ExpandTo(uint64_t new_size);
 
   // mm::TraceableObject functionality
   mm::TO_TYPE TraceableType() const override { return mm::TO_TYPE::TO_INDEXTABLE; }
@@ -118,10 +118,10 @@ class IndexTable : private system::CacheableItem, public mm::TraceableObject {
 
   unsigned char *buf = nullptr;  // polymorphic: unsigned short, unsigned int or int64_t
 
-  int max_buffer_size_in_bytes;
+  uint64_t max_buffer_size_in_bytes;
   int bytes_per_value;
   int max_block_used;
-  size_t buffer_size_in_bytes;
+  uint64_t buffer_size_in_bytes;
   int block_shift;
   uint64_t block_mask;
   uint64_t size;

--- a/storage/tianmu/core/multi_index_builder.h
+++ b/storage/tianmu/core/multi_index_builder.h
@@ -47,7 +47,7 @@ class MultiIndexBuilder {
 
     IndexTable *ReleaseIndexTable(int dim);
     bool NullExisted(int dim) const { return nulls_possible_[dim]; }
-    int GetCount() const { return added_count_; }
+    uint64_t GetCount() const { return added_count_; }
     bool IsEmpty() const { return (added_count_ == 0) ? true : false; }
 
    private:
@@ -59,7 +59,7 @@ class MultiIndexBuilder {
     std::vector<int64_t> cached_values_;
     std::vector<bool> nulls_possible_;
 
-    int added_count_ = 0;
+    uint64_t added_count_ = 0;
     IndexTable **index_table_;
     std::unique_ptr<MINewContentsRSorter> rough_sorter_;
   };

--- a/storage/tianmu/system/cacheable_item.h
+++ b/storage/tianmu/system/cacheable_item.h
@@ -51,7 +51,7 @@ class CacheableItem {
   // or its subrange from position 'off', of length 'size' bytes.
   // Returns 0 if successfully got the (sub)block, -1 otherwise
 
-  void CI_SetDefaultSize(int size)  // If the value is set (here, or in constructor),
+  void CI_SetDefaultSize(uint64_t size)  // If the value is set (here, or in constructor),
   {
     default_block_size_ = size;
   }  // then the size parameter in CI_Put may be omitted.
@@ -73,7 +73,7 @@ class CacheableItem {
   std::vector<int> file_start_;     // an address in the file where the i-th data block starts
   std::vector<int> file_size_;      // a size of the i-th data block
 
-  int default_block_size_ = 0;
+  uint64_t default_block_size_ = 0;
   TianmuFile cur_file_handle_;
   int cur_file_number_ = -1;  // the number of currently opened file
   void *cur_map_addr_ = nullptr;


### PR DESCRIPTION
    Causes of the crash:
        When the hash join is executed,
        the cache data will be written to the disk.
        If the cache data is written beyond the int type boundary,
        overflow will occur and the service will crash
    Test method:
        When tested locally,
        crashes occur only when the write disk cache exceeds 14GB or so.
        This amount of data is not suitable for testing in MTR

<!--

Thank you for contributing to StoneDB!

PR Title Format: <type>(<scope>): description to this pr (#issue_id)
e.g.
fix(util): fix sth..... (#1)

-->

## Summary about this PR
<!--

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".
e.g.:
Issue: close #1

-->

Issue Number: close #1110 


## Tests Check List
<!-- At least one of next options must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

## Changelog
<!-- At least one of next options must be included. -->

- [ ] New Feature
- [x] Bug Fix
- [ ] Performance Improvement
- [ ] Build/Testing/CI/CD
- [ ] Documentation
- [ ] Not for changelog (changelog entry is not required)

## Documentation
<!-- At least one of next options must be included. -->

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
