### PR TITLE
feat(tianmu):sql_mode set MANDATORY_TIANMU do not work (#1131)

### DIFF
--- a/mysql-test/suite/tianmu/r/issue1131.result
+++ b/mysql-test/suite/tianmu/r/issue1131.result
@@ -1,0 +1,160 @@
+use test;
+drop table IF EXISTS tmp_table;
+# 
+# sql_mode='STRICT_TRANS_TABLES,NO_AUTO_CREATE_USER,NO_ENGINE_SUBSTITUTION'
+# 
+set sql_mode='STRICT_TRANS_TABLES,NO_AUTO_CREATE_USER,NO_ENGINE_SUBSTITUTION';
+create table t_issue1131(c1 int,c2 varchar(255))engine=innodb;
+show create table t_issue1131;
+Table	Create Table
+t_issue1131	CREATE TABLE `t_issue1131` (
+  `c1` int(11) DEFAULT NULL,
+  `c2` varchar(255) DEFAULT NULL
+) ENGINE=InnoDB DEFAULT CHARSET=latin1
+show variables like 'sql_mode';
+Variable_name	Value
+sql_mode	STRICT_TRANS_TABLES,NO_AUTO_CREATE_USER,NO_ENGINE_SUBSTITUTION
+show variables like '%_engine';
+Variable_name	Value
+default_storage_engine	TIANMU
+default_tmp_storage_engine	InnoDB
+internal_tmp_disk_storage_engine	InnoDB
+alter table t_issue1131 add c3 int;
+show create table t_issue1131;
+Table	Create Table
+t_issue1131	CREATE TABLE `t_issue1131` (
+  `c1` int(11) DEFAULT NULL,
+  `c2` varchar(255) DEFAULT NULL,
+  `c3` int(11) DEFAULT NULL
+) ENGINE=InnoDB DEFAULT CHARSET=latin1
+drop table t_issue1131;
+CREATE TEMPORARY TABLE tmp_table (
+name VARCHAR(10) NOT NULL,
+value INTEGER NOT NULL
+)engine=innodb;
+show create table tmp_table;
+Table	Create Table
+tmp_table	CREATE TEMPORARY TABLE `tmp_table` (
+  `name` varchar(10) NOT NULL,
+  `value` int(11) NOT NULL
+) ENGINE=InnoDB DEFAULT CHARSET=latin1
+drop table tmp_table;
+# 
+# sql_mode='MANDATORY_TIANMU'
+# 
+set sql_mode='STRICT_TRANS_TABLES,NO_AUTO_CREATE_USER,NO_ENGINE_SUBSTITUTION,MANDATORY_TIANMU';
+create table t_issue1131(c1 int,c2 varchar(255))engine=innodb;
+show create table t_issue1131;
+Table	Create Table
+t_issue1131	CREATE TABLE `t_issue1131` (
+  `c1` int(11) DEFAULT NULL,
+  `c2` varchar(255) DEFAULT NULL
+) ENGINE=TIANMU DEFAULT CHARSET=latin1
+show variables like 'sql_mode';
+Variable_name	Value
+sql_mode	STRICT_TRANS_TABLES,NO_AUTO_CREATE_USER,NO_ENGINE_SUBSTITUTION,MANDATORY_TIANMU
+show variables like '%_engine';
+Variable_name	Value
+default_storage_engine	TIANMU
+default_tmp_storage_engine	InnoDB
+internal_tmp_disk_storage_engine	InnoDB
+alter table t_issue1131 add c3 int;
+show create table t_issue1131;
+Table	Create Table
+t_issue1131	CREATE TABLE `t_issue1131` (
+  `c1` int(11) DEFAULT NULL,
+  `c2` varchar(255) DEFAULT NULL,
+  `c3` int(11) DEFAULT NULL
+) ENGINE=TIANMU DEFAULT CHARSET=latin1
+drop table t_issue1131;
+CREATE TEMPORARY TABLE tmp_table (
+name VARCHAR(10) NOT NULL,
+value INTEGER NOT NULL
+)engine=innodb;
+show create table tmp_table;
+Table	Create Table
+tmp_table	CREATE TEMPORARY TABLE `tmp_table` (
+  `name` varchar(10) NOT NULL,
+  `value` int(11) NOT NULL
+) ENGINE=InnoDB DEFAULT CHARSET=latin1
+drop table tmp_table;
+# 
+# sql_mode='MANDATORY_TIANMU'
+# set default_storage_engine=innodb;
+set sql_mode='STRICT_TRANS_TABLES,NO_AUTO_CREATE_USER,NO_ENGINE_SUBSTITUTION,MANDATORY_TIANMU';
+set default_storage_engine=innodb;
+create table t_issue1131(c1 int,c2 varchar(255));
+show create table t_issue1131;
+Table	Create Table
+t_issue1131	CREATE TABLE `t_issue1131` (
+  `c1` int(11) DEFAULT NULL,
+  `c2` varchar(255) DEFAULT NULL
+) ENGINE=TIANMU DEFAULT CHARSET=latin1
+show variables like 'sql_mode';
+Variable_name	Value
+sql_mode	STRICT_TRANS_TABLES,NO_AUTO_CREATE_USER,NO_ENGINE_SUBSTITUTION,MANDATORY_TIANMU
+show variables like '%_engine';
+Variable_name	Value
+default_storage_engine	InnoDB
+default_tmp_storage_engine	InnoDB
+internal_tmp_disk_storage_engine	InnoDB
+alter table t_issue1131 add c3 int;
+show create table t_issue1131;
+Table	Create Table
+t_issue1131	CREATE TABLE `t_issue1131` (
+  `c1` int(11) DEFAULT NULL,
+  `c2` varchar(255) DEFAULT NULL,
+  `c3` int(11) DEFAULT NULL
+) ENGINE=TIANMU DEFAULT CHARSET=latin1
+drop table t_issue1131;
+CREATE TEMPORARY TABLE tmp_table (
+name VARCHAR(10) NOT NULL,
+value INTEGER NOT NULL
+);
+show create table tmp_table;
+Table	Create Table
+tmp_table	CREATE TEMPORARY TABLE `tmp_table` (
+  `name` varchar(10) NOT NULL,
+  `value` int(11) NOT NULL
+) ENGINE=InnoDB DEFAULT CHARSET=latin1
+drop table tmp_table;
+# 
+# sql_mode='STRICT_TRANS_TABLES,NO_AUTO_CREATE_USER,NO_ENGINE_SUBSTITUTION'
+# 
+[on slave]
+set sql_mode='STRICT_TRANS_TABLES,NO_AUTO_CREATE_USER,NO_ENGINE_SUBSTITUTION';
+create table t_issue1131(c1 int,c2 varchar(255));
+show create table t_issue1131;
+Table	Create Table
+t_issue1131	CREATE TABLE `t_issue1131` (
+  `c1` int(11) DEFAULT NULL,
+  `c2` varchar(255) DEFAULT NULL
+) ENGINE=InnoDB DEFAULT CHARSET=latin1
+show variables like 'sql_mode';
+Variable_name	Value
+sql_mode	STRICT_TRANS_TABLES,NO_AUTO_CREATE_USER,NO_ENGINE_SUBSTITUTION
+show variables like '%_engine';
+Variable_name	Value
+default_storage_engine	InnoDB
+default_tmp_storage_engine	InnoDB
+internal_tmp_disk_storage_engine	InnoDB
+alter table t_issue1131 add c3 int;
+show create table t_issue1131;
+Table	Create Table
+t_issue1131	CREATE TABLE `t_issue1131` (
+  `c1` int(11) DEFAULT NULL,
+  `c2` varchar(255) DEFAULT NULL,
+  `c3` int(11) DEFAULT NULL
+) ENGINE=InnoDB DEFAULT CHARSET=latin1
+drop table t_issue1131;
+CREATE TEMPORARY TABLE tmp_table (
+name VARCHAR(10) NOT NULL,
+value INTEGER NOT NULL
+);
+show create table tmp_table;
+Table	Create Table
+tmp_table	CREATE TEMPORARY TABLE `tmp_table` (
+  `name` varchar(10) NOT NULL,
+  `value` int(11) NOT NULL
+) ENGINE=InnoDB DEFAULT CHARSET=latin1
+drop table tmp_table;

--- a/mysql-test/suite/tianmu/r/issue956.result
+++ b/mysql-test/suite/tianmu/r/issue956.result
@@ -145,7 +145,7 @@ Table	Create Table
 t_issue956_3	CREATE TABLE `t_issue956_3` (
   `c1` int(11) DEFAULT NULL,
   `c2` varchar(255) DEFAULT NULL
-) ENGINE=TIANMU DEFAULT CHARSET=latin1
+) ENGINE=InnoDB DEFAULT CHARSET=latin1
 [on master]
 alter table t_issue956_3 engine=MyISAM;
 show create table t_issue956_3;
@@ -168,7 +168,7 @@ Table	Create Table
 t_issue956_3	CREATE TABLE `t_issue956_3` (
   `c1` int(11) DEFAULT NULL,
   `c2` varchar(255) DEFAULT NULL
-) ENGINE=TIANMU DEFAULT CHARSET=latin1
+) ENGINE=MyISAM DEFAULT CHARSET=latin1
 [on master]
 drop table t_issue956_3;
 include/sync_slave_sql_with_master.inc

--- a/mysql-test/suite/tianmu/t/issue1131.test
+++ b/mysql-test/suite/tianmu/t/issue1131.test
@@ -1,0 +1,100 @@
+-- source include/have_tianmu.inc
+
+use test;
+--disable_warnings
+drop table IF EXISTS tmp_table;
+--enable_warnings
+--echo # 
+--echo # sql_mode='STRICT_TRANS_TABLES,NO_AUTO_CREATE_USER,NO_ENGINE_SUBSTITUTION'
+--echo # 
+--disable_warnings
+set sql_mode='STRICT_TRANS_TABLES,NO_AUTO_CREATE_USER,NO_ENGINE_SUBSTITUTION';
+--enable_warnings
+
+create table t_issue1131(c1 int,c2 varchar(255))engine=innodb;
+show create table t_issue1131;
+show variables like 'sql_mode';
+show variables like '%_engine';
+alter table t_issue1131 add c3 int;
+show create table t_issue1131;
+drop table t_issue1131;
+
+CREATE TEMPORARY TABLE tmp_table (
+ name VARCHAR(10) NOT NULL,
+ value INTEGER NOT NULL
+)engine=innodb;
+
+show create table tmp_table;
+drop table tmp_table;
+
+
+--echo # 
+--echo # sql_mode='MANDATORY_TIANMU'
+--echo # 
+--disable_warnings
+set sql_mode='STRICT_TRANS_TABLES,NO_AUTO_CREATE_USER,NO_ENGINE_SUBSTITUTION,MANDATORY_TIANMU';
+--enable_warnings
+
+create table t_issue1131(c1 int,c2 varchar(255))engine=innodb;
+show create table t_issue1131;
+show variables like 'sql_mode';
+show variables like '%_engine';
+alter table t_issue1131 add c3 int;
+show create table t_issue1131;
+drop table t_issue1131;
+
+CREATE TEMPORARY TABLE tmp_table (
+ name VARCHAR(10) NOT NULL,
+ value INTEGER NOT NULL
+)engine=innodb;
+
+show create table tmp_table;
+drop table tmp_table;
+
+--echo # 
+--echo # sql_mode='MANDATORY_TIANMU'
+--echo # set default_storage_engine=innodb;
+--disable_warnings
+set sql_mode='STRICT_TRANS_TABLES,NO_AUTO_CREATE_USER,NO_ENGINE_SUBSTITUTION,MANDATORY_TIANMU';
+--enable_warnings
+set default_storage_engine=innodb;
+
+create table t_issue1131(c1 int,c2 varchar(255));
+show create table t_issue1131;
+show variables like 'sql_mode';
+show variables like '%_engine';
+alter table t_issue1131 add c3 int;
+show create table t_issue1131;
+drop table t_issue1131;
+
+CREATE TEMPORARY TABLE tmp_table (
+ name VARCHAR(10) NOT NULL,
+ value INTEGER NOT NULL
+);
+
+show create table tmp_table;
+drop table tmp_table;
+
+--echo # 
+--echo # sql_mode='STRICT_TRANS_TABLES,NO_AUTO_CREATE_USER,NO_ENGINE_SUBSTITUTION'
+--echo # 
+--echo [on slave]
+--disable_warnings
+set sql_mode='STRICT_TRANS_TABLES,NO_AUTO_CREATE_USER,NO_ENGINE_SUBSTITUTION';
+--enable_warnings
+
+create table t_issue1131(c1 int,c2 varchar(255));
+show create table t_issue1131;
+show variables like 'sql_mode';
+show variables like '%_engine';
+alter table t_issue1131 add c3 int;
+show create table t_issue1131;
+drop table t_issue1131;
+
+CREATE TEMPORARY TABLE tmp_table (
+ name VARCHAR(10) NOT NULL,
+ value INTEGER NOT NULL
+);
+
+show create table tmp_table;
+drop table tmp_table;

--- a/sql/sql_parse.cc
+++ b/sql/sql_parse.cc
@@ -2774,21 +2774,17 @@ mysql_execute_command(THD *thd, bool first_level)
   if (!thd->in_sub_stmt)
     thd->query_plan.set_query_plan(lex->sql_command, lex,
                                    !thd->stmt_arena->is_conventional());
-  /*
-    When stonedb is used as a slave library, 
-    the default engine is tianmu, or the (sql_mode) of (MANDATORY_TIANMU) is set,
+  /* 
+    the (sql_mode) of (MANDATORY_TIANMU) is set,
     the engine will be forcibly converted to the tianmu engine.
-    Priority:
-    sql_mode ='MANDATORY_TIANMU' > default_storage_engine
   */
-  if(thd->slave_thread && 
-    ((lex->sql_command == SQLCOM_CREATE_TABLE) || 
-    (lex->sql_command == SQLCOM_ALTER_TABLE)) &&
+  if(lex && ((lex->sql_command == SQLCOM_CREATE_TABLE) || 
+    (lex->sql_command == SQLCOM_ALTER_TABLE)) && 
     !(lex->create_info.options & HA_LEX_CREATE_TMP_TABLE)){
 
-    legacy_db_type default_db_type = plugin_data<handlerton*>(global_system_variables.table_plugin)->db_type;
-    if((global_system_variables.sql_mode & MODE_MANDATORY_TIANMU) || 
-        (default_db_type == DB_TYPE_TIANMU)){
+    sql_mode_t sql_mode = thd->variables.sql_mode;
+    if(thd->slave_thread) sql_mode = global_system_variables.sql_mode;
+    if(sql_mode & MODE_MANDATORY_TIANMU){
 
       lex->create_info.db_type = ha_default_handlerton(thd);
       old_db_type = lex->create_info.db_type->db_type;
@@ -4994,11 +4990,7 @@ error:
   res= TRUE;
 
 finish:
-  if(thd->slave_thread && 
-    ((lex->sql_command == SQLCOM_CREATE_TABLE) || 
-    (lex->sql_command == SQLCOM_ALTER_TABLE)) &&
-    !(lex->create_info.options & HA_LEX_CREATE_TMP_TABLE) &&
-    (old_db_type != DB_TYPE_DEFAULT)){
+  if(old_db_type != DB_TYPE_DEFAULT){
       //If the engine is replaced, restore it at the end
       lex->create_info.db_type->db_type = old_db_type;
     }


### PR DESCRIPTION
Force the engine to be converted to tianmu in any scenario as long as this parameter is set.
Do not include temporary tables.

<!--

Thank you for contributing to StoneDB!

PR Title Format: <type>(<scope>): description to this pr (#issue_id)
e.g.
fix(util): fix sth..... (#1)

-->

## Summary about this PR
<!--

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".
e.g.:
Issue: close #1

-->

Issue Number: close #issue_number_you_created


## Tests Check List
<!-- At least one of next options must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

## Changelog
<!-- At least one of next options must be included. -->

- [ ] New Feature
- [ ] Bug Fix
- [ ] Performance Improvement
- [ ] Build/Testing/CI/CD
- [ ] Documentation
- [ ] Not for changelog (changelog entry is not required)

## Documentation
<!-- At least one of next options must be included. -->

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
