### PR TITLE
fix(tianmu): the sock file directory of ./reinstall.sh is inconsistent with the directory in my.cnf(#1075)

### DIFF
--- a/scripts/my.cnf.sample
+++ b/scripts/my.cnf.sample
@@ -1,6 +1,6 @@
 [client]
 port = 3306
-socket          = /tmp/mysql.sock
+socket          = YOUR_ABS_PATH/tmp/mysql.sock
 
 [mysqld]
 port                            = 3306
@@ -8,7 +8,7 @@ basedir                         = YOUR_ABS_PATH/
 character-sets-dir              = YOUR_ABS_PATH/share/charsets/
 plugin_dir                      = YOUR_ABS_PATH/lib/plugin/
 tmpdir                          = YOUR_ABS_PATH/tmp/
-socket                          = /tmp/mysql.sock
+socket                          = YOUR_ABS_PATH/tmp/mysql.sock
 datadir                         = YOUR_ABS_PATH/data/
 pid-file                        = YOUR_ABS_PATH/data/mysqld.pid
 log-error                       = YOUR_ABS_PATH/data/mysqld.log

--- a/scripts/reinstall.sh
+++ b/scripts/reinstall.sh
@@ -1,10 +1,10 @@
+#!/bin/bash
 mysql_server_script=mysql_server
 mysql_install_db_script=mysqld
 
 # uninstall
 ./${mysql_server_script} stop
 echo "clean the directories..."
-#sleep 3
 rm -fr data
 rm -fr binlog 
 rm -fr log 


### PR DESCRIPTION
<!--

Thank you for contributing to StoneDB!

PR Title Format: <type>(<scope>): description to this pr (#issue_id)
e.g.
fix(util): fix sth..... (#1)

-->

## Summary about this PR
<!--

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".
e.g.:
Issue: close #1

-->

Issue Number: close #1075 
**anlysis：** `mysql.sock` generated in the installation directory can resolve the inconsistency and avoid conflict with the mysql server in the environment.
**main fix:** `socket          = /tmp/mysql.sock` -> `socket          = YOUR_ABS_PATH/tmp/mysql.sock`

## Tests Check List
<!-- At least one of next options must be included. -->

- [x] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

## Changelog
<!-- At least one of next options must be included. -->

- [ ] New Feature
- [x] Bug Fix
- [ ] Performance Improvement
- [ ] Build/Testing/CI/CD
- [ ] Documentation
- [ ] Not for changelog (changelog entry is not required)

## Documentation
<!-- At least one of next options must be included. -->

- [x] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
