### PR TITLE
fix(tianmu): ALTER TABLE prompt information is incorrect.(#1142)

### DIFF
--- a/mysql-test/suite/tianmu/r/alter_column.result
+++ b/mysql-test/suite/tianmu/r/alter_column.result
@@ -48,7 +48,7 @@ description VARCHAR(200) NULL,
 PRIMARY KEY (task_id)
 );
 ALTER TABLE st1 ADD COLUMN test numeric(20,10);
-ERROR HY000: Unable to inplace alter table
+ERROR HY000: Precision must be less than or equal to 18.
 ALTER TABLE st1 ADD COLUMN test1 numeric(8,2);
 SHOW CREATE TABLE st1;
 Table	Create Table
@@ -59,6 +59,26 @@ st1	CREATE TABLE `st1` (
   `end_date` date DEFAULT NULL,
   `description` varchar(200) DEFAULT NULL,
   `test1` decimal(8,2) DEFAULT NULL,
+  PRIMARY KEY (`task_id`)
+) ENGINE=TIANMU DEFAULT CHARSET=latin1
+CREATE TABLE st2 (
+task_id INT NOT NULL,
+subject VARCHAR(45) NULL,
+start_date DATE NULL,
+end_date DATE NULL,
+description VARCHAR(200) NULL,
+PRIMARY KEY (task_id)
+);
+ALTER TABLE st2 ADD COLUMN col_name3 int auto_increment;
+ERROR HY000: AUTO_INCREMENT can be only declared on primary key column!
+SHOW CREATE TABLE st2;
+Table	Create Table
+st2	CREATE TABLE `st2` (
+  `task_id` int(11) NOT NULL,
+  `subject` varchar(45) DEFAULT NULL,
+  `start_date` date DEFAULT NULL,
+  `end_date` date DEFAULT NULL,
+  `description` varchar(200) DEFAULT NULL,
   PRIMARY KEY (`task_id`)
 ) ENGINE=TIANMU DEFAULT CHARSET=latin1
 DROP DATABASE alter_colunm;

--- a/mysql-test/suite/tianmu/t/alter_column.test
+++ b/mysql-test/suite/tianmu/t/alter_column.test
@@ -76,5 +76,25 @@ ALTER TABLE st1 ADD COLUMN test1 numeric(8,2);
 
 SHOW CREATE TABLE st1;
 
-# Clean UP
+#################
+# ADD  COLUMEN  WARNING INFO
+#################
+
+CREATE TABLE st2 (
+    task_id INT NOT NULL,
+    subject VARCHAR(45) NULL,
+    start_date DATE NULL,
+    end_date DATE NULL,
+    description VARCHAR(200) NULL,
+    PRIMARY KEY (task_id)
+); 
+
+--error 6
+ALTER TABLE st2 ADD COLUMN col_name3 int auto_increment;
+
+SHOW CREATE TABLE st2;
+
+#################
+# CLEAR UP
+#################
 DROP DATABASE alter_colunm;

--- a/storage/tianmu/core/tianmu_table.cpp
+++ b/storage/tianmu/core/tianmu_table.cpp
@@ -107,15 +107,19 @@ void TianmuTable::Alter(const std::string &table_path, std::vector<Field *> &new
   for (auto &p : fs::directory_iterator(tmp_dir / common::COLUMN_DIR)) fs::remove(p);
 
   TABLE_META meta;
-  system::TianmuFile f;
-  f.OpenReadOnly(tab_dir / common::TABLE_DESC_FILE);
-  f.ReadExact(&meta, sizeof(meta));
+  {
+    system::TianmuFile f;
+    f.OpenReadOnly(tab_dir / common::TABLE_DESC_FILE);
+    f.ReadExact(&meta, sizeof(meta));
+  }
   meta.id = ha_tianmu_engine_->GetNextTableId();  // only table id is updated
 
-  system::TianmuFile tempf;
-  tempf.OpenReadWrite(tmp_dir / common::TABLE_DESC_FILE);
-  tempf.WriteExact(&meta, sizeof(meta));
-  tempf.Flush();
+  {
+    system::TianmuFile tempf;
+    tempf.OpenReadWrite(tmp_dir / common::TABLE_DESC_FILE);
+    tempf.WriteExact(&meta, sizeof(meta));
+    tempf.Flush();
+  }
 
   std::vector<common::TX_ID> old_versions(old_cols.size());
   {

--- a/storage/tianmu/handler/ha_tianmu.cpp
+++ b/storage/tianmu/handler/ha_tianmu.cpp
@@ -1642,15 +1642,16 @@ bool ha_tianmu::inplace_alter_table(TABLE *altered_table, Alter_inplace_info *ha
     }
   } catch (std::exception &e) {
     TIANMU_LOG(LogCtl_Level::ERROR, "An exception is caught: %s", e.what());
+    my_message(static_cast<int>(common::ErrorCode::UNKNOWN_ERROR), e.what(), MYF(0));
   } catch (...) {
     TIANMU_LOG(LogCtl_Level::ERROR, "An unknown system exception error caught.");
+    my_message(static_cast<int>(common::ErrorCode::UNKNOWN_ERROR), "Unable to inplace alter table", MYF(0));
   }
 
+  // if catch exception, remove tmp dir
   fs::path tmp_dir = table_name_ + ".tmp";
   if (fs::exists(tmp_dir))
     fs::remove_all(tmp_dir);
-
-  my_message(static_cast<int>(common::ErrorCode::UNKNOWN_ERROR), "Unable to inplace alter table", MYF(0));
 
   DBUG_RETURN(true);
 }


### PR DESCRIPTION
<!--

Thank you for contributing to StoneDB!

PR Title Format: <type>(<scope>): description to this pr (#issue_id)
e.g.
fix(util): fix sth..... (#1)

-->

## Summary about this PR
<!--

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".
e.g.:
Issue: close #1

-->

Issue Number: close #1142 

[summary]
1.Add test cases for ALTER TABLE when exception occurs by inplace algorithm
2.Print the specific information of known exceptions to better understand the cause of the problem

## Tests Check List
<!-- At least one of next options must be included. -->

- [ ] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

## Changelog
<!-- At least one of next options must be included. -->

- [ ] New Feature
- [x] Bug Fix
- [ ] Performance Improvement
- [ ] Build/Testing/CI/CD
- [ ] Documentation
- [ ] Not for changelog (changelog entry is not required)

## Documentation
<!-- At least one of next options must be included. -->

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
