### PR TITLE
fix: fix incorrect result when executed insert into t select with ... #1182

### DIFF
--- a/mysql-test/suite/tianmu/r/bit_type.result
+++ b/mysql-test/suite/tianmu/r/bit_type.result
@@ -204,4 +204,79 @@ select hex(a) from bittest where a=57;
 hex(a)
 39
 drop table bittest;
+CREATE TABLE `bit_test` (
+`bit1` bit(1) DEFAULT NULL,
+`bit2` bit(2) DEFAULT NULL,
+`bit8` bit(8) DEFAULT NULL,
+`bit16` bit(16) DEFAULT NULL,
+`bit32` bit(32) DEFAULT NULL,
+`bit63` bit(63) DEFAULT NULL
+) ENGINE=TIANMU DEFAULT CHARSET=utf8mb4;
+insert into bit_test values(b'1', b'11',b'111',b'1111',b'11',b'111');
+insert into bit_test values(null, b'11',b'111000',b'1111',b'11',null);
+insert into bit_test values(b'0', b'10',b'111',b'1111',b'11',b'0');
+insert into bit_test values(b'1', b'1',b'11111111',b'1111',b'11',b'111');
+insert into bit_test values(b'1', b'1',b'1',b'1111111111111111',b'11',b'111');
+insert into bit_test values(b'1', b'1',b'1',b'1', b'11111111111111111111111111111111',b'111');
+insert into bit_test values(b'1', b'1',b'1', b'1', b'1', b'11111111111111111111111111111111111111111111111111111111111111');
+insert into bit_test values(null, null, null, null, null, null);
+select count(*) from  bit_test;
+count(*)
+8
+select bit1+0, bit2+0, bit8+0, bit16+0, bit32+0, bit63+0 from bit_test;
+bit1+0	bit2+0	bit8+0	bit16+0	bit32+0	bit63+0
+1	3	7	15	3	7
+NULL	3	56	15	3	NULL
+0	2	7	15	3	0
+1	1	255	15	3	7
+1	1	1	65535	3	7
+1	1	1	1	4294967295	7
+1	1	1	1	1	4611686018427387903
+NULL	NULL	NULL	NULL	NULL	NULL
+insert into bit_test select * from bit_test;
+select count(*) from  bit_test;
+count(*)
+16
+select bit1+0, bit2+0, bit8+0, bit16+0, bit32+0, bit63+0 from bit_test;
+bit1+0	bit2+0	bit8+0	bit16+0	bit32+0	bit63+0
+1	3	7	15	3	7
+NULL	3	56	15	3	NULL
+0	2	7	15	3	0
+1	1	255	15	3	7
+1	1	1	65535	3	7
+1	1	1	1	4294967295	7
+1	1	1	1	1	4611686018427387903
+NULL	NULL	NULL	NULL	NULL	NULL
+1	3	7	15	3	7
+NULL	3	56	15	3	NULL
+0	2	7	15	3	0
+1	1	255	15	3	7
+1	1	1	65535	3	7
+1	1	1	1	4294967295	7
+1	1	1	1	1	4611686018427387903
+NULL	NULL	NULL	NULL	NULL	NULL
+create table fork_bit select * from bit_test;
+select count(*) from  fork_bit;
+count(*)
+16
+select bit1+0, bit2+0, bit8+0, bit16+0, bit32+0, bit63+0 from fork_bit;
+bit1+0	bit2+0	bit8+0	bit16+0	bit32+0	bit63+0
+1	3	7	15	3	7
+NULL	3	56	15	3	NULL
+0	2	7	15	3	0
+1	1	255	15	3	7
+1	1	1	65535	3	7
+1	1	1	1	4294967295	7
+1	1	1	1	1	4611686018427387903
+NULL	NULL	NULL	NULL	NULL	NULL
+1	3	7	15	3	7
+NULL	3	56	15	3	NULL
+0	2	7	15	3	0
+1	1	255	15	3	7
+1	1	1	65535	3	7
+1	1	1	1	4294967295	7
+1	1	1	1	1	4611686018427387903
+NULL	NULL	NULL	NULL	NULL	NULL
+drop table bit_test;
+drop table fork_bit;
 drop database test_bit;

--- a/mysql-test/suite/tianmu/r/primary_secondary_bit.result
+++ b/mysql-test/suite/tianmu/r/primary_secondary_bit.result
@@ -1,0 +1,71 @@
+include/master-slave.inc
+[connection master]
+#
+# Multiple types
+# 
+# connection master
+CREATE TABLE `bit_test` (
+`bit1` bit(1) DEFAULT NULL,
+`bit2` bit(2) DEFAULT NULL,
+`bit8` bit(8) DEFAULT NULL,
+`bit16` bit(16) DEFAULT NULL,
+`bit32` bit(32) DEFAULT NULL,
+`bit63` bit(63) DEFAULT NULL
+) ENGINE=TIANMU DEFAULT CHARSET=utf8mb4;
+insert into bit_test values(b'1', b'11',b'111',b'1111',b'11',b'111');
+insert into bit_test values(null, b'11',b'111000',b'1111',b'11',null);
+insert into bit_test values(b'0', b'10',b'111',b'1111',b'11',b'0');
+insert into bit_test values(b'1', b'1',b'11111111',b'1111',b'11',b'111');
+insert into bit_test values(b'1', b'1',b'1',b'1111111111111111',b'11',b'111');
+insert into bit_test values(b'1', b'1',b'1',b'1', b'11111111111111111111111111111111',b'111');
+insert into bit_test values(b'1', b'1',b'1', b'1', b'1', b'11111111111111111111111111111111111111111111111111111111111111');
+insert into bit_test values(null, null, null, null, null, null);
+update bit_test set bit8=0x44  where bit8=0x38;
+select bit1+0, bit2+0, bit8+0, bit16+0, bit32+0, bit63+0 from bit_test;
+bit1+0	bit2+0	bit8+0	bit16+0	bit32+0	bit63+0
+1	3	7	15	3	7
+NULL	3	68	15	3	NULL
+0	2	7	15	3	0
+1	1	255	15	3	7
+1	1	1	65535	3	7
+1	1	1	1	4294967295	7
+1	1	1	1	1	4611686018427387903
+NULL	NULL	NULL	NULL	NULL	NULL
+# connection slave
+include/sync_slave_sql_with_master.inc
+select bit1+0, bit2+0, bit8+0, bit16+0, bit32+0, bit63+0 from bit_test;
+bit1+0	bit2+0	bit8+0	bit16+0	bit32+0	bit63+0
+1	3	7	15	3	7
+NULL	3	68	15	3	NULL
+0	2	7	15	3	0
+1	1	255	15	3	7
+1	1	1	65535	3	7
+1	1	1	1	4294967295	7
+1	1	1	1	1	4611686018427387903
+NULL	NULL	NULL	NULL	NULL	NULL
+# connection master
+delete from bit_test where bit8=0x44;
+select bit1+0, bit2+0, bit8+0, bit16+0, bit32+0, bit63+0 from bit_test;
+bit1+0	bit2+0	bit8+0	bit16+0	bit32+0	bit63+0
+1	3	7	15	3	7
+0	2	7	15	3	0
+1	1	255	15	3	7
+1	1	1	65535	3	7
+1	1	1	1	4294967295	7
+1	1	1	1	1	4611686018427387903
+NULL	NULL	NULL	NULL	NULL	NULL
+# connection slave
+include/sync_slave_sql_with_master.inc
+select bit1+0, bit2+0, bit8+0, bit16+0, bit32+0, bit63+0 from bit_test;
+bit1+0	bit2+0	bit8+0	bit16+0	bit32+0	bit63+0
+1	3	7	15	3	7
+0	2	7	15	3	0
+1	1	255	15	3	7
+1	1	1	65535	3	7
+1	1	1	1	4294967295	7
+1	1	1	1	1	4611686018427387903
+NULL	NULL	NULL	NULL	NULL	NULL
+# connection master
+drop table bit_test;
+include/sync_slave_sql_with_master.inc
+stop slave;

--- a/mysql-test/suite/tianmu/t/bit_type.test
+++ b/mysql-test/suite/tianmu/t/bit_type.test
@@ -169,4 +169,37 @@ select hex(a) from bittest where a=48;
 select hex(a) from bittest where a=57;
 drop table bittest;
 
+# test "insert into bit_test select * from bit_test"
+CREATE TABLE `bit_test` (
+  `bit1` bit(1) DEFAULT NULL,
+  `bit2` bit(2) DEFAULT NULL,
+  `bit8` bit(8) DEFAULT NULL,
+  `bit16` bit(16) DEFAULT NULL,
+  `bit32` bit(32) DEFAULT NULL,
+  `bit63` bit(63) DEFAULT NULL
+) ENGINE=TIANMU DEFAULT CHARSET=utf8mb4;
+insert into bit_test values(b'1', b'11',b'111',b'1111',b'11',b'111');
+insert into bit_test values(null, b'11',b'111000',b'1111',b'11',null);
+insert into bit_test values(b'0', b'10',b'111',b'1111',b'11',b'0');
+insert into bit_test values(b'1', b'1',b'11111111',b'1111',b'11',b'111');
+insert into bit_test values(b'1', b'1',b'1',b'1111111111111111',b'11',b'111');
+insert into bit_test values(b'1', b'1',b'1',b'1', b'11111111111111111111111111111111',b'111');
+insert into bit_test values(b'1', b'1',b'1', b'1', b'1', b'11111111111111111111111111111111111111111111111111111111111111');
+insert into bit_test values(null, null, null, null, null, null);
+
+select count(*) from  bit_test;
+select bit1+0, bit2+0, bit8+0, bit16+0, bit32+0, bit63+0 from bit_test;
+
+insert into bit_test select * from bit_test;
+select count(*) from  bit_test;
+select bit1+0, bit2+0, bit8+0, bit16+0, bit32+0, bit63+0 from bit_test;
+
+# test "create table t select * from bit_test"
+create table fork_bit select * from bit_test;
+select count(*) from  fork_bit;
+select bit1+0, bit2+0, bit8+0, bit16+0, bit32+0, bit63+0 from fork_bit;
+
+drop table bit_test;
+drop table fork_bit;
+
 drop database test_bit;

--- a/mysql-test/suite/tianmu/t/primary_secondary_bit.test
+++ b/mysql-test/suite/tianmu/t/primary_secondary_bit.test
@@ -1,0 +1,47 @@
+-- source include/have_tianmu.inc
+--disable_warnings
+-- source include/master-slave.inc
+--enable_warnings
+--echo #
+--echo # Multiple types
+--echo # 
+
+--echo # connection master
+connection master;
+
+# test "update/delete from master"
+CREATE TABLE `bit_test` (
+  `bit1` bit(1) DEFAULT NULL,
+  `bit2` bit(2) DEFAULT NULL,
+  `bit8` bit(8) DEFAULT NULL,
+  `bit16` bit(16) DEFAULT NULL,
+  `bit32` bit(32) DEFAULT NULL,
+  `bit63` bit(63) DEFAULT NULL
+) ENGINE=TIANMU DEFAULT CHARSET=utf8mb4;
+insert into bit_test values(b'1', b'11',b'111',b'1111',b'11',b'111');
+insert into bit_test values(null, b'11',b'111000',b'1111',b'11',null);
+insert into bit_test values(b'0', b'10',b'111',b'1111',b'11',b'0');
+insert into bit_test values(b'1', b'1',b'11111111',b'1111',b'11',b'111');
+insert into bit_test values(b'1', b'1',b'1',b'1111111111111111',b'11',b'111');
+insert into bit_test values(b'1', b'1',b'1',b'1', b'11111111111111111111111111111111',b'111');
+insert into bit_test values(b'1', b'1',b'1', b'1', b'1', b'11111111111111111111111111111111111111111111111111111111111111');
+insert into bit_test values(null, null, null, null, null, null);
+
+update bit_test set bit8=0x44  where bit8=0x38;
+select bit1+0, bit2+0, bit8+0, bit16+0, bit32+0, bit63+0 from bit_test;
+--echo # connection slave
+--source include/sync_slave_sql_with_master.inc
+select bit1+0, bit2+0, bit8+0, bit16+0, bit32+0, bit63+0 from bit_test;
+--echo # connection master
+connection master;
+delete from bit_test where bit8=0x44;
+select bit1+0, bit2+0, bit8+0, bit16+0, bit32+0, bit63+0 from bit_test;
+--echo # connection slave
+--source include/sync_slave_sql_with_master.inc
+select bit1+0, bit2+0, bit8+0, bit16+0, bit32+0, bit63+0 from bit_test;
+
+--echo # connection master
+connection master;
+drop table bit_test;
+--source include/sync_slave_sql_with_master.inc
+stop slave;


### PR DESCRIPTION
<!--

Thank you for contributing to StoneDB!

PR Title Format: <type>(<scope>): description to this pr (#issue_id)
e.g.
fix(util): fix sth..... (#1)

-->

## Summary about this PR
<!--

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".
e.g.:
Issue: close #1

-->

The root cause:
before: we used "*reinterpret_cast<int64_t *>(field->ptr)" to store value from longlong, it will make "ptr" little-endian bytes order and will get wrong value when used Field_bit::val_int() to get bit value back. "val_int()" parse data according big-endian bytes order.

after fix: we use "type_conversion_status Field_bit::store(longlong nr, bool unsigned_val)" to store longlong val. Stored in big-endian bytes order.

When do insert ... select .../create ... select/update or delete in primary-secondary synchronization, the function next will be called:
```
 static void do_field_int(Copy_field *copy)
 {
   longlong value= copy->from_field()->val_int();---->here that make the data uncorrect when parsing data stored in little-endian in field->ptr
   copy->to_field()->store(value,
                           MY_TEST(copy->from_field()->flags & UNSIGNED_FLAG));
 }
```


Issue Number: close #1182


## Tests Check List
<!-- At least one of next options must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

## Changelog
<!-- At least one of next options must be included. -->

- [ ] New Feature
- [ ] Bug Fix
- [ ] Performance Improvement
- [ ] Build/Testing/CI/CD
- [ ] Documentation
- [ ] Not for changelog (changelog entry is not required)

## Documentation
<!-- At least one of next options must be included. -->

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
