### PR TITLE
fix: limit unsigned integer range. #1151

### DIFF
--- a/mysql-test/suite/tianmu/r/out_of_range_issue1151.result
+++ b/mysql-test/suite/tianmu/r/out_of_range_issue1151.result
@@ -1,6 +1,8 @@
-drop database if exists test;
-create database test;
-use test;
+drop database if exists out_of_range_issue1151;
+Warnings:
+Note	1008	Can't drop database 'out_of_range_issue1151'; database doesn't exist
+create database out_of_range_issue1151;
+use out_of_range_issue1151;
 create table tiny(a tinyint, b tinyint unsigned) engine = tianmu DEFAULT CHARSET=utf8mb4;
 insert into tiny values(-128, 0);
 insert into tiny values(127, 127);
@@ -187,3 +189,4 @@ ERROR 22003: Out of range value for column 'b' at row 1
 insert into bigint_ values(0, 1844674407370955161566);
 ERROR 22003: Out of range value for column 'b' at row 1
 drop table bigint_;
+drop database if exists out_of_range_issue1151;

--- a/mysql-test/suite/tianmu/r/out_of_range_issue1151.result
+++ b/mysql-test/suite/tianmu/r/out_of_range_issue1151.result
@@ -1,0 +1,189 @@
+drop database if exists test;
+create database test;
+use test;
+create table tiny(a tinyint, b tinyint unsigned) engine = tianmu DEFAULT CHARSET=utf8mb4;
+insert into tiny values(-128, 0);
+insert into tiny values(127, 127);
+insert into tiny values(0, 127);
+insert into tiny values(-0, -0);
+insert into tiny values(+0, +0);
+select * from tiny;
+a	b
+-128	0
+127	127
+0	127
+0	0
+0	0
+insert into tiny values(-129, 0);
+ERROR 22003: Out of range value for column 'a' at row 1
+insert into tiny values(128, 0);
+ERROR 22003: Out of range value for column 'a' at row 1
+insert into tiny values(1234, 0);
+ERROR 22003: Out of range value for column 'a' at row 1
+insert into tiny values(0, 128);
+ERROR 22003: Out of range[0, 127] for column 'b' value: 128
+insert into tiny values(0, 255);
+ERROR 22003: Out of range[0, 127] for column 'b' value: 255
+insert into tiny values(0, -1);
+ERROR 22003: Out of range value for column 'b' at row 1
+insert into tiny values(0, -127);
+ERROR 22003: Out of range value for column 'b' at row 1
+insert into tiny values(0, 256);
+ERROR 22003: Out of range value for column 'b' at row 1
+insert into tiny values(0, 1234567);
+ERROR 22003: Out of range value for column 'b' at row 1
+drop table tiny;
+create table small(a smallint, b smallint unsigned) engine = tianmu DEFAULT CHARSET=utf8mb4;
+insert into small values(-32768, 0);
+insert into small values(0, 0);
+insert into small values(122, 122);
+insert into small values(32767, 32767);
+insert into small values(-0, -0);
+insert into small values(+0, +0);
+select * from small;
+a	b
+-32768	0
+0	0
+122	122
+32767	32767
+0	0
+0	0
+insert into small values(-32769, 0);
+ERROR 22003: Out of range value for column 'a' at row 1
+insert into small values(32768, 0);
+ERROR 22003: Out of range value for column 'a' at row 1
+insert into small values(-3276911, 0);
+ERROR 22003: Out of range value for column 'a' at row 1
+insert into small values(3276811, 0);
+ERROR 22003: Out of range value for column 'a' at row 1
+insert into small values(0, 32768);
+ERROR 22003: Out of range[0, 32767] for column 'b' value: 32768
+insert into small values(0, 41234);
+ERROR 22003: Out of range[0, 32767] for column 'b' value: 41234
+insert into small values(0, 65535);
+ERROR 22003: Out of range[0, 32767] for column 'b' value: 65535
+insert into small values(0, -1);
+ERROR 22003: Out of range value for column 'b' at row 1
+insert into small values(0, -32768);
+ERROR 22003: Out of range value for column 'b' at row 1
+insert into small values(0, 65536);
+ERROR 22003: Out of range value for column 'b' at row 1
+insert into small values(0, 1234567);
+ERROR 22003: Out of range value for column 'b' at row 1
+drop table small;
+create table medium(a mediumint, b mediumint unsigned) engine = tianmu DEFAULT CHARSET=utf8mb4;
+insert into medium values(-8388608, 0);
+insert into medium values(0, 0);
+insert into medium values(122, 122);
+insert into medium values(8388607, 8388607);
+insert into medium values(-0, -0);
+insert into medium values(+0, +0);
+select * from medium;
+a	b
+-8388608	0
+0	0
+122	122
+8388607	8388607
+0	0
+0	0
+insert into medium values(-8388609, 0);
+ERROR 22003: Out of range value for column 'a' at row 1
+insert into medium values(8388608, 0);
+ERROR 22003: Out of range value for column 'a' at row 1
+insert into medium values(-8388608111, 0);
+ERROR 22003: Out of range value for column 'a' at row 1
+insert into medium values(8388608111, 0);
+ERROR 22003: Out of range value for column 'a' at row 1
+insert into medium values(0, 8388608);
+ERROR 22003: Out of range[0, 8388607] for column 'b' value: 8388608
+insert into medium values(0, 8388610);
+ERROR 22003: Out of range[0, 8388607] for column 'b' value: 8388610
+insert into medium values(0, 16777215);
+ERROR 22003: Out of range[0, 8388607] for column 'b' value: 16777215
+insert into medium values(0, -1);
+ERROR 22003: Out of range value for column 'b' at row 1
+insert into medium values(0, -8388608);
+ERROR 22003: Out of range value for column 'b' at row 1
+insert into medium values(0, 16777216);
+ERROR 22003: Out of range value for column 'b' at row 1
+insert into medium values(0, 1677721511);
+ERROR 22003: Out of range value for column 'b' at row 1
+drop table medium;
+create table int_(a int, b int unsigned) engine = tianmu DEFAULT CHARSET=utf8mb4;
+insert into int_ values(-2147483647, 0);
+insert into int_ values(0, 0);
+insert into int_ values(122, 122);
+insert into int_ values(2147483647, 2147483647);
+insert into int_ values(-0, -0);
+insert into int_ values(+0, +0);
+select * from int_;
+a	b
+-2147483647	0
+0	0
+122	122
+2147483647	2147483647
+0	0
+0	0
+insert into int_ values(-2147483649, 0);
+ERROR 22003: Out of range value for column 'a' at row 1
+insert into int_ values(2147483648, 0);
+ERROR 22003: Out of range value for column 'a' at row 1
+insert into int_ values(-214748364811, 0);
+ERROR 22003: Out of range value for column 'a' at row 1
+insert into int_ values(214748364811, 0);
+ERROR 22003: Out of range value for column 'a' at row 1
+insert into int_ values(-2147483648, 0);
+ERROR 22003: Out of range[-2147483647, 2147483647] for column 'a' value: -2147483648
+insert into int_ values(0, 2147483648);
+ERROR 22003: Out of range[0, 2147483647] for column 'b' value: 2147483648
+insert into int_ values(0, 3294967295);
+ERROR 22003: Out of range[0, 2147483647] for column 'b' value: 3294967295
+insert into int_ values(0, 4294967295);
+ERROR 22003: Out of range[0, 2147483647] for column 'b' value: 4294967295
+insert into int_ values(0, -1);
+ERROR 22003: Out of range value for column 'b' at row 1
+insert into int_ values(0, -4294967295);
+ERROR 22003: Out of range value for column 'b' at row 1
+insert into int_ values(0, 4294967296);
+ERROR 22003: Out of range value for column 'b' at row 1
+insert into int_ values(0, 429496729611);
+ERROR 22003: Out of range value for column 'b' at row 1
+drop table int_;
+create table bigint_(a bigint, b bigint unsigned) engine = tianmu DEFAULT CHARSET=utf8mb4;
+insert into bigint_ values(-9223372036854775806, 0);
+insert into bigint_ values(0, 0);
+insert into bigint_ values(122, 122);
+insert into bigint_ values(9223372036854775807, 9223372036854775807);
+insert into bigint_ values(-0, -0);
+insert into bigint_ values(+0, +0);
+select * from bigint_;
+a	b
+-9223372036854775806	0
+0	0
+122	122
+9223372036854775807	9223372036854775807
+0	0
+0	0
+insert into bigint_ values(-9223372036854775808, 0);
+ERROR 22003: Out of range[-9223372036854775807, 9223372036854775807] for column 'a' value: -9223372036854775808
+insert into bigint_ values(9223372036854775808, 0);
+ERROR 22003: Out of range value for column 'a' at row 1
+insert into bigint_ values(-9223372036854775810, 0);
+ERROR 22003: Out of range value for column 'a' at row 1
+insert into bigint_ values(9223372036854775810, 0);
+ERROR 22003: Out of range value for column 'a' at row 1
+insert into bigint_ values(0, 9223372036854775808);
+ERROR 22003: Out of range[0, 9223372036854775807] for column 'b' value: 9223372036854775808
+insert into bigint_ values(0, 10223372036854775808);
+ERROR 22003: Out of range[0, 9223372036854775807] for column 'b' value: 10223372036854775808
+insert into bigint_ values(0, 18446744073709551615);
+ERROR 22003: Out of range[0, 9223372036854775807] for column 'b' value: 18446744073709551615
+insert into bigint_ values(0, -1);
+ERROR 22003: Out of range value for column 'b' at row 1
+insert into bigint_ values(0, -4294967295);
+ERROR 22003: Out of range value for column 'b' at row 1
+insert into bigint_ values(0, 18446744073709551616);
+ERROR 22003: Out of range value for column 'b' at row 1
+insert into bigint_ values(0, 1844674407370955161566);
+ERROR 22003: Out of range value for column 'b' at row 1
+drop table bigint_;

--- a/mysql-test/suite/tianmu/t/auto_increment.testbak
+++ b/mysql-test/suite/tianmu/t/auto_increment.testbak
@@ -87,7 +87,8 @@ CREATE TABLE tintu (
   PRIMARY KEY (id)
 )  engine=tianmu;
 
-insert into tintu (id, data) values(4294967294, "first"),(63, "middle"),(0, "last");
+#insert into tintu (id, data) values(4294967294, "first"),(63, "middle"),(0, "last");
+insert into tintu (id, data) values(2147483647, "first"),(63, "middle"),(0, "last");
 select * from tintu;
 --error 1062
 insert into tintu (id, data) values (0, "last");
@@ -123,7 +124,8 @@ CREATE TABLE tmediumintu (
   PRIMARY KEY (id)
 )  engine=tianmu;
 
-insert into tmediumintu (id, data) values(16777214, "first"),(63, "middle"),(0, "last");
+#insert into tmediumintu (id, data) values(16777214, "first"),(63, "middle"),(0, "last");
+insert into tmediumintu (id, data) values(8388607, "first"),(63, "middle"),(0, "last");
 select * from tmediumintu;
 --error 1062
 insert into tmediumintu (id, data) values (0, "last");
@@ -135,7 +137,8 @@ CREATE TABLE tbigintu (
   PRIMARY KEY (id)
 )  engine=tianmu;
 
-insert into tbigintu (id, data) values(18446744073709551614, "first"),(63, "middle"),(0, "last");
+#insert into tbigintu (id, data) values(18446744073709551614, "first"),(63, "middle"),(0, "last");
+insert into tbigintu (id, data) values(9223372036854775807, "first"),(63, "middle"),(0, "last");
 select * from tbigintu;
 --error 1062
 insert into tbigintu (id, data) values (0, "last");

--- a/mysql-test/suite/tianmu/t/out_of_range_issue1151.test
+++ b/mysql-test/suite/tianmu/t/out_of_range_issue1151.test
@@ -1,8 +1,8 @@
 --source include/have_tianmu.inc
 
-drop database if exists test;
-create database test;
-use test;
+drop database if exists out_of_range_issue1151;
+create database out_of_range_issue1151;
+use out_of_range_issue1151;
 create table tiny(a tinyint, b tinyint unsigned) engine = tianmu DEFAULT CHARSET=utf8mb4;
 # test insert correctly
 insert into tiny values(-128, 0);
@@ -184,3 +184,4 @@ insert into bigint_ values(0, 18446744073709551616);
 --error 1264
 insert into bigint_ values(0, 1844674407370955161566);
 drop table bigint_;
+drop database if exists out_of_range_issue1151;

--- a/mysql-test/suite/tianmu/t/out_of_range_issue1151.test
+++ b/mysql-test/suite/tianmu/t/out_of_range_issue1151.test
@@ -1,0 +1,186 @@
+--source include/have_tianmu.inc
+
+drop database if exists test;
+create database test;
+use test;
+create table tiny(a tinyint, b tinyint unsigned) engine = tianmu DEFAULT CHARSET=utf8mb4;
+# test insert correctly
+insert into tiny values(-128, 0);
+insert into tiny values(127, 127);
+insert into tiny values(0, 127);
+insert into tiny values(-0, -0);
+insert into tiny values(+0, +0);
+select * from tiny;
+# test out of range, currently the max value of unsigned is equal to signed
+# column signed a out of value
+--error 1264
+insert into tiny values(-129, 0);
+--error 1264
+insert into tiny values(128, 0);
+--error 1264
+insert into tiny values(1234, 0);
+# column unsigned b out of value[128, 255], deal with tianmu
+--error 1264
+insert into tiny values(0, 128);
+--error 1264
+insert into tiny values(0, 255);
+# column unsigned b out of value(>255 || <0), deal with mysql
+--error 1264
+insert into tiny values(0, -1);
+--error 1264
+insert into tiny values(0, -127);
+--error 1264
+insert into tiny values(0, 256);
+--error 1264
+insert into tiny values(0, 1234567);
+drop table tiny;
+
+create table small(a smallint, b smallint unsigned) engine = tianmu DEFAULT CHARSET=utf8mb4;
+# test insert correctly
+insert into small values(-32768, 0);
+insert into small values(0, 0);
+insert into small values(122, 122);
+insert into small values(32767, 32767);
+insert into small values(-0, -0);
+insert into small values(+0, +0);
+select * from small;
+# test out of range, currently the max value of unsigned is equal to signed
+# column signed a out of value
+--error 1264
+insert into small values(-32769, 0);
+--error 1264
+insert into small values(32768, 0);
+--error 1264
+insert into small values(-3276911, 0);
+--error 1264
+insert into small values(3276811, 0);
+# column unsigned b out of value[32768, 65535], deal with tianmu
+--error 1264
+insert into small values(0, 32768);
+--error 1264
+insert into small values(0, 41234);
+--error 1264
+insert into small values(0, 65535);
+# column unsigned b out of value(>65535 || <0), deal with mysql
+--error 1264
+insert into small values(0, -1);
+--error 1264
+insert into small values(0, -32768);
+--error 1264
+insert into small values(0, 65536);
+--error 1264
+insert into small values(0, 1234567);
+drop table small;
+
+create table medium(a mediumint, b mediumint unsigned) engine = tianmu DEFAULT CHARSET=utf8mb4;
+# test insert correctly
+insert into medium values(-8388608, 0);
+insert into medium values(0, 0);
+insert into medium values(122, 122);
+insert into medium values(8388607, 8388607);
+insert into medium values(-0, -0);
+insert into medium values(+0, +0);
+select * from medium;
+# test out of range, currently the max value of unsigned is equal to signed
+# column signed a out of value
+--error 1264
+insert into medium values(-8388609, 0);
+--error 1264
+insert into medium values(8388608, 0);
+--error 1264
+insert into medium values(-8388608111, 0);
+--error 1264
+insert into medium values(8388608111, 0);
+# column unsigned b out of value[8388608, 16777215], deal with tianmu
+--error 1264
+insert into medium values(0, 8388608);
+--error 1264
+insert into medium values(0, 8388610);
+--error 1264
+insert into medium values(0, 16777215);
+# column unsigned b out of value(>8388607 || <0), deal with mysql
+--error 1264
+insert into medium values(0, -1);
+--error 1264
+insert into medium values(0, -8388608);
+--error 1264
+insert into medium values(0, 16777216);
+--error 1264
+insert into medium values(0, 1677721511);
+drop table medium;
+
+create table int_(a int, b int unsigned) engine = tianmu DEFAULT CHARSET=utf8mb4;
+# test insert correctly, range[-2147483647, 2147483647]
+insert into int_ values(-2147483647, 0);
+insert into int_ values(0, 0);
+insert into int_ values(122, 122);
+insert into int_ values(2147483647, 2147483647);
+insert into int_ values(-0, -0);
+insert into int_ values(+0, +0);
+select * from int_;
+# test out of range, currently the max value of unsigned is equal to signed
+# column signed a out of value
+--error 1264
+insert into int_ values(-2147483649, 0);
+--error 1264
+insert into int_ values(2147483648, 0);
+--error 1264
+insert into int_ values(-214748364811, 0);
+--error 1264
+insert into int_ values(214748364811, 0);
+# column unsigned b out of value[2147483648, 4294967295], deal with tianmu, -2147483648 also deal with tianmu
+--error 1264
+insert into int_ values(-2147483648, 0);
+--error 1264
+insert into int_ values(0, 2147483648);
+--error 1264
+insert into int_ values(0, 3294967295);
+--error 1264
+insert into int_ values(0, 4294967295);
+# column unsigned b out of value(>4294967295 || <0), deal with mysql
+--error 1264
+insert into int_ values(0, -1);
+--error 1264
+insert into int_ values(0, -4294967295);
+--error 1264
+insert into int_ values(0, 4294967296);
+--error 1264
+insert into int_ values(0, 429496729611);
+drop table int_;
+
+create table bigint_(a bigint, b bigint unsigned) engine = tianmu DEFAULT CHARSET=utf8mb4;
+# test insert correctly, range [-9223372036854775806, 9223372036854775807]
+insert into bigint_ values(-9223372036854775806, 0);
+insert into bigint_ values(0, 0);
+insert into bigint_ values(122, 122);
+insert into bigint_ values(9223372036854775807, 9223372036854775807);
+insert into bigint_ values(-0, -0);
+insert into bigint_ values(+0, +0);
+select * from bigint_;
+# test out of range, currently the max value of unsigned is equal to signed
+# column signed a out of value, -9223372036854775808 ret error and -9223372036854775807(null)
+--error 1264
+insert into bigint_ values(-9223372036854775808, 0);
+--error 1264
+insert into bigint_ values(9223372036854775808, 0);
+--error 1264
+insert into bigint_ values(-9223372036854775810, 0);
+--error 1264
+insert into bigint_ values(9223372036854775810, 0);
+# column unsigned b out of value[9223372036854775808, 18446744073709551615], deal with tianmu
+--error 1264
+insert into bigint_ values(0, 9223372036854775808);
+--error 1264
+insert into bigint_ values(0, 10223372036854775808);
+--error 1264
+insert into bigint_ values(0, 18446744073709551615);
+# column unsigned b out of value(>18446744073709551615 || <0), deal with mysql
+--error 1264
+insert into bigint_ values(0, -1);
+--error 1264
+insert into bigint_ values(0, -4294967295);
+--error 1264
+insert into bigint_ values(0, 18446744073709551616);
+--error 1264
+insert into bigint_ values(0, 1844674407370955161566);
+drop table bigint_;

--- a/storage/tianmu/common/common_definitions.cpp
+++ b/storage/tianmu/common/common_definitions.cpp
@@ -32,7 +32,8 @@ void PushWarning(THD *thd, Sql_condition::enum_severity_level level, uint code, 
   push_warning(thd, level, code, msg);
 }
 
-// Here for args int `type`, we do not use enum directly as it'll caused compiling failed for the dependent package.
+// TODO:Here for args int `type`, we do not use enum directly as it'll caused compiling failed for the dependent
+// package. It will be changed back to enum type later
 void PushWarningIfOutOfRange(THD *thd, std::string col_name, int64_t v, int type, bool unsigned_flag) {
   // below `0` is for min unsigned value.
   switch (type) {

--- a/storage/tianmu/common/common_definitions.cpp
+++ b/storage/tianmu/common/common_definitions.cpp
@@ -32,6 +32,74 @@ void PushWarning(THD *thd, Sql_condition::enum_severity_level level, uint code, 
   push_warning(thd, level, code, msg);
 }
 
+// Here for args int `type`, we do not use enum directly as it'll caused compiling failed for the dependent package.
+void PushWarningIfOutOfRange(THD *thd, std::string col_name, int64_t v, int type, bool unsigned_flag) {
+  // below `0` is for min unsigned value.
+  switch (type) {
+    case 1: {  // MYSQL_TYPE_TINY
+      if (unsigned_flag && (static_cast<uint64_t>(v) > TIANMU_TINYINT_MAX)) {
+        PushWarning(thd, Sql_condition::SL_WARNING, ER_WARN_DATA_OUT_OF_RANGE,
+                    getErrMsg(col_name, 0, TIANMU_TINYINT_MAX, unsigned_flag, v).c_str());
+      } else if (v > TIANMU_TINYINT_MAX || v < TIANMU_TINYINT_MIN) {
+        PushWarning(thd, Sql_condition::SL_WARNING, ER_WARN_DATA_OUT_OF_RANGE,
+                    getErrMsg(col_name, TIANMU_TINYINT_MIN, TIANMU_TINYINT_MAX, unsigned_flag, v).c_str());
+      }
+    } break;
+    case 2: {  // MYSQL_TYPE_SHORT
+      if (unsigned_flag && (static_cast<uint64_t>(v) > TIANMU_SMALLINT_MAX)) {
+        PushWarning(thd, Sql_condition::SL_WARNING, ER_WARN_DATA_OUT_OF_RANGE,
+                    getErrMsg(col_name, 0, TIANMU_SMALLINT_MAX, unsigned_flag, v).c_str());
+      } else if (v > TIANMU_SMALLINT_MAX || v < TIANMU_SMALLINT_MIN) {
+        PushWarning(thd, Sql_condition::SL_WARNING, ER_WARN_DATA_OUT_OF_RANGE,
+                    getErrMsg(col_name, TIANMU_SMALLINT_MIN, TIANMU_SMALLINT_MAX, unsigned_flag, v).c_str());
+      };
+    } break;
+    case 9: {  // MYSQL_TYPE_INT24
+      if (unsigned_flag && (static_cast<uint64_t>(v) > TIANMU_MEDIUMINT_MAX)) {
+        PushWarning(thd, Sql_condition::SL_WARNING, ER_WARN_DATA_OUT_OF_RANGE,
+                    getErrMsg(col_name, 0, TIANMU_MEDIUMINT_MAX, unsigned_flag, v).c_str());
+      } else if (v > TIANMU_MEDIUMINT_MAX || v < TIANMU_MEDIUMINT_MIN) {
+        PushWarning(thd, Sql_condition::SL_WARNING, ER_WARN_DATA_OUT_OF_RANGE,
+                    getErrMsg(col_name, TIANMU_MEDIUMINT_MIN, TIANMU_MEDIUMINT_MAX, unsigned_flag, v).c_str());
+      }
+    } break;
+    case 3: {  // MYSQL_TYPE_LONG
+      if (unsigned_flag && (static_cast<uint64_t>(v) > TIANMU_INT_MAX)) {
+        PushWarning(thd, Sql_condition::SL_WARNING, ER_WARN_DATA_OUT_OF_RANGE,
+                    getErrMsg(col_name, 0, TIANMU_INT_MAX, unsigned_flag, v).c_str());
+      } else if (v > TIANMU_INT_MAX || v < TIANMU_INT_MIN) {
+        PushWarning(thd, Sql_condition::SL_WARNING, ER_WARN_DATA_OUT_OF_RANGE,
+                    getErrMsg(col_name, TIANMU_INT_MIN, TIANMU_INT_MAX, unsigned_flag, v).c_str());
+      }
+    } break;
+    case 8: {  // MYSQL_TYPE_LONGLONG
+      if (unsigned_flag && (static_cast<uint64_t>(v) > TIANMU_BIGINT_MAX)) {
+        PushWarning(thd, Sql_condition::SL_WARNING, ER_WARN_DATA_OUT_OF_RANGE,
+                    getErrMsg(col_name, 0, TIANMU_BIGINT_MAX, unsigned_flag, v).c_str());
+      } else if (v > TIANMU_BIGINT_MAX || v < TIANMU_BIGINT_MIN) {
+        PushWarning(thd, Sql_condition::SL_WARNING, ER_WARN_DATA_OUT_OF_RANGE,
+                    getErrMsg(col_name, TIANMU_BIGINT_MIN, TIANMU_BIGINT_MAX, unsigned_flag, v).c_str());
+      }
+    } break;
+    default:  // For type which is not integer, nothing to do
+      break;
+  }
+}
+
+// Msg: Out of range[min, max] for column 'col' value: 123
+// Just for unsigned type check in tianmu engine.
+std::string getErrMsg(std::string col_name, int64_t min, int64_t max, bool unsigned_flag, int64_t v) {
+  std::string str = "Out of range[";
+  str += std::to_string(min);
+  str += ", ";
+  str += std::to_string(max);
+  str += "] for column '";
+  str += col_name;
+  str += "' value: ";
+  str += unsigned_flag ? std::to_string(static_cast<uint64_t>(v)) : std::to_string(v);
+  return str;
+}
+
 std::string TX_ID::ToString() const {
   std::stringstream ss;
   ss << std::setfill('0') << std::setw(sizeof(v) * 2) << std::hex << v;

--- a/storage/tianmu/common/common_definitions.h
+++ b/storage/tianmu/common/common_definitions.h
@@ -38,6 +38,8 @@ constexpr size_t operator""_GB(unsigned long long v) { return 1024u * 1024u * 10
 namespace common {
 
 extern void PushWarning(THD *thd, Sql_condition::enum_severity_level level, uint code, const char *msg);
+extern void PushWarningIfOutOfRange(THD *thd, std::string col_name, int64_t v, int type, bool unsigned_flag);
+std::string getErrMsg(std::string col_name, int64_t min, int64_t max, bool unsigned_flag, int64_t v);
 
 // Column Type
 // NOTE: do not change the order of implemented data types! Stored as int(...)

--- a/storage/tianmu/core/engine.h
+++ b/storage/tianmu/core/engine.h
@@ -182,7 +182,7 @@ class Engine final {
   void ProcessDelayedMerge();
   std::unique_ptr<char[]> GetRecord(size_t &len);
   void EncodeRecord(const std::string &table_path, int table_id, Field **field, size_t col, size_t blobs,
-                    std::unique_ptr<char[]> &buf, uint32_t &size);
+                    std::unique_ptr<char[]> &buf, uint32_t &size, THD *thd);
 
  private:
   struct TianmuStat {


### PR DESCRIPTION
<!--

Thank you for contributing to StoneDB!

PR Title Format: <type>(<scope>): description to this pr (#issue_id)
e.g.
fix(util): fix sth..... (#1)

-->

## Summary about this PR
<!--

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".
e.g.:
Issue: close #1

-->
tinyint: signed range is -128 to 127, unsigned range is 0 to 127.

smallint: signed range is -32768 to 32767, unsigned range is 0 to 32767.

mediumint: signed range is -8388608 to 8388607, unsigned range is 0 to 8388607.

int/integer: signed range is -2147483647 to 2147483647, unsigned range is 0 to 2147483647. Note: -2147483648 is not allowed in tianmu engine currently.

bigint: signed range is -9223372036854775806 to 9223372036854775807, unsigned range is 0 to 9223372036854775807.
Note: -9223372036854775807 will be set to null and -9223372036854775808 will ret out of range.
Issue Number: close #1151 


## Tests Check List
<!-- At least one of next options must be included. -->

- [ ] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

## Changelog
<!-- At least one of next options must be included. -->

- [ ] New Feature
- [x] Bug Fix
- [ ] Performance Improvement
- [ ] Build/Testing/CI/CD
- [ ] Documentation
- [ ] Not for changelog (changelog entry is not required)

## Documentation
<!-- At least one of next options must be included. -->

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
