### PR TITLE
fix: insert with unsigned data return out of range, but still being queried #1218

### DIFF
--- a/mysql-test/suite/tianmu/r/out_of_range_issue1151.result
+++ b/mysql-test/suite/tianmu/r/out_of_range_issue1151.result
@@ -34,6 +34,13 @@ insert into tiny values(0, 256);
 ERROR 22003: Out of range value for column 'b' at row 1
 insert into tiny values(0, 1234567);
 ERROR 22003: Out of range value for column 'b' at row 1
+select * from tiny;
+a	b
+-128	0
+127	127
+0	127
+0	0
+0	0
 drop table tiny;
 create table small(a smallint, b smallint unsigned) engine = tianmu DEFAULT CHARSET=utf8mb4;
 insert into small values(-32768, 0);
@@ -72,6 +79,14 @@ insert into small values(0, 65536);
 ERROR 22003: Out of range value for column 'b' at row 1
 insert into small values(0, 1234567);
 ERROR 22003: Out of range value for column 'b' at row 1
+select * from small;
+a	b
+-32768	0
+0	0
+122	122
+32767	32767
+0	0
+0	0
 drop table small;
 create table medium(a mediumint, b mediumint unsigned) engine = tianmu DEFAULT CHARSET=utf8mb4;
 insert into medium values(-8388608, 0);
@@ -110,6 +125,14 @@ insert into medium values(0, 16777216);
 ERROR 22003: Out of range value for column 'b' at row 1
 insert into medium values(0, 1677721511);
 ERROR 22003: Out of range value for column 'b' at row 1
+select * from medium;
+a	b
+-8388608	0
+0	0
+122	122
+8388607	8388607
+0	0
+0	0
 drop table medium;
 create table int_(a int, b int unsigned) engine = tianmu DEFAULT CHARSET=utf8mb4;
 insert into int_ values(-2147483647, 0);
@@ -150,6 +173,14 @@ insert into int_ values(0, 4294967296);
 ERROR 22003: Out of range value for column 'b' at row 1
 insert into int_ values(0, 429496729611);
 ERROR 22003: Out of range value for column 'b' at row 1
+select * from int_;
+a	b
+-2147483647	0
+0	0
+122	122
+2147483647	2147483647
+0	0
+0	0
 drop table int_;
 create table bigint_(a bigint, b bigint unsigned) engine = tianmu DEFAULT CHARSET=utf8mb4;
 insert into bigint_ values(-9223372036854775806, 0);
@@ -188,5 +219,13 @@ insert into bigint_ values(0, 18446744073709551616);
 ERROR 22003: Out of range value for column 'b' at row 1
 insert into bigint_ values(0, 1844674407370955161566);
 ERROR 22003: Out of range value for column 'b' at row 1
+select * from bigint_;
+a	b
+-9223372036854775806	0
+0	0
+122	122
+9223372036854775807	9223372036854775807
+0	0
+0	0
 drop table bigint_;
 drop database if exists out_of_range_issue1151;

--- a/mysql-test/suite/tianmu/t/out_of_range_issue1151.test
+++ b/mysql-test/suite/tianmu/t/out_of_range_issue1151.test
@@ -33,6 +33,7 @@ insert into tiny values(0, -127);
 insert into tiny values(0, 256);
 --error 1264
 insert into tiny values(0, 1234567);
+select * from tiny;
 drop table tiny;
 
 create table small(a smallint, b smallint unsigned) engine = tianmu DEFAULT CHARSET=utf8mb4;
@@ -70,6 +71,7 @@ insert into small values(0, -32768);
 insert into small values(0, 65536);
 --error 1264
 insert into small values(0, 1234567);
+select * from small;
 drop table small;
 
 create table medium(a mediumint, b mediumint unsigned) engine = tianmu DEFAULT CHARSET=utf8mb4;
@@ -107,6 +109,7 @@ insert into medium values(0, -8388608);
 insert into medium values(0, 16777216);
 --error 1264
 insert into medium values(0, 1677721511);
+select * from medium;
 drop table medium;
 
 create table int_(a int, b int unsigned) engine = tianmu DEFAULT CHARSET=utf8mb4;
@@ -146,6 +149,7 @@ insert into int_ values(0, -4294967295);
 insert into int_ values(0, 4294967296);
 --error 1264
 insert into int_ values(0, 429496729611);
+select * from int_;
 drop table int_;
 
 create table bigint_(a bigint, b bigint unsigned) engine = tianmu DEFAULT CHARSET=utf8mb4;
@@ -183,5 +187,6 @@ insert into bigint_ values(0, -4294967295);
 insert into bigint_ values(0, 18446744073709551616);
 --error 1264
 insert into bigint_ values(0, 1844674407370955161566);
+select * from bigint_;
 drop table bigint_;
 drop database if exists out_of_range_issue1151;

--- a/storage/tianmu/common/common_definitions.cpp
+++ b/storage/tianmu/common/common_definitions.cpp
@@ -34,6 +34,8 @@ void PushWarning(THD *thd, Sql_condition::enum_severity_level level, uint code, 
 
 // TODO:Here for args int `type`, we do not use enum directly as it'll caused compiling failed for the dependent
 // package. It will be changed back to enum type later
+// We use std::exception() but not commong::Exceptions here as it will raise infos like "internal error in storage
+// tianmu ..." on mysql client, this is not user friendly. Users has already get error msg from push_warning() func.
 void PushWarningIfOutOfRange(THD *thd, std::string col_name, int64_t v, int type, bool unsigned_flag) {
   // below `0` is for min unsigned value.
   switch (type) {
@@ -41,45 +43,55 @@ void PushWarningIfOutOfRange(THD *thd, std::string col_name, int64_t v, int type
       if (unsigned_flag && (static_cast<uint64_t>(v) > TIANMU_TINYINT_MAX)) {
         PushWarning(thd, Sql_condition::SL_WARNING, ER_WARN_DATA_OUT_OF_RANGE,
                     getErrMsg(col_name, 0, TIANMU_TINYINT_MAX, unsigned_flag, v).c_str());
+        throw std::exception();
       } else if (v > TIANMU_TINYINT_MAX || v < TIANMU_TINYINT_MIN) {
         PushWarning(thd, Sql_condition::SL_WARNING, ER_WARN_DATA_OUT_OF_RANGE,
                     getErrMsg(col_name, TIANMU_TINYINT_MIN, TIANMU_TINYINT_MAX, unsigned_flag, v).c_str());
+        throw std::exception();
       }
     } break;
     case 2: {  // MYSQL_TYPE_SHORT
       if (unsigned_flag && (static_cast<uint64_t>(v) > TIANMU_SMALLINT_MAX)) {
         PushWarning(thd, Sql_condition::SL_WARNING, ER_WARN_DATA_OUT_OF_RANGE,
                     getErrMsg(col_name, 0, TIANMU_SMALLINT_MAX, unsigned_flag, v).c_str());
+        throw std::exception();
       } else if (v > TIANMU_SMALLINT_MAX || v < TIANMU_SMALLINT_MIN) {
         PushWarning(thd, Sql_condition::SL_WARNING, ER_WARN_DATA_OUT_OF_RANGE,
                     getErrMsg(col_name, TIANMU_SMALLINT_MIN, TIANMU_SMALLINT_MAX, unsigned_flag, v).c_str());
+        throw std::exception();
       };
     } break;
     case 9: {  // MYSQL_TYPE_INT24
       if (unsigned_flag && (static_cast<uint64_t>(v) > TIANMU_MEDIUMINT_MAX)) {
         PushWarning(thd, Sql_condition::SL_WARNING, ER_WARN_DATA_OUT_OF_RANGE,
                     getErrMsg(col_name, 0, TIANMU_MEDIUMINT_MAX, unsigned_flag, v).c_str());
+        throw std::exception();
       } else if (v > TIANMU_MEDIUMINT_MAX || v < TIANMU_MEDIUMINT_MIN) {
         PushWarning(thd, Sql_condition::SL_WARNING, ER_WARN_DATA_OUT_OF_RANGE,
                     getErrMsg(col_name, TIANMU_MEDIUMINT_MIN, TIANMU_MEDIUMINT_MAX, unsigned_flag, v).c_str());
+        throw std::exception();
       }
     } break;
     case 3: {  // MYSQL_TYPE_LONG
       if (unsigned_flag && (static_cast<uint64_t>(v) > TIANMU_INT_MAX)) {
         PushWarning(thd, Sql_condition::SL_WARNING, ER_WARN_DATA_OUT_OF_RANGE,
                     getErrMsg(col_name, 0, TIANMU_INT_MAX, unsigned_flag, v).c_str());
+        throw std::exception();
       } else if (v > TIANMU_INT_MAX || v < TIANMU_INT_MIN) {
         PushWarning(thd, Sql_condition::SL_WARNING, ER_WARN_DATA_OUT_OF_RANGE,
                     getErrMsg(col_name, TIANMU_INT_MIN, TIANMU_INT_MAX, unsigned_flag, v).c_str());
+        throw std::exception();
       }
     } break;
     case 8: {  // MYSQL_TYPE_LONGLONG
       if (unsigned_flag && (static_cast<uint64_t>(v) > TIANMU_BIGINT_MAX)) {
         PushWarning(thd, Sql_condition::SL_WARNING, ER_WARN_DATA_OUT_OF_RANGE,
                     getErrMsg(col_name, 0, TIANMU_BIGINT_MAX, unsigned_flag, v).c_str());
+        throw std::exception();
       } else if (v > TIANMU_BIGINT_MAX || v < TIANMU_BIGINT_MIN) {
         PushWarning(thd, Sql_condition::SL_WARNING, ER_WARN_DATA_OUT_OF_RANGE,
                     getErrMsg(col_name, TIANMU_BIGINT_MIN, TIANMU_BIGINT_MAX, unsigned_flag, v).c_str());
+        throw std::exception();
       }
     } break;
     default:  // For type which is not integer, nothing to do


### PR DESCRIPTION
<!--

Thank you for contributing to StoneDB!

PR Title Format: <type>(<scope>): description to this pr (#issue_id)
e.g.
fix(util): fix sth..... (#1)

-->

## Summary about this PR
<!--

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".
e.g.:
Issue: close #1

-->
1. Fix int signed & unsigned: -2147483648 and [2147483648, 4294967295] is not allowed.
2. Fix bigint signed & unsigned: -9223372036854775808 and [9223372036854775808, 18446744073709551615] is not allowed.
3. Like int&bigint, fix unsigned [tinyint, smallint, mediumint] unsupported values except negative data.

Issue Number: close #1218


## Tests Check List
<!-- At least one of next options must be included. -->

- [ ] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

## Changelog
<!-- At least one of next options must be included. -->

- [ ] New Feature
- [x] Bug Fix
- [ ] Performance Improvement
- [ ] Build/Testing/CI/CD
- [ ] Documentation
- [ ] Not for changelog (changelog entry is not required)

## Documentation
<!-- At least one of next options must be included. -->

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
