### PR TITLE
fix(tianmu):the data is wrong when altering table after deleting.(#1199)

### DIFF
--- a/mysql-test/suite/tianmu/r/alter_delete.result
+++ b/mysql-test/suite/tianmu/r/alter_delete.result
@@ -1,0 +1,28 @@
+DROP DATABASE IF EXISTS alter_delete;
+CREATE DATABASE alter_delete;
+USE alter_delete;
+CREATE TABLE ttt1(id INT,name VARCHAR(5));
+INSERT INTO ttt1 VALUES(0,"XXX"),(1,'AAA'),(2,'BBB');
+SELECT * FROM ttt1;
+id	name
+0	XXX
+1	AAA
+2	BBB
+DELETE FROM ttt1 WHERE id=1;
+SELECT * FROM ttt1;
+id	name
+0	XXX
+2	BBB
+ALTER TABLE ttt1 CONVERT TO CHARACTER SET utf8;
+SELECT * FROM ttt1;
+id	name
+0	XXX
+2	BBB
+SHOW CREATE TABLE ttt1;
+Table	Create Table
+ttt1	CREATE TABLE `ttt1` (
+  `id` int(11) DEFAULT NULL,
+  `name` varchar(5) DEFAULT NULL
+) ENGINE=TIANMU DEFAULT CHARSET=utf8
+DROP TABLE ttt1;
+DROP DATABASE alter_delete;

--- a/mysql-test/suite/tianmu/t/alter_delete.test
+++ b/mysql-test/suite/tianmu/t/alter_delete.test
@@ -1,0 +1,29 @@
+--source include/have_tianmu.inc
+
+--disable_warnings
+DROP DATABASE IF EXISTS alter_delete;
+--enable_warnings
+
+CREATE DATABASE alter_delete;
+
+USE alter_delete;
+
+CREATE TABLE ttt1(id INT,name VARCHAR(5));
+
+INSERT INTO ttt1 VALUES(0,"XXX"),(1,'AAA'),(2,'BBB');
+
+SELECT * FROM ttt1;
+
+DELETE FROM ttt1 WHERE id=1;
+
+SELECT * FROM ttt1;
+
+ALTER TABLE ttt1 CONVERT TO CHARACTER SET utf8;
+
+SELECT * FROM ttt1;
+
+SHOW CREATE TABLE ttt1;
+
+DROP TABLE ttt1;
+
+DROP DATABASE alter_delete;

--- a/storage/tianmu/core/dimension_group.cpp
+++ b/storage/tianmu/core/dimension_group.cpp
@@ -353,9 +353,7 @@ int DimensionGroupMaterialized::DGMaterializedIterator::GetNextPackrow(int dim, 
   if (next_pack[dim] >= no_obj || uint64_t(next_pack[dim]) >= end_block)
     return -1;
   uint64_t ahead_pos = 0;
-  //	cout << "dim " << dim << ",  " << next_pack[dim] << " -> " <<
-  // ahead1[dim] << "  " <<
-  // ahead2[dim] << "  " << ahead3[dim] << "    (" << ahead << ")" << endl;
+
   if (ahead == 1)
     ahead_pos = t[dim]->Get64InsideBlock(next_pack[dim]);
   else if (ahead == 2 && ahead1[dim] != -1)

--- a/storage/tianmu/core/tianmu_table.h
+++ b/storage/tianmu/core/tianmu_table.h
@@ -179,6 +179,7 @@ class TianmuTable final : public JustATable {
     void MoveToRow(int64_t row_id);
     int64_t GetCurrentRowId() const { return position; }
     bool Inited() const { return table != nullptr; }
+    std::vector<TianmuAttr *> GetAttrs() { return attrs; }
 
    private:
     void FetchValues();


### PR DESCRIPTION
Because the records which was deleted is not filtered.

<!--

Thank you for contributing to StoneDB!

PR Title Format: <type>(<scope>): description to this pr (#issue_id)
e.g.
fix(util): fix sth..... (#1)

-->

## Summary about this PR
<!--

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".
e.g.:
Issue: close #1

-->

Issue Number: close #1199 

[summary]
Because the records which was deleted is not filtered in fill_row().


## Tests Check List
<!-- At least one of next options must be included. -->

- [ ] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

## Changelog
<!-- At least one of next options must be included. -->

- [ ] New Feature
- [x] Bug Fix
- [ ] Performance Improvement
- [ ] Build/Testing/CI/CD
- [ ] Documentation
- [ ] Not for changelog (changelog entry is not required)

## Documentation
<!-- At least one of next options must be included. -->

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
