### PR TITLE
fix(tianmu):the data is wrong when updating data after atlering table.(#1253)

### DIFF
--- a/mysql-test/suite/tianmu/r/alter_update.result
+++ b/mysql-test/suite/tianmu/r/alter_update.result
@@ -1,0 +1,20 @@
+DROP DATABASE IF EXISTS alter_update;
+CREATE DATABASE alter_update;
+USE alter_update;
+CREATE TABLE test (a INT,b INT);
+INSERT INTO test(a,b) VALUES (1,37),(64,34),(65,17);
+ALTER TABLE test ADD COLUMN c INT;
+UPDATE test SET c=b;
+SELECT * FROM test;
+a	b	c
+1	37	37
+64	34	34
+65	17	17
+UPDATE test SET c=a;
+SELECT * FROM test;
+a	b	c
+1	37	1
+64	34	64
+65	17	65
+DROP TABLE test;
+DROP DATABASE alter_update;

--- a/mysql-test/suite/tianmu/t/alter_update.test
+++ b/mysql-test/suite/tianmu/t/alter_update.test
@@ -1,0 +1,27 @@
+--source include/have_tianmu.inc
+
+--disable_warnings
+DROP DATABASE IF EXISTS alter_update;
+--enable_warnings
+
+CREATE DATABASE alter_update;
+
+USE alter_update;
+
+CREATE TABLE test (a INT,b INT);
+
+INSERT INTO test(a,b) VALUES (1,37),(64,34),(65,17);
+
+ALTER TABLE test ADD COLUMN c INT;
+
+UPDATE test SET c=b;
+
+SELECT * FROM test;
+
+UPDATE test SET c=a;
+
+SELECT * FROM test;
+
+DROP TABLE test;
+
+DROP DATABASE alter_update;

--- a/storage/tianmu/core/mysql_expression.cpp
+++ b/storage/tianmu/core/mysql_expression.cpp
@@ -505,8 +505,6 @@ std::shared_ptr<ValueOrNull> MysqlExpression::ItemDecimal2ValueOrNull(Item *item
       my_decimal2decimal(retdec, &dec);
     int64_t v;
     int err;
-    // err = my_decimal_shift((uint)-1, &dec, item->decimals <= 18 ?
-    // item->decimals : 18);
     if (dec_scale == -1)
       err = my_decimal_shift((uint)-1, &dec, item->decimals <= 18 ? item->decimals : 18);
     else

--- a/storage/tianmu/core/pack_int.cpp
+++ b/storage/tianmu/core/pack_int.cpp
@@ -363,6 +363,7 @@ void PackInt::UpdateValueFixed(size_t locationInPack, const Value &v) {
       // for fixed number, it is sufficient to simply zero the data_
       std::memset(data_.ptr_, 0, data_.value_type_ * dpn_->numOfRecords);
       dpn_->numOfNulls--;
+      SetVal64(locationInPack, l - dpn_->min_i);
     } else {
       ASSERT(data_.ptr_ != nullptr);
       dpn_->numOfNulls--;
@@ -385,7 +386,7 @@ void PackInt::UpdateValueFixed(size_t locationInPack, const Value &v) {
         dpn_->max_i = l;
         new_vt = GetValueSize(dpn_->max_i - dpn_->min_i);
       }
-      if (new_vt > data_.value_type_) {
+      if (new_vt != data_.value_type_ || delta != 0) {
         auto tmp = alloc(new_vt * dpn_->numOfRecords, mm::BLOCK_TYPE::BLOCK_UNCOMPRESSED);
         xf[{data_.value_type_, new_vt}](data_.ptr_, data_.ptr_int8_ + (data_.value_type_ * dpn_->numOfRecords), tmp,
                                         delta);

--- a/storage/tianmu/core/pack_str.cpp
+++ b/storage/tianmu/core/pack_str.cpp
@@ -565,10 +565,6 @@ void PackStr::LoadCompressed(system::Stream *f) {
 
   dpn_->synced = true;
 
-  // if (ATI::IsBinType(s->ColType().GetTypeName())) {
-  //    throw common::Exception("Compression format no longer supported.");
-  //}
-
   // uncompress the data_
   mm::MMGuard<char *> tmp_index(
       reinterpret_cast<char **>(alloc(dpn_->numOfRecords * sizeof(char *), mm::BLOCK_TYPE::BLOCK_TEMPORARY)), *this);


### PR DESCRIPTION

<!--

Thank you for contributing to StoneDB!

PR Title Format: <type>(<scope>): description to this pr (#issue_id)
e.g.
fix(util): fix sth..... (#1)

-->

## Summary about this PR
<!--

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".
e.g.:
Issue: close #1

-->

Issue Number: close #1253

[summary]
After altering table add column, the data of the added column is NULL. When handling the NULL data, the updating operation is not correct.

## Tests Check List
<!-- At least one of next options must be included. -->

- [ ] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

## Changelog
<!-- At least one of next options must be included. -->

- [ ] New Feature
- [x] Bug Fix
- [ ] Performance Improvement
- [ ] Build/Testing/CI/CD
- [ ] Documentation
- [ ] Not for changelog (changelog entry is not required)

## Documentation
<!-- At least one of next options must be included. -->

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
