### PR TITLE
fix(tianmu):issue1090.test occasionally fails to run(#1234)

### DIFF
--- a/mysql-test/suite/tianmu/r/issue1090.result
+++ b/mysql-test/suite/tianmu/r/issue1090.result
@@ -41,6 +41,7 @@ t_issue1090	CREATE TABLE `t_issue1090` (
   `c3` int(11) DEFAULT NULL
 ) ENGINE=InnoDB DEFAULT CHARSET=latin1
 [on slave]
+include/sync_slave_sql_with_master.inc
 show global variables like 'sql_mode';
 Variable_name	Value
 sql_mode	STRICT_TRANS_TABLES,NO_AUTO_CREATE_USER,NO_ENGINE_SUBSTITUTION
@@ -98,6 +99,7 @@ t_issue1090_2	CREATE TABLE `t_issue1090_2` (
   `c3` int(11) DEFAULT NULL
 ) ENGINE=InnoDB DEFAULT CHARSET=latin1
 [on slave]
+include/sync_slave_sql_with_master.inc
 show global variables like 'sql_mode';
 Variable_name	Value
 sql_mode	STRICT_TRANS_TABLES,NO_AUTO_CREATE_USER,NO_ENGINE_SUBSTITUTION,MANDATORY_TIANMU
@@ -155,6 +157,7 @@ t_issue1090_3	CREATE TABLE `t_issue1090_3` (
   `c3` int(11) DEFAULT NULL
 ) ENGINE=InnoDB DEFAULT CHARSET=latin1
 [on slave]
+include/sync_slave_sql_with_master.inc
 show global variables like 'sql_mode';
 Variable_name	Value
 sql_mode	STRICT_TRANS_TABLES,NO_AUTO_CREATE_USER,NO_ENGINE_SUBSTITUTION
@@ -210,6 +213,7 @@ t_issue1090_4	CREATE TABLE `t_issue1090_4` (
   `c1` int(11) DEFAULT NULL
 ) ENGINE=InnoDB DEFAULT CHARSET=latin1
 [on slave]
+include/sync_slave_sql_with_master.inc
 show global variables like 'sql_mode';
 Variable_name	Value
 sql_mode	STRICT_TRANS_TABLES,NO_AUTO_CREATE_USER,NO_ENGINE_SUBSTITUTION,MANDATORY_TIANMU

--- a/mysql-test/suite/tianmu/t/issue1090.test
+++ b/mysql-test/suite/tianmu/t/issue1090.test
@@ -28,8 +28,7 @@ connection master;
 alter table t_issue1090 add c3 int;
 show create table t_issue1090;
 --echo [on slave]
-connection slave;
-sleep 1;
+--source include/sync_slave_sql_with_master.inc
 show global variables like 'sql_mode';
 show global variables like '%_engine';
 show create table t_issue1090;
@@ -61,8 +60,7 @@ connection master;
 alter table t_issue1090_2 add c3 int;
 show create table t_issue1090_2;
 --echo [on slave]
-connection slave;
-sleep 1;
+--source include/sync_slave_sql_with_master.inc
 show global variables like 'sql_mode';
 show global variables like '%_engine';
 show create table t_issue1090_2;
@@ -94,8 +92,7 @@ connection master;
 alter table t_issue1090_3 add c3 int;
 show create table t_issue1090_3;
 --echo [on slave]
-connection slave;
-sleep 1;
+--source include/sync_slave_sql_with_master.inc
 show global variables like 'sql_mode';
 show global variables like '%_engine';
 show create table t_issue1090_3;
@@ -129,8 +126,7 @@ connection master;
 alter table t_issue1090_4 DROP COLUMN c2;
 show create table t_issue1090_4;
 --echo [on slave]
-connection slave;
-sleep 1;
+--source include/sync_slave_sql_with_master.inc
 show global variables like 'sql_mode';
 show global variables like '%_engine';
 show create table t_issue1090_4;


### PR DESCRIPTION
Cause of the problem:
There is a problem in the method of waiting for the master/slave synchronization to complete, which leads to the data not being synchronized, and then proceed to the next step

Modify scheme:
Use the correct method to determine whether the slave database is synchronized

<!--

Thank you for contributing to StoneDB!

PR Title Format: <type>(<scope>): description to this pr (#issue_id)
e.g.
fix(util): fix sth..... (#1)

-->

## Summary about this PR
<!--

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".
e.g.:
Issue: close #1

-->

Issue Number: close #1234


## Tests Check List
<!-- At least one of next options must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

## Changelog
<!-- At least one of next options must be included. -->

- [ ] New Feature
- [x] Bug Fix
- [ ] Performance Improvement
- [ ] Build/Testing/CI/CD
- [ ] Documentation
- [ ] Not for changelog (changelog entry is not required)

## Documentation
<!-- At least one of next options must be included. -->

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
