### PR TITLE
fix(tianmu): fix OOM when too many data and  aggregate (#949,#1291)

### DIFF
--- a/scripts/my.cnf.sample
+++ b/scripts/my.cnf.sample
@@ -173,6 +173,16 @@ tianmu_groupby_parallel_rows_minimum=655360
 # order by parallel switch
 tianmu_orderby_speedup=1
 
+# DIR
+tianmu_hugefiledir='/tmp'
+
+# MB, If the value is set to 0, the system does not use it
+tianmu_hugefilesize=30720
+
+# minimum available memory of the system, MB
+# If the remaining memory is smaller than this value, huge memory is used
+tianmu_os_least_mem=512
+
 # here, at the end of [mysqld] group mtr will automatically disable
 # all optional plugins.
 

--- a/storage/tianmu/core/aggregation_algorithm.cpp
+++ b/storage/tianmu/core/aggregation_algorithm.cpp
@@ -27,6 +27,7 @@ low-level mechanisms
 #include "core/mi_iterator.h"
 #include "core/pack_guardian.h"
 #include "core/transaction.h"
+#include "mm/memory_statistics.h"
 #include "system/fet.h"
 #include "system/tianmu_system.h"
 
@@ -292,10 +293,14 @@ void AggregationAlgorithm::MultiDimensionalGroupByScan(GroupByWrapper &gbw, int6
 
 #ifdef DEBUG_AGGREGA_COST
       std::chrono::high_resolution_clock::time_point start = std::chrono::high_resolution_clock::now();
+      uint64_t mem_available = MemoryStatisticsOS::Instance()->GetMemInfo().mem_available;
+      uint64_t swap_used = MemoryStatisticsOS::Instance()->GetMemInfo().swap_used;
+      MEMORY_STATISTICS("AGGREGA", "START");
+      uint64_t mem_used = 0;
 #endif
 
       if (ag_worker.ThreadsUsed() > 1) {
-        ag_worker.DistributeAggreTaskAverage(mit);
+        ag_worker.DistributeAggreTaskAverage(mit, &mem_used);
       } else {
         thread_type = "sin";
         while (mit.IsValid()) {  // need muti thread
@@ -306,7 +311,7 @@ void AggregationAlgorithm::MultiDimensionalGroupByScan(GroupByWrapper &gbw, int6
 
           // Grouping on a packrow
           int64_t packrow_length = mit.GetPackSizeLeft();
-          AggregaGroupingResult grouping_result = AggregatePackrow(gbw, &mit, cur_tuple);
+          AggregaGroupingResult grouping_result = AggregatePackrow(gbw, &mit, cur_tuple, &mem_used);
           if (sender) {
             sender->SetAffectRows(gbw.NumOfGroups());
           }
@@ -324,12 +329,17 @@ void AggregationAlgorithm::MultiDimensionalGroupByScan(GroupByWrapper &gbw, int6
       }
 
 #ifdef DEBUG_AGGREGA_COST
+      int64_t mem_available_chg = MemoryStatisticsOS::Instance()->GetMemInfo().mem_available - mem_available;
+      int64_t swap_used_chg = MemoryStatisticsOS::Instance()->GetMemInfo().swap_used - swap_used;
       auto diff =
           std::chrono::duration_cast<std::chrono::duration<float>>(std::chrono::high_resolution_clock::now() - start);
       if (diff.count() > tianmu_sysvar_slow_query_record_interval) {
-        TIANMU_LOG(LogCtl_Level::INFO, "AggregatePackrow thread_type: %s spend: %f NumOfTuples: %d", thread_type,
-                   diff.count(), mit.NumOfTuples());
+        TIANMU_LOG(LogCtl_Level::INFO,
+                   "AggregatePackrow thread_type: %s spend: %f NumOfTuples: %d mem_available_chg: %ld swap_used_chg: "
+                   "%ld collec_mem_used: %lu",
+                   thread_type, diff.count(), mit.NumOfTuples(), mem_available_chg, swap_used_chg, mem_used);
       }
+      MEMORY_STATISTICS("AGGREGA", "END");
 #endif
 
       gbw.ClearDistinctBuffers();              // reset buffers for a new contents
@@ -517,12 +527,20 @@ void AggregationAlgorithm::MultiDimensionalDistinctScan(GroupByWrapper &gbw, MII
   }
 }
 
-AggregaGroupingResult AggregationAlgorithm::AggregatePackrow(GroupByWrapper &gbw, MIIterator *mit, int64_t cur_tuple) {
+AggregaGroupingResult AggregationAlgorithm::AggregatePackrow(GroupByWrapper &gbw, MIIterator *mit, int64_t cur_tuple,
+                                                             uint64_t *mem_used) {
   int64_t packrow_length = mit->GetPackSizeLeft();
   if (!gbw.AnyTuplesLeft(cur_tuple, cur_tuple + packrow_length - 1)) {
     mit->NextPackrow();
     return AggregaGroupingResult::AGR_NO_LEFT;
   }
+
+#ifdef DEBUG_AGGREGA_COST
+  const auto &mem_info = MemoryStatisticsOS::Instance()->GetMemInfo();
+  uint64_t mem_available = mem_info.mem_available;
+  uint64_t swap_used = mem_info.swap_used;
+#endif
+
   int64_t uniform_pos = common::NULL_VALUE_64;
   bool skip_packrow = false;
   bool packrow_done = false;
@@ -641,6 +659,32 @@ AggregaGroupingResult AggregationAlgorithm::AggregatePackrow(GroupByWrapper &gbw
       break;
   }
   gbw.CommitResets();
+
+#ifdef DEBUG_AGGREGA_COST
+  {
+    if (mem_available) {
+      const auto mem_info = MemoryStatisticsOS::Instance()->GetMemInfo();
+      int64_t mem_available_chg = mem_info.mem_available - mem_available;
+      int64_t swap_used_chg = mem_info.swap_used - swap_used;
+
+      if (mem_used && (mem_available_chg < 0)) {
+        (*mem_used) -= mem_available_chg;
+      }
+
+      // #ifdef DEBUG_AGGREGA_PACK_COST
+      //			if ((mem_available_chg < (-(1 * 1024))) || (swap_used_chg > (1 * 1024))) {
+      //				TIANMU_LOG(LogCtl_Level::INFO, "AggregatePackrow mem_available_chg: %ld "
+      //					"swap_used_chg: %ld pri_mem_available: %lu mem_available: %lu
+      // pri_swap_used: %lu swap_used: %lu", 					mem_available_chg, swap_used_chg,
+      // mem_available, mem_info.mem_available, swap_used,
+      // mem_info.swap_used);
+      //				// MEMORY_STATISTICS("AGGRE", "PACK");
+      //			}
+      // #endif
+    }
+  }
+#endif
+
   return AggregaGroupingResult::AGR_OK;  // success
 }
 
@@ -873,11 +917,12 @@ void AggregationAlgorithm::TaskFillOutput(GroupByWrapper *gbw, Transaction *ci, 
 
 void AggregationWorkerEnt::TaskAggrePacks(MIIterator *taskIterator, DimensionVector *dims [[maybe_unused]],
                                           MIIterator *mit [[maybe_unused]], CTask *task [[maybe_unused]],
-                                          GroupByWrapper *gbw, Transaction *ci [[maybe_unused]]) {
+                                          GroupByWrapper *gbw, Transaction *ci [[maybe_unused]], uint64_t *mem_used) {
   TIANMU_LOG(LogCtl_Level::DEBUG, "TaskAggrePacks task_id: %d start pack_start: %d pack_end: %d", task->dwTaskId,
              task->dwStartPackno, task->dwEndPackno);
 #ifdef DEBUG_AGGREGA_COST
   std::chrono::high_resolution_clock::time_point start = std::chrono::high_resolution_clock::now();
+  uint64_t mem_available = MemoryStatisticsOS::Instance()->GetMemInfo().mem_available;
 #endif
 
   taskIterator->Rewind();
@@ -886,7 +931,7 @@ void AggregationWorkerEnt::TaskAggrePacks(MIIterator *taskIterator, DimensionVec
     if ((task_pack_num >= task->dwStartPackno) && (task_pack_num <= task->dwEndPackno)) {
       int cur_tuple = (*task->dwPack2cur)[task_pack_num];
       MIInpackIterator mii(*taskIterator);
-      AggregaGroupingResult grouping_result = aa->AggregatePackrow(*gbw, &mii, cur_tuple);
+      AggregaGroupingResult grouping_result = aa->AggregatePackrow(*gbw, &mii, cur_tuple, mem_used);
       if (grouping_result == AggregaGroupingResult::AGR_FINISH)
         break;
       if (grouping_result == AggregaGroupingResult::AGR_KILLED)
@@ -901,11 +946,13 @@ void AggregationWorkerEnt::TaskAggrePacks(MIIterator *taskIterator, DimensionVec
   }
 
 #ifdef DEBUG_AGGREGA_COST
+  int64_t mem_available_chg = MemoryStatisticsOS::Instance()->GetMemInfo().mem_available - mem_available;
   auto diff =
       std::chrono::duration_cast<std::chrono::duration<float>>(std::chrono::high_resolution_clock::now() - start);
   if (diff.count() > tianmu_sysvar_slow_query_record_interval) {
-    TIANMU_LOG(LogCtl_Level::INFO, "TaskAggrePacks task_id: %d spend: %f pack_start: %d pack_end: %d", task->dwTaskId,
-               diff.count(), task->dwStartPackno, task->dwEndPackno);
+    TIANMU_LOG(LogCtl_Level::INFO,
+               "TaskAggrePacks task_id: %d spend: %f pack_start: %d pack_end: %d mem_available_chg: %ld",
+               task->dwTaskId, diff.count(), task->dwStartPackno, task->dwEndPackno, mem_available_chg);
   }
 #endif
 }
@@ -924,7 +971,13 @@ void AggregationWorkerEnt::PrepShardingCopy(MIIterator *mit, GroupByWrapper *gb_
 }
 
 /*Average allocation task*/
-void AggregationWorkerEnt::DistributeAggreTaskAverage(MIIterator &mit) {
+void AggregationWorkerEnt::DistributeAggreTaskAverage(MIIterator &mit, uint64_t *mem_used) {
+#ifdef DEBUG_AGGREGA_COST
+  const auto mem_info = MemoryStatisticsOS::Instance()->GetMemInfo();
+  uint64_t mem_available = mem_info.mem_available;
+  uint64_t swap_used = mem_info.swap_used;
+#endif
+
   Transaction *conn = current_txn_;
   DimensionVector dims(mind->NumOfDimensions());
   std::vector<CTask> vTask;
@@ -1015,10 +1068,20 @@ void AggregationWorkerEnt::DistributeAggreTaskAverage(MIIterator &mit) {
 
   for (size_t i = 0; i < vTask.size(); ++i) {
     GroupByWrapper *gbw = i == 0 ? gb_main : vGBW[i].get();
-    res1.insert(ha_tianmu_engine_->query_thread_pool.add_task(&AggregationWorkerEnt::TaskAggrePacks, this,
-                                                              &taskIterator[i], &dims, &mit, &vTask[i], gbw, conn));
+    res1.insert(ha_tianmu_engine_->query_thread_pool.add_task(
+        &AggregationWorkerEnt::TaskAggrePacks, this, &taskIterator[i], &dims, &mit, &vTask[i], gbw, conn, mem_used));
   }
   res1.get_all_with_except();
+
+#ifdef DEBUG_AGGREGA_COST
+  {
+    int64_t mem_available_chg = MemoryStatisticsOS::Instance()->GetMemInfo().mem_available - mem_available;
+    int64_t swap_used_chg = MemoryStatisticsOS::Instance()->GetMemInfo().swap_used - swap_used;
+    TIANMU_LOG(LogCtl_Level::INFO, "DistributeAggreTaskAverage TASK mem_available_chg: %ld swap_used_chg: %ld",
+               mem_available_chg, swap_used_chg);
+  }
+  MEMORY_STATISTICS("AGGREGA", "TASK");
+#endif
 
   for (size_t i = 0; i < vTask.size(); ++i) {
     // Merge aggreation data together
@@ -1027,6 +1090,16 @@ void AggregationWorkerEnt::DistributeAggreTaskAverage(MIIterator &mit) {
       gb_main->Merge(*(vGBW[i]));
     }
   }
+
+#ifdef DEBUG_AGGREGA_COST
+  {
+    int64_t mem_available_chg = MemoryStatisticsOS::Instance()->GetMemInfo().mem_available - mem_available;
+    int64_t swap_used_chg = MemoryStatisticsOS::Instance()->GetMemInfo().swap_used - swap_used;
+    TIANMU_LOG(LogCtl_Level::INFO, "DistributeAggreTaskAverage MERGE mem_available_chg: %ld swap_used_chg: %ld",
+               mem_available_chg, swap_used_chg);
+  }
+  MEMORY_STATISTICS("AGGREGA", "MERGE");
+#endif
 }
 }  // namespace core
 }  // namespace Tianmu

--- a/storage/tianmu/core/aggregation_algorithm.cpp
+++ b/storage/tianmu/core/aggregation_algorithm.cpp
@@ -248,8 +248,10 @@ void AggregationAlgorithm::MultiDimensionalGroupByScan(GroupByWrapper &gbw, int6
   unsigned int thd_cnt = 1;
   if (tianmu_sysvar_groupby_parallel_degree > 1) {
     if (static_cast<uint64_t>(mit.NumOfTuples()) > tianmu_sysvar_groupby_parallel_rows_minimum) {
-      unsigned int thd_limit = std::thread::hardware_concurrency() * 2;
+      unsigned int thd_limit = std::thread::hardware_concurrency();
+      thd_limit = thd_limit > 8 ? 8 : thd_limit;  // limit no more 8
       thd_cnt = tianmu_sysvar_groupby_parallel_degree > thd_limit ? thd_limit : tianmu_sysvar_groupby_parallel_degree;
+      thd_cnt = tianmu_sysvar_groupby_parallel_degree;
       TIANMU_LOG(LogCtl_Level::DEBUG,
                  "MultiDimensionalGroupByScan multi threads thd_cnt: %d thd_limit: %d NumOfTuples: %d "
                  "groupby_parallel_degree: %d groupby_parallel_rows_minimum: %lld",

--- a/storage/tianmu/core/aggregation_algorithm.h
+++ b/storage/tianmu/core/aggregation_algorithm.h
@@ -53,7 +53,8 @@ class AggregationAlgorithm {
 
   // Return code for AggregatePackrow: 0 - success, 1 - stop aggregation
   // (finished), 5 - pack already aggregated (skip)
-  AggregaGroupingResult AggregatePackrow(GroupByWrapper &gbw, MIIterator *mit, int64_t cur_tuple);
+  AggregaGroupingResult AggregatePackrow(GroupByWrapper &gbw, MIIterator *mit, int64_t cur_tuple,
+                                         uint64_t *mem_used = nullptr);
 
   // No parallel for subquery/join/distinct cases
   bool ParallelAllowed(GroupByWrapper &gbw) {
@@ -99,8 +100,8 @@ class AggregationWorkerEnt {
   int ThreadsUsed() { return m_threads; }
   void Barrier() {}
   void TaskAggrePacks(MIIterator *taskIterator, DimensionVector *dims, MIIterator *mit, CTask *task,
-                      GroupByWrapper *gbw, Transaction *ci);
-  void DistributeAggreTaskAverage(MIIterator &mit);
+                      GroupByWrapper *gbw, Transaction *ci, uint64_t *mem_used = nullptr);
+  void DistributeAggreTaskAverage(MIIterator &mit, uint64_t *mem_used = nullptr);
   void PrepShardingCopy(MIIterator *mit, GroupByWrapper *gb_sharding,
                         std::vector<std::unique_ptr<GroupByWrapper>> *vGBW);
 

--- a/storage/tianmu/core/blocked_mem_table.cpp
+++ b/storage/tianmu/core/blocked_mem_table.cpp
@@ -16,10 +16,14 @@
 */
 
 #include "blocked_mem_table.h"
+#include "util/log_ctl.h"
 
 namespace Tianmu {
 namespace core {
 MemBlockManager::~MemBlockManager() {
+  TIANMU_LOG(LogCtl_Level::INFO, "destructor block_size: %d current_size: %ld allock_num: %d", block_size, current_size,
+             allock_num);
+
   for (auto &it : free_blocks) dealloc(it);
 
   for (auto &it : used_blocks) dealloc(it);
@@ -40,6 +44,7 @@ void *MemBlockManager::GetBlock() {
     } else {
       p = alloc(block_size, mm::BLOCK_TYPE::BLOCK_TEMPORARY);
       current_size += block_size;
+      ++allock_num;
     }
     used_blocks.insert(p);
     return p;
@@ -103,6 +108,9 @@ void BlockedRowMemStorage::Init(int rowl, std::shared_ptr<MemBlockManager> mbm, 
       blocks.push_back(b);
     }
   no_rows = initial_size;
+
+  TIANMU_LOG(LogCtl_Level::INFO, "Init block_size: %d no_rows: %ld rows_in_block: %d row_len: %d min_block_len: %d",
+             block_size, no_rows, rows_in_block, row_len, min_block_len);
 }
 
 void BlockedRowMemStorage::Clear() {

--- a/storage/tianmu/core/blocked_mem_table.h
+++ b/storage/tianmu/core/blocked_mem_table.h
@@ -100,6 +100,7 @@ class MemBlockManager final : public mm::TraceableObject {
   int no_threads{1};
   int64_t current_size{0};
   std::mutex mx;
+  int allock_num{0};
 };
 
 class BlockedRowMemStorage {

--- a/storage/tianmu/core/engine.cpp
+++ b/storage/tianmu/core/engine.cpp
@@ -33,6 +33,7 @@
 #include "core/tools.h"
 #include "core/transaction.h"
 #include "mm/initializer.h"
+#include "mm/memory_statistics.h"
 #include "mysql/thread_pool_priv.h"
 #include "mysqld_thd_manager.h"
 #include "system/file_out.h"
@@ -1374,6 +1375,22 @@ void Engine::LogStat() {
     }
     msg = msg + "queries " + std::to_string(queries) + "/" + std::to_string(global_query_id);
     TIANMU_LOG(LogCtl_Level::INFO, msg.c_str());
+  }
+
+  {
+    const auto &&mem_info = MemoryStatisticsOS::Instance()->GetMemInfo();
+    const auto &&mem_self = MemoryStatisticsOS::Instance()->GetSelfStatm();
+
+    uint64_t mem_available = mem_info.mem_available;
+    uint64_t swap_used = mem_info.swap_used;
+    int64_t mem_available_chg = mem_available - m_mem_available_;
+    int64_t swap_used_chg = swap_used - m_swap_used_;
+    m_mem_available_ = mem_available;
+    m_swap_used_ = swap_used;
+
+    TIANMU_LOG(LogCtl_Level::INFO, "mem_available_chg: %ld swap_used_chg: %ld", mem_available_chg, swap_used_chg);
+
+    MEMORY_STATISTICS("HEATBEAT", "UPDATE");
   }
 
   TIANMU_LOG(LogCtl_Level::DEBUG,

--- a/storage/tianmu/core/engine.cpp
+++ b/storage/tianmu/core/engine.cpp
@@ -224,7 +224,7 @@ int Engine::Init(uint engine_slot) {
   size_t main_size = size_t(tianmu_sysvar_servermainheapsize) << 20;
 
   std::string hugefiledir = tianmu_sysvar_hugefiledir;
-  int hugefilesize = 0;  // unused
+  int hugefilesize = tianmu_sysvar_hugefilesize;  // MB
   if (hugefiledir.empty())
     mm::MemoryManagerInitializer::Instance(0, main_size);
   else

--- a/storage/tianmu/core/engine.h
+++ b/storage/tianmu/core/engine.h
@@ -258,6 +258,8 @@ class Engine final {
   std::condition_variable cv_drop_;
   std::mutex cv_drop_mtx_;
   std::unique_ptr<TaskExecutor> task_executor;
+  uint64_t m_mem_available_ = 0;
+  uint64_t m_swap_used_ = 0;
 };
 
 class ResultSender {

--- a/storage/tianmu/core/temp_table_low.cpp
+++ b/storage/tianmu/core/temp_table_low.cpp
@@ -28,6 +28,7 @@
 #include "core/temp_table.h"
 #include "core/transaction.h"
 #include "exporter/data_exporter.h"
+#include "mm/memory_statistics.h"
 #include "system/fet.h"
 #include "system/io_parameters.h"
 #include "system/tianmu_system.h"
@@ -193,7 +194,7 @@ bool TempTable::OrderByAndMaterialize(
     for (int i = 0; i < task_num; ++i) {
       int pstart = ((i == 0) ? 0 : mod + i * num);
       int pend = mod + (i + 1) * num - 1;
-      TIANMU_LOG(LogCtl_Level::INFO, "create new MIIterator: start pack %d, endpack %d", pstart, pend);
+      TIANMU_LOG(LogCtl_Level::DEBUG, "create new MIIterator: start pack %d, endpack %d", pstart, pend);
 
       auto &mi = mis.emplace_back(*filter.mind_, true);
 
@@ -305,6 +306,11 @@ bool TempTable::OrderByAndMaterialize(
 
   // TIANMU_LOG(LogCtl_Level::INFO, "OrderByAndMaterialize complete global_row %d, limit %d,
   // offset %d", global_row, limit, offset);
+
+#ifdef DEBUG_AGGREGA_COST
+  MEMORY_STATISTICS("AGGREGA", "ORDER_BY");
+#endif
+
   return true;
 }
 

--- a/storage/tianmu/core/value_matching_hashtable.cpp
+++ b/storage/tianmu/core/value_matching_hashtable.cpp
@@ -104,6 +104,11 @@ void ValueMatching_HashTable::Init(int64_t mem_available, int64_t max_no_groups,
   bmanager = std::make_shared<MemBlockManager>(mem_available, 1);
   t.Init(total_width, bmanager, 0, (int)min_block_len);
   Clear();
+
+  TIANMU_LOG(LogCtl_Level::INFO,
+             "Init mem_available: %ld max_no_groups: %ld max_no_rows: %ld total_width: %d input_buffer_width: %d "
+             "matching_width: %d min_block_len: %d",
+             mem_available, max_no_groups, max_no_rows, total_width, input_buffer_width, matching_width, min_block_len);
 }
 
 int64_t ValueMatching_HashTable::ByteSize() {

--- a/storage/tianmu/handler/ha_tianmu.cpp
+++ b/storage/tianmu/handler/ha_tianmu.cpp
@@ -2374,6 +2374,10 @@ static MYSQL_SYSVAR_UINT(insert_max_buffered, tianmu_sysvar_insert_max_buffered,
 static MYSQL_SYSVAR_BOOL(compensation_start, tianmu_sysvar_compensation_start, PLUGIN_VAR_BOOL, "-", nullptr, nullptr,
                          FALSE);
 static MYSQL_SYSVAR_STR(hugefiledir, tianmu_sysvar_hugefiledir, PLUGIN_VAR_READONLY, "-", nullptr, nullptr, "");
+static MYSQL_SYSVAR_UINT(os_least_mem, tianmu_os_least_mem, PLUGIN_VAR_READONLY, "-", nullptr, nullptr, 1, 0,
+                         UINT32_MAX, 0);
+static MYSQL_SYSVAR_UINT(hugefilesize, tianmu_sysvar_hugefilesize, PLUGIN_VAR_READONLY, "-", nullptr, nullptr, 1, 0,
+                         UINT32_MAX, 0);
 static MYSQL_SYSVAR_UINT(cachinglevel, tianmu_sysvar_cachinglevel, PLUGIN_VAR_READONLY, "-", nullptr, nullptr, 1, 0,
                          512, 0);
 static MYSQL_SYSVAR_STR(mm_policy, tianmu_sysvar_mm_policy, PLUGIN_VAR_READONLY, "-", nullptr, nullptr, "");
@@ -2548,6 +2552,8 @@ static struct st_mysql_sys_var *tianmu_showvars[] = {MYSQL_SYSVAR(bg_load_thread
                                                      MYSQL_SYSVAR(groupby_parallel_rows_minimum),
                                                      MYSQL_SYSVAR(slow_query_record_interval),
                                                      MYSQL_SYSVAR(hugefiledir),
+                                                     MYSQL_SYSVAR(hugefilesize),
+                                                     MYSQL_SYSVAR(os_least_mem),
                                                      MYSQL_SYSVAR(index_cache_size),
                                                      MYSQL_SYSVAR(index_search),
                                                      MYSQL_SYSVAR(enable_rowstore),

--- a/storage/tianmu/mm/memory_block.h
+++ b/storage/tianmu/mm/memory_block.h
@@ -26,6 +26,7 @@ enum class BLOCK_TYPE : char {
   BLOCK_COMPRESSED,
   BLOCK_UNCOMPRESSED,
   BLOCK_TEMPORARY,
+  BLOCK_HUGE,
   BLOCK_FIXED  // Used in rc_realloc when pointer != nullptr
 };
 

--- a/storage/tianmu/mm/memory_handling_policy.cpp
+++ b/storage/tianmu/mm/memory_handling_policy.cpp
@@ -169,6 +169,13 @@ void *MemoryHandling::alloc(size_t size, BLOCK_TYPE type, TraceableObject *owner
   std::scoped_lock guard(m_mutex);
   HeapPolicy *heap;
 
+  if (type != BLOCK_TYPE::BLOCK_HUGE && tianmu_sysvar_hugefilesize > 0 && tianmu_os_least_mem > 0) {
+    uint64_t mem_available = MemoryStatisticsOS::Instance()->GetMemInfo().mem_available;  // KB
+    if (mem_available <= (1024 * tianmu_os_least_mem)) {
+      type = BLOCK_TYPE::BLOCK_HUGE;
+    }
+  }
+
   ASSERT(size < (size_t)(1 << 31), "Oversized alloc request!");
   // choose appropriate heap for this request
   switch (type) {
@@ -192,6 +199,9 @@ void *MemoryHandling::alloc(size_t size, BLOCK_TYPE type, TraceableObject *owner
         }
       else
         heap = m_main_heap;
+      break;
+    case BLOCK_TYPE::BLOCK_HUGE:
+      heap = (m_huge_heap->getHeapStatus() == HEAP_STATUS::HEAP_SUCCESS) ? m_huge_heap : m_main_heap;
       break;
     default:
       heap = m_main_heap;

--- a/storage/tianmu/mm/memory_statistics.cpp
+++ b/storage/tianmu/mm/memory_statistics.cpp
@@ -1,0 +1,32 @@
+/* Copyright (c) 2022 StoneAtom, Inc. All rights reserved.
+   Use is subject to license terms
+
+   This program is free software; you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation; version 2 of the License.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program; if not, write to the Free Software
+   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1335 USA
+*/
+
+#include "mm/memory_statistics.h"
+
+namespace Tianmu {
+
+MemoryStatisticsOS *MemoryStatisticsOS::instance = nullptr;
+
+void SplitString(const std::string &str, const char pattern, std::vector<std::string> &res) {
+  std::stringstream input(str);
+  std::string temp;
+  while (getline(input, temp, pattern)) {
+    res.push_back(temp);
+  }
+}
+
+}  // namespace Tianmu

--- a/storage/tianmu/mm/memory_statistics.h
+++ b/storage/tianmu/mm/memory_statistics.h
@@ -1,0 +1,208 @@
+/* Copyright (c) 2022 StoneAtom, Inc. All rights reserved.
+   Use is subject to license terms
+
+   This program is free software; you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation; version 2 of the License.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program; if not, write to the Free Software
+   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1335 USA
+*/
+#ifndef TIANMU_MEMORY_STATICS_H_
+#define TIANMU_MEMORY_STATICS_H_
+
+#include <cstdint>
+#include <fstream>
+#include <sstream>
+#include <string>
+#include <vector>
+
+#include <errno.h>
+#include <fcntl.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <unistd.h>
+
+#include "common/assert.h"
+#include "util/log_ctl.h"
+
+namespace Tianmu {
+
+static const char *filename_self_statm = "/proc/self/statm";
+static const char *filename_meminfo = "/proc/meminfo";
+
+void SplitString(const std::string &str, const char pattern, std::vector<std::string> &res);
+
+class MemoryStatisticsOS {
+ public:
+  // In number of bytes.
+  struct DataSelfStatm {
+    uint64_t virt;
+    uint64_t resident;
+    uint64_t shared;
+    uint64_t code;
+    uint64_t data_and_stack;
+  };
+
+  struct DataMemInfo {
+    uint64_t mem_total;
+    uint64_t mem_free;
+    uint64_t mem_available;
+    uint64_t buffers;
+    uint64_t cached;
+    uint64_t swap_cached;
+    uint64_t swap_total;
+    uint64_t swap_free;
+    uint64_t swap_used;
+    uint64_t free_total;
+  };
+
+  // Thread-safe.
+  DataSelfStatm GetSelfStatm() const {
+    DataSelfStatm data;
+
+    constexpr size_t buf_size = 1024;
+    char buf[buf_size] = {0};
+
+    ssize_t res = 0;
+
+    do {
+      res = ::pread(fd_self_statm, buf, buf_size, 0);
+
+      if (-1 == res) {
+        if (errno == EINTR)
+          continue;
+
+        TIANMU_LOG(LogCtl_Level::ERROR, "MemoryStatisticsOS pread fail, errno: %d strerrno: %s", errno,
+                   strerror(errno));
+        return data;
+      }
+
+      if (res < 0) {
+        TIANMU_LOG(LogCtl_Level::ERROR, "MemoryStatisticsOS pread fail, errno: %d strerrno: %s", errno,
+                   strerror(errno));
+        return data;
+      }
+
+      break;
+    } while (true);
+
+    std::vector<std::string> vec_str;
+    SplitString(buf, ' ', vec_str);
+    ASSERT(vec_str.size() == 7);
+
+    data.virt = std::atoll(vec_str[0].c_str());
+    data.resident = std::atoll(vec_str[1].c_str());
+    data.shared = std::atoll(vec_str[2].c_str());
+    data.code = std::atoll(vec_str[3].c_str());
+    data.data_and_stack = std::atoll(vec_str[5].c_str());
+
+    return data;
+  }
+
+  // Thread-safe.
+  DataMemInfo GetMemInfo() {
+    DataMemInfo data;
+
+    std::ifstream in(filename_meminfo, std::ios_base::in);
+
+    constexpr size_t line_num = 16;
+    std::vector<std::string> vec_buf;
+    vec_buf.reserve(line_num);
+    char name[20] = {0};
+
+    for (size_t i = 0; i < line_num; ++i) {
+      std::string line;
+      if (!std::getline(in, line)) {
+        TIANMU_LOG(LogCtl_Level::ERROR, "GetMemInfo fgets fail, line: %d errno: %d strerrno: %s", i, errno,
+                   strerror(errno));
+        return data;
+      }
+
+      vec_buf.emplace_back(line);
+    }
+
+    sscanf(vec_buf[0].c_str(), "%s%lu", name, &data.mem_total);
+    sscanf(vec_buf[1].c_str(), "%s%lu", name, &data.mem_free);
+    sscanf(vec_buf[2].c_str(), "%s%lu", name, &data.mem_available);
+    sscanf(vec_buf[3].c_str(), "%s%lu", name, &data.buffers);
+    sscanf(vec_buf[4].c_str(), "%s%lu", name, &data.cached);
+    sscanf(vec_buf[5].c_str(), "%s%lu", name, &data.swap_cached);
+
+    sscanf(vec_buf[14].c_str(), "%s%lu", name, &data.swap_total);
+    sscanf(vec_buf[15].c_str(), "%s%lu", name, &data.swap_free);
+
+    data.free_total = data.mem_free + data.buffers + data.cached;
+    data.swap_used = data.swap_total - data.swap_free;
+
+    return data;
+  }
+
+ public:
+  static MemoryStatisticsOS *Instance() {
+    if (!instance) {
+      instance = new MemoryStatisticsOS();
+    }
+
+    return instance;
+  }
+
+ private:
+  MemoryStatisticsOS() {
+    auto open_file = ([&](const char *filename, int &fd) {
+      fd = ::open(filename, O_RDONLY | O_CLOEXEC);
+      if (-1 == fd_self_statm) {
+        TIANMU_LOG(LogCtl_Level::ERROR, "MemoryStatisticsOS open fail, errno: %d strerrno: %s", errno, strerror(errno));
+        ASSERT(0, "MemoryStatisticsOS open fail " + std::string(filename));
+      }
+    });
+
+    open_file(filename_self_statm, fd_self_statm);
+  }
+
+  ~MemoryStatisticsOS() {
+    auto close_file = ([&](int fd) {
+      if (0 != ::close(fd)) {
+        TIANMU_LOG(LogCtl_Level::ERROR, "MemoryStatisticsOS close fail, errno: %d strerrno: %s", errno,
+                   strerror(errno));
+      }
+    });
+
+    close_file(fd_self_statm);
+    fd_self_statm = -1;
+  }
+
+ private:
+  int fd_self_statm = -1;
+  static MemoryStatisticsOS *instance;
+};
+
+#ifndef MEMORY_STATISTICS
+#define MEMORY_STATISTICS(model, deal)                                                                                \
+  do {                                                                                                                \
+    {                                                                                                                 \
+      const auto mem_info = MemoryStatisticsOS::Instance()->GetMemInfo();                                             \
+      const auto mem_self = MemoryStatisticsOS::Instance()->GetSelfStatm();                                           \
+      TIANMU_LOG(                                                                                                     \
+          LogCtl_Level::INFO,                                                                                         \
+          "[ %s ] [ %s ] { mem_total: %lu mem_free: %lu mem_available: %lu buffers: %lu cached: %lu swap_cached: %lu" \
+          " swap_total: %lu swap_free: %lu swap_used: %lu free_total: %lu } { virt: "                                 \
+          "%lu resident: %lu shared: %lu data_and_stack: %lu }",                                                      \
+          model, deal, mem_info.mem_total, mem_info.mem_free, mem_info.mem_available, mem_info.buffers,               \
+          mem_info.cached, mem_info.swap_cached, mem_info.swap_total, mem_info.swap_free, mem_info.swap_used,         \
+          mem_info.free_total, mem_self.virt, mem_self.resident, mem_self.shared, mem_self.data_and_stack);           \
+    }                                                                                                                 \
+  } while (0);
+#endif  // MEMORY_STATISTICS
+
+}  // namespace Tianmu
+
+#endif  // TIANMU_MEMORY_STATICS_H_

--- a/storage/tianmu/system/configuration.cpp
+++ b/storage/tianmu/system/configuration.cpp
@@ -25,6 +25,8 @@ char *tianmu_sysvar_cachefolder;
 char *tianmu_sysvar_hugefiledir;
 char *tianmu_sysvar_mm_policy;
 char *tianmu_sysvar_mm_releasepolicy;
+unsigned int tianmu_os_least_mem;
+unsigned int tianmu_sysvar_hugefilesize;
 unsigned int tianmu_sysvar_allowmysqlquerypath;
 unsigned int tianmu_sysvar_bg_load_threads;
 unsigned int tianmu_sysvar_cachereleasethreshold;

--- a/storage/tianmu/system/configuration.h
+++ b/storage/tianmu/system/configuration.h
@@ -38,6 +38,8 @@ extern char *tianmu_sysvar_cachefolder;
 extern char *tianmu_sysvar_hugefiledir;
 extern char *tianmu_sysvar_mm_policy;
 extern char *tianmu_sysvar_mm_releasepolicy;
+extern unsigned int tianmu_os_least_mem;
+extern unsigned int tianmu_sysvar_hugefilesize;
 extern unsigned int tianmu_sysvar_allowmysqlquerypath;
 extern unsigned int tianmu_sysvar_bg_load_threads;
 extern unsigned int tianmu_sysvar_cachereleasethreshold;


### PR DESCRIPTION
    fix(tianmu): fix OOM when too many data and aggregate  (#949,#1291)
    1. limit aggregate threads mo more 8
    2. use MMAP for lasrge memory to reduce RAM OOM


<!--

Thank you for contributing to StoneDB!

PR Title Format: <type>(<scope>): description to this pr (#issue_id)
e.g.
fix(util): fix sth..... (#1)

-->

## Summary about this PR
<!--

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".
e.g.:
Issue: close #1

-->

Issue Number: close #949 #1291 


## Tests Check List
<!-- At least one of next options must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

## Changelog
<!-- At least one of next options must be included. -->

- [x] New Feature
- [x] Bug Fix
- [ ] Performance Improvement
- [ ] Build/Testing/CI/CD
- [ ] Documentation
- [ ] Not for changelog (changelog entry is not required)

## Documentation
<!-- At least one of next options must be included. -->

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
