### PR TITLE
fix(core): rm incorrect boundary check on rough check with between #1344

### DIFF
--- a/mysql-test/suite/tianmu/r/signed_boundary.result
+++ b/mysql-test/suite/tianmu/r/signed_boundary.result
@@ -2,6 +2,8 @@
 # Test signed boundary
 #
 DROP DATABASE IF EXISTS signed_boundary;
+CREATE DATABASE signed_boundary;
+USE signed_boundary;
 CREATE TABLE int32_(c_max int, c_min int) engine = tianmu;
 INSERT INTO int32_ values(-2147483647, 2147483647);
 INSERT INTO int32_ values(-2147483648, 2147483647);
@@ -16,3 +18,47 @@ ERROR 22003: Out of range[-9223372036854775807, 9223372036854775807] for column 
 INSERT INTO int64_ values(-9223372036854775806, 9223372036854775808);
 ERROR 22003: Out of range value for column 'c_min' at row 1
 DROP TABLE int64_;
+create table t1 (
+value64  bigint  not null,
+value32  integer          not null
+);
+insert into t1 values(9223372036854775806, 1);
+insert into t1 values(9223372036854775807, 2);
+insert into t1 values(-9223372036854775806, 2);
+select * from t1;
+value64	value32
+9223372036854775806	1
+9223372036854775807	2
+-9223372036854775806	2
+select * from t1 where value64= 9223372036854775807;
+value64	value32
+9223372036854775807	2
+select * from t1 where value64= -9223372036854775806;
+value64	value32
+-9223372036854775806	2
+select * from t1 where value64 between 9223372036854775806 and 9223372036854775807;
+value64	value32
+9223372036854775806	1
+9223372036854775807	2
+drop table t1;
+create table txxx(a double);
+insert into txxx values(1.79769313486231570814527423731704357e+308);
+insert into txxx values(-1.79769313486231570814527423731704357e+308);
+select * from txxx;
+a
+1.7976931348623157e308
+-1.7976931348623157e308
+select * from txxx where a = -1.7976931348623157e308;
+a
+-1.7976931348623157e308
+select * from txxx where a = 1.7976931348623157e308;
+a
+1.7976931348623157e308
+select * from txxx where a between 1.7976931348623157e308 and 1.7976931348623157e308;
+a
+1.7976931348623157e308
+select * from txxx where a between -1.7976931348623157e308 and -1.7976931348623157e308;
+a
+-1.7976931348623157e308
+drop table txxx;
+DROP DATABASE signed_boundary;

--- a/mysql-test/suite/tianmu/t/signed_boundary.test
+++ b/mysql-test/suite/tianmu/t/signed_boundary.test
@@ -8,6 +8,8 @@
 DROP DATABASE IF EXISTS signed_boundary;
 --enable_warnings
 
+CREATE DATABASE signed_boundary;
+USE signed_boundary;
 # int32 limit
 CREATE TABLE int32_(c_max int, c_min int) engine = tianmu;
 INSERT INTO int32_ values(-2147483647, 2147483647);
@@ -25,3 +27,30 @@ INSERT INTO int64_ values(-9223372036854775807, 9223372036854775807);
 --error 1264
 INSERT INTO int64_ values(-9223372036854775806, 9223372036854775808);
 DROP TABLE int64_;
+
+# fix issue #1344, select * from t where col = 9223372036854775807,1.797693134862315708e+308, -1.797693134862315708e+308
+create table t1 (
+    value64  bigint  not null,
+    value32  integer          not null
+    );
+
+insert into t1 values(9223372036854775806, 1);
+insert into t1 values(9223372036854775807, 2);
+insert into t1 values(-9223372036854775806, 2);
+select * from t1;
+select * from t1 where value64= 9223372036854775807;
+select * from t1 where value64= -9223372036854775806;
+select * from t1 where value64 between 9223372036854775806 and 9223372036854775807;
+drop table t1;
+
+create table txxx(a double);
+insert into txxx values(1.79769313486231570814527423731704357e+308);
+insert into txxx values(-1.79769313486231570814527423731704357e+308);
+select * from txxx;
+select * from txxx where a = -1.7976931348623157e308;
+select * from txxx where a = 1.7976931348623157e308;
+select * from txxx where a between 1.7976931348623157e308 and 1.7976931348623157e308;
+select * from txxx where a between -1.7976931348623157e308 and -1.7976931348623157e308;
+drop table txxx;
+
+DROP DATABASE signed_boundary;

--- a/storage/tianmu/core/tianmu_attr_exeq_rs.cpp
+++ b/storage/tianmu/core/tianmu_attr_exeq_rs.cpp
@@ -562,11 +562,13 @@ common::RoughSetValue TianmuAttr::RoughCheckBetween(int pack, int64_t v1, int64_
                                                                // and then consider negation
   bool is_float = Type().IsFloat();
   auto const &dpn(get_dpn(pack));
-  if (!is_float && (v1 == common::PLUS_INF_64 || v2 == common::MINUS_INF_64)) {
-    res = common::RoughSetValue::RS_NONE;
-  } else if (is_float && (v1 == *(int64_t *)&common::PLUS_INF_DBL || v2 == *(int64_t *)&common::MINUS_INF_DBL)) {
-    res = common::RoughSetValue::RS_NONE;
-  } else if (!is_float && (v1 > dpn.max_i || v2 < dpn.min_i)) {
+
+  // before:
+  // if(v1 == common::PLUS_INF_64 || v2 == common::MINUS_INF_64) --> RS_NONE
+  // if(is_float && (v1 == *(int64_t *)&common::PLUS_INF_DBL || v2 == *(int64_t *)&common::MINUS_INF_DBL)) --> RS_NONE
+  // actually the v1 or v2 equal to boundary is illegal and it will cause empty result when condition
+  // like `where col = PLUS_INF_64`, `where col = PLUS_INF_DBL`, `where col = MINUS_INF_DBL`
+  if (!is_float && (v1 > dpn.max_i || v2 < dpn.min_i)) {
     res = common::RoughSetValue::RS_NONE;
   } else if (is_float && (*(double *)&v1 > dpn.max_d || *(double *)&v2 < dpn.min_d)) {
     res = common::RoughSetValue::RS_NONE;


### PR DESCRIPTION
<!--

Thank you for contributing to StoneDB!

PR Title Format: <type>(<scope>): description to this pr (#issue_id)
e.g.
fix(util): fix sth..... (#1)

-->

## Summary about this PR
<!--

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".
e.g.:
Issue: close #1

-->
1. change file(tianmu_attr_exeq_rs.cpp) format from dos 2 unix

2. rm incorrect between check, actually the v1 or v2 equal to boundary is illegal and it will cause empty result when condition like `where col = PLUS_INF_64`, `where col = PLUS_INF_DBL`, `where col = MINUS_INF_DBL`:

```
common::RoughSetValue TianmuAttr::RoughCheckBetween(int pack, int64_t v1, int64_
                                                                // and then consider negation
   bool is_float = Type().IsFloat();
   auto const &dpn(get_dpn(pack));
-  if (!is_float && (v1 == common::PLUS_INF_64 || v2 == common::MINUS_INF_64)) {
-    res = common::RoughSetValue::RS_NONE;
-  } else if (is_float && (v1 == *(int64_t *)&common::PLUS_INF_DBL || v2 == *(int64_t *)&common::MINUS_INF_DBL)) {
-    res = common::RoughSetValue::RS_NONE;
-  } else if (!is_float && (v1 > dpn.max_i || v2 < dpn.min_i)) {
+  if (!is_float && (v1 > dpn.max_i || v2 < dpn.min_i)) {
```

Issue Number: close #1344


## Tests Check List
<!-- At least one of next options must be included. -->

- [ ] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

## Changelog
<!-- At least one of next options must be included. -->

- [ ] New Feature
- [x] Bug Fix
- [ ] Performance Improvement
- [ ] Build/Testing/CI/CD
- [ ] Documentation
- [ ] Not for changelog (changelog entry is not required)

## Documentation
<!-- At least one of next options must be included. -->

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
