### PR TITLE
    fix(tianmu): fix mysqld crash when exec query limit 0 (#1394)

### DIFF
--- a/mysql-test/suite/tianmu/r/issue1394.result
+++ b/mysql-test/suite/tianmu/r/issue1394.result
@@ -1,0 +1,79 @@
+DROP DATABASE IF EXISTS issue1394_test;
+CREATE DATABASE issue1394_test;
+USE issue1394_test;
+create table c(c1 int, c2 varchar(2)) engine=TIANMU;
+create table d(d1 int, d2 varchar(2)) engine=TIANMU;
+insert into c values(1, 'c1');
+insert into c values(2, 'c2');
+insert into c values(null, 'c3');
+insert into d values(1, 'd1');
+insert into d values(2, 'd2');
+insert into d values(null, 'd3');
+select * from d;
+d1	d2
+1	d1
+2	d2
+NULL	d3
+select * from d limit 0;
+d1	d2
+select * from d limit 1;
+d1	d2
+1	d1
+select * from d where d1=1 limit 0;
+d1	d2
+select * from d where d1=1 limit 1;
+d1	d2
+1	d1
+select * from c where  exists ( select * from d where d1=1  limit 0);
+c1	c2
+1	c1
+2	c2
+NULL	c3
+select * from c where  exists ( select * from d where d1=1  limit 1);
+c1	c2
+1	c1
+2	c2
+NULL	c3
+select * from c where  exists ( select * from d where d1=1  limit 0,1) limit 0;
+c1	c2
+select * from c where  exists ( select * from d where d1=1  limit 0,1) limit 1;
+c1	c2
+1	c1
+select * from c where  exists ( select * from d where d1=1  limit 0) limit 0;
+c1	c2
+select * from c where  exists ( select * from d where d1=1  limit 1) limit 1;
+c1	c2
+1	c1
+SELECT * FROM c RIGHT OUTER JOIN d ON c.c1 = d.d1 WHERE d.d1 IS NULL;
+c1	c2	d1	d2
+NULL	NULL	NULL	d3
+SELECT * FROM c RIGHT OUTER JOIN d ON c.c1 = d.d1 WHERE d.d1 IS NULL limit 1;
+c1	c2	d1	d2
+NULL	NULL	NULL	d3
+SELECT * FROM c RIGHT OUTER JOIN d ON c.c1 = d.d1 WHERE d.d1 IS NULL limit 0;
+c1	c2	d1	d2
+SELECT * FROM c RIGHT OUTER JOIN d ON c.c1 = d.d1 WHERE d.d1 IS NOT NULL;
+c1	c2	d1	d2
+1	c1	1	d1
+2	c2	2	d2
+SELECT * FROM c RIGHT OUTER JOIN d ON c.c1 = d.d1 WHERE d.d1 IS NOT NULL limit 1;
+c1	c2	d1	d2
+1	c1	1	d1
+SELECT * FROM c RIGHT OUTER JOIN d ON c.c1 = d.d1 WHERE d.d1 IS NOT NULL limit 0;
+c1	c2	d1	d2
+SELECT * FROM c INNER JOIN d ON c.c1 = d.d1 WHERE d.d1 IS NULL;
+c1	c2	d1	d2
+SELECT * FROM c INNER JOIN d ON c.c1 = d.d1 WHERE d.d1 IS NULL limit 1;
+c1	c2	d1	d2
+SELECT * FROM c INNER JOIN d ON c.c1 = d.d1 WHERE d.d1 IS NULL limit 0;
+c1	c2	d1	d2
+SELECT * FROM c INNER JOIN d ON c.c1 = d.d1 WHERE d.d1 IS NOT NULL;
+c1	c2	d1	d2
+1	c1	1	d1
+2	c2	2	d2
+SELECT * FROM c INNER JOIN d ON c.c1 = d.d1 WHERE d.d1 IS NOT NULL limit 1;
+c1	c2	d1	d2
+1	c1	1	d1
+SELECT * FROM c INNER JOIN d ON c.c1 = d.d1 WHERE d.d1 IS NOT NULL limit 0;
+c1	c2	d1	d2
+DROP DATABASE issue1394_test;

--- a/mysql-test/suite/tianmu/t/issue1394.test
+++ b/mysql-test/suite/tianmu/t/issue1394.test
@@ -1,0 +1,83 @@
+--source include/have_tianmu.inc
+
+--disable_warnings
+DROP DATABASE IF EXISTS issue1394_test;
+--enable_warnings
+
+CREATE DATABASE issue1394_test;
+
+USE issue1394_test;
+
+--disable_warnings
+
+## DDL
+ 
+create table c(c1 int, c2 varchar(2)) engine=TIANMU;
+ 
+create table d(d1 int, d2 varchar(2)) engine=TIANMU;
+
+## insert data
+
+insert into c values(1, 'c1');
+ 
+insert into c values(2, 'c2');
+ 
+insert into c values(null, 'c3');
+ 
+insert into d values(1, 'd1');
+ 
+insert into d values(2, 'd2');
+ 
+insert into d values(null, 'd3');
+
+## query
+
+select * from d;
+
+select * from d limit 0;
+
+select * from d limit 1;
+
+select * from d where d1=1 limit 0;
+
+select * from d where d1=1 limit 1;
+
+select * from c where  exists ( select * from d where d1=1  limit 0);
+
+select * from c where  exists ( select * from d where d1=1  limit 1);
+
+select * from c where  exists ( select * from d where d1=1  limit 0,1) limit 0;
+
+select * from c where  exists ( select * from d where d1=1  limit 0,1) limit 1;
+
+select * from c where  exists ( select * from d where d1=1  limit 0) limit 0;
+
+select * from c where  exists ( select * from d where d1=1  limit 1) limit 1;
+
+SELECT * FROM c RIGHT OUTER JOIN d ON c.c1 = d.d1 WHERE d.d1 IS NULL;
+
+SELECT * FROM c RIGHT OUTER JOIN d ON c.c1 = d.d1 WHERE d.d1 IS NULL limit 1;
+
+SELECT * FROM c RIGHT OUTER JOIN d ON c.c1 = d.d1 WHERE d.d1 IS NULL limit 0;
+
+SELECT * FROM c RIGHT OUTER JOIN d ON c.c1 = d.d1 WHERE d.d1 IS NOT NULL;
+
+SELECT * FROM c RIGHT OUTER JOIN d ON c.c1 = d.d1 WHERE d.d1 IS NOT NULL limit 1;
+
+SELECT * FROM c RIGHT OUTER JOIN d ON c.c1 = d.d1 WHERE d.d1 IS NOT NULL limit 0;
+
+SELECT * FROM c INNER JOIN d ON c.c1 = d.d1 WHERE d.d1 IS NULL;
+
+SELECT * FROM c INNER JOIN d ON c.c1 = d.d1 WHERE d.d1 IS NULL limit 1;
+
+SELECT * FROM c INNER JOIN d ON c.c1 = d.d1 WHERE d.d1 IS NULL limit 0;
+
+SELECT * FROM c INNER JOIN d ON c.c1 = d.d1 WHERE d.d1 IS NOT NULL;
+
+SELECT * FROM c INNER JOIN d ON c.c1 = d.d1 WHERE d.d1 IS NOT NULL limit 1;
+
+SELECT * FROM c INNER JOIN d ON c.c1 = d.d1 WHERE d.d1 IS NOT NULL limit 0;
+
+## clean test table
+
+DROP DATABASE issue1394_test;

--- a/storage/tianmu/core/engine_execute.cpp
+++ b/storage/tianmu/core/engine_execute.cpp
@@ -422,6 +422,13 @@ QueryRouteTo Engine::Execute(THD *thd, LEX *lex, Query_result *result_output, SE
     }
   }
 
+  for (SELECT_LEX *sl = selects_list; sl; sl = sl->next_select()) {
+    if (sl->join->m_select_limit == 0) {
+      exec_direct = true;
+      break;
+    }
+  }
+
   if (exec_direct) {
     return join_exec();
   }


### PR DESCRIPTION
   Cause: tianmu engine cannot process this scenario when limit=0 and cannot get conds, resulting in crash
    Solution: limit 0 is executed without tianmu

<!--

Thank you for contributing to StoneDB!

PR Title Format: <type>(<scope>): description to this pr (#issue_id)
e.g.
fix(util): fix sth..... (#1)

-->

## Summary about this PR
<!--

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".
e.g.:
Issue: close #1

-->

Issue Number: close #1394 


## Tests Check List
<!-- At least one of next options must be included. -->

- [ ] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

## Changelog
<!-- At least one of next options must be included. -->

- [ ] New Feature
- [x] Bug Fix
- [ ] Performance Improvement
- [ ] Build/Testing/CI/CD
- [ ] Documentation
- [ ] Not for changelog (changelog entry is not required)

## Documentation
<!-- At least one of next options must be included. -->

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
