### PR TITLE
fix(tianmu):(Primary/Secondary)Error 1032 occasionally occurs during …

### DIFF
--- a/mysql-test/suite/tianmu/r/issue1325.result
+++ b/mysql-test/suite/tianmu/r/issue1325.result
@@ -134,15 +134,4 @@ student_score	CREATE TABLE `student_score` (
 DROP DATABASE issue1325_test;
 include/sync_slave_sql_with_master.inc
 # on slave:
-show databases;
-Database
-information_schema
-cache
-mtr
-mysql
-performance_schema
-sys
-sys_tianmu
-test
-tianmu_data
 stop slave;

--- a/mysql-test/suite/tianmu/r/issue1464.result
+++ b/mysql-test/suite/tianmu/r/issue1464.result
@@ -1,0 +1,51 @@
+include/master-slave.inc
+[connection master]
+# on master:
+DROP DATABASE IF EXISTS issue1464_test;
+CREATE DATABASE issue1464_test;
+USE issue1464_test;
+include/sync_slave_sql_with_master.inc
+# on slave:
+USE issue1464_test;
+# on master:
+create table ttt(id varchar(64) primary key,name varchar(10))engine=innodb;
+insert into ttt values('0000352b6b4f4011bd18da7176e22c03','AAA');
+insert into ttt values('000246c51ca745f893a705f1699e9b2a','BBB');
+insert into ttt values('00049c87d9c64c498e004f6b08f1dd38','CCC');
+delete from ttt where id='0000352b6b4f4011bd18da7176e22c03';
+select * from ttt order by id;
+id	name
+000246c51ca745f893a705f1699e9b2a	BBB
+00049c87d9c64c498e004f6b08f1dd38	CCC
+include/sync_slave_sql_with_master.inc
+# on slave:
+show create table ttt;
+Table	Create Table
+ttt	CREATE TABLE `ttt` (
+  `id` varchar(64) NOT NULL,
+  `name` varchar(10) DEFAULT NULL,
+  PRIMARY KEY (`id`)
+) ENGINE=TIANMU DEFAULT CHARSET=latin1
+select * from ttt order by id;
+id	name
+000246c51ca745f893a705f1699e9b2a	BBB
+00049c87d9c64c498e004f6b08f1dd38	CCC
+# on master:
+insert into ttt values('0000352b6b4f4011bd18da7176e22c03','AAA');
+update ttt set name='name_' where id='000246c51ca745f893a705f1699e9b2a';
+select * from ttt order by id;
+id	name
+0000352b6b4f4011bd18da7176e22c03	AAA
+000246c51ca745f893a705f1699e9b2a	name_
+00049c87d9c64c498e004f6b08f1dd38	CCC
+include/sync_slave_sql_with_master.inc
+# on slave:
+select * from ttt order by id;
+id	name
+0000352b6b4f4011bd18da7176e22c03	AAA
+000246c51ca745f893a705f1699e9b2a	name_
+00049c87d9c64c498e004f6b08f1dd38	CCC
+# on master:
+DROP DATABASE issue1464_test;
+include/sync_slave_sql_with_master.inc
+stop slave;

--- a/mysql-test/suite/tianmu/t/issue1325.test
+++ b/mysql-test/suite/tianmu/t/issue1325.test
@@ -110,5 +110,4 @@ DROP DATABASE issue1325_test;
 
 --source include/sync_slave_sql_with_master.inc
 --echo # on slave:
-show databases;
 stop slave;

--- a/mysql-test/suite/tianmu/t/issue1464-slave.opt
+++ b/mysql-test/suite/tianmu/t/issue1464-slave.opt
@@ -1,0 +1,2 @@
+--tianmu_mandatory=ON
+--tianmu_no_key_error=ON

--- a/mysql-test/suite/tianmu/t/issue1464.test
+++ b/mysql-test/suite/tianmu/t/issue1464.test
@@ -1,0 +1,44 @@
+--source include/have_tianmu.inc
+--source include/have_binlog_format_row.inc
+--disable_warnings
+--source include/master-slave.inc
+--enable_warnings
+
+connection master;
+--echo # on master:
+--disable_warnings
+DROP DATABASE IF EXISTS issue1464_test;
+--enable_warnings
+CREATE DATABASE issue1464_test;
+USE issue1464_test;
+--source include/sync_slave_sql_with_master.inc
+--echo # on slave:
+USE issue1464_test;
+
+connection master;
+--echo # on master:
+create table ttt(id varchar(64) primary key,name varchar(10))engine=innodb;
+insert into ttt values('0000352b6b4f4011bd18da7176e22c03','AAA');
+insert into ttt values('000246c51ca745f893a705f1699e9b2a','BBB');
+insert into ttt values('00049c87d9c64c498e004f6b08f1dd38','CCC');
+delete from ttt where id='0000352b6b4f4011bd18da7176e22c03';
+select * from ttt order by id;
+--source include/sync_slave_sql_with_master.inc
+--echo # on slave:
+show create table ttt;
+select * from ttt order by id;
+
+connection master;
+--echo # on master:
+insert into ttt values('0000352b6b4f4011bd18da7176e22c03','AAA');
+update ttt set name='name_' where id='000246c51ca745f893a705f1699e9b2a';
+select * from ttt order by id;
+--source include/sync_slave_sql_with_master.inc
+--echo # on slave:
+select * from ttt order by id;
+
+connection master;
+--echo # on master:
+DROP DATABASE issue1464_test;
+--source include/sync_slave_sql_with_master.inc
+stop slave;

--- a/storage/tianmu/handler/ha_tianmu.cpp
+++ b/storage/tianmu/handler/ha_tianmu.cpp
@@ -1035,7 +1035,6 @@ void ha_tianmu::position([[maybe_unused]] const uchar *record) {
   if (table->in_use->slave_thread && table->s->primary_key != MAX_INDEXES) {
     /* Copy primary key as the row reference */
     KEY *key_info = table->key_info + table->s->primary_key;
-    key_copy(ref, (uchar *)record, key_info, key_info->key_length);
     ref_length = key_info->key_length;
     active_index = table->s->primary_key;
   } else {


### PR DESCRIPTION
…primary/secondary synchronization if UUIDs are used as the primary key(#1464)

Cause of the problem:
When performing a primary key scan under the master slave, "ha_tianmu:: position()" is called first to obtain the primary key value from the "record", However, in this scenario, after calling the "key_copy()" function, the "record" will be cleared, resulting in the subsequent "GetKeys()" obtaining a null primary key value. Solution:
Because the value "handler->ref" is not used in the future, you can simply delete the call to "key_copy()".

<!--

Thank you for contributing to StoneDB!

PR Title Format: <type>(<scope>): description to this pr (#issue_id)
e.g.
fix(util): fix sth..... (#1)

-->

## Summary about this PR
<!--

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".
e.g.:
Issue: close #1

-->

Issue Number: close #1464


## Tests Check List
<!-- At least one of next options must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

## Changelog
<!-- At least one of next options must be included. -->

- [ ] New Feature
- [x] Bug Fix
- [ ] Performance Improvement
- [ ] Build/Testing/CI/CD
- [ ] Documentation
- [ ] Not for changelog (changelog entry is not required)

## Documentation
<!-- At least one of next options must be included. -->

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
