### PR TITLE
fix(tianmu):The mysqld is crashed when you are starting replication.(#1523)

### DIFF
--- a/mysql-test/suite/tianmu/r/issue1523.result
+++ b/mysql-test/suite/tianmu/r/issue1523.result
@@ -1,0 +1,156 @@
+include/master-slave.inc
+[connection master]
+# on master:
+DROP DATABASE IF EXISTS issue1523_test;
+CREATE DATABASE issue1523_test;
+USE issue1523_test;
+include/sync_slave_sql_with_master.inc
+# on slave:
+USE issue1523_test;
+# on master:
+CREATE TABLE t1 (
+`id` int(10) NOT NULL AUTO_INCREMENT,
+`dev_code` varchar(20) NOT NULL,
+`port` smallint(2) DEFAULT '0',
+`server_ip` varchar(20) DEFAULT NULL,
+`work_status` int(1) DEFAULT '2',
+`port_link_car` int(1) NOT NULL DEFAULT '0',
+`last_order_sn` varchar(42) DEFAULT NULL,
+`last_charge_type` smallint(1) DEFAULT NULL,
+`last_charge_mode` int(2) DEFAULT '0',
+`last_status` smallint(1) DEFAULT NULL,
+`last_soc` int(3) DEFAULT NULL,
+`last_car_no` varchar(42) DEFAULT NULL,
+`last_vin` varchar(45) DEFAULT NULL,
+`create_time` timestamp NULL DEFAULT CURRENT_TIMESTAMP,
+`update_time` timestamp NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+PRIMARY KEY (`id`),
+UNIQUE KEY `portindex` (`dev_code`,`port`),
+KEY `dev_code` (`dev_code`)
+) ENGINE=INNODB;
+insert into t1(id,dev_code,port,server_ip,work_status,port_link_car,last_charge_mode,create_time,update_time) values
+(1,'3301081000000019',0,'172.16.171.219',2,0,0,'2018-08-20 13:46:42','2023-04-02 22:10:30');
+insert into t1(id,dev_code,port,server_ip,work_status,port_link_car,last_charge_mode,create_time,update_time) values
+(2,'3301081000000020',0,'172.16.171.219',3,1,1,'2018-08-20 13:46:42','2023-04-02 22:10:30');
+insert into t1(id,dev_code,port,server_ip,work_status,port_link_car,last_charge_mode,create_time,update_time) values
+(3,'3301081000000021',0,'172.16.171.219',4,2,2,'2018-08-20 13:46:42','2023-04-02 22:10:30');
+insert into t1 values
+(4,'3301081000000022',1,'172.16.171.219',2,1,'2023040314582504221842260',5,0,5,100,'JJY3786','LKLA6G1M4HA727506','2018-08-20 13:46:42','2023-04-02 22:10:30');
+insert into t1 values
+(5,'3301081000000023',1,'172.16.171.219',2,1,'2023040314582504221842261',6,0,6,101,'JJY3787','LKLA6G1M4HA727506','2018-08-20 13:46:42','2023-04-02 22:10:30');
+insert into t1 values
+(6,'3301081000000024',1,'172.16.171.219',2,1,'2023040314582504221842262',7,0,7,102,'JJY3788','LKLA6G1M4HA727506','2018-08-20 13:46:42','2023-04-02 22:10:30');
+update t1 set last_car_no='JJY3786' where id=1;
+update t1 set last_car_no=NULL where id=1;
+insert into t1(id,dev_code,port,server_ip,work_status,port_link_car,last_charge_mode,create_time,update_time) values
+(7,'3301081000000025',0,'172.16.171.219',2,0,0,'2018-08-20 13:46:42','2023-04-02 22:10:30');
+select last_car_no from t1 where id=1;
+last_car_no
+NULL
+select count(*) from t1;
+count(*)
+7
+include/sync_slave_sql_with_master.inc
+# on slave:
+select last_car_no from t1 where id=1;
+last_car_no
+NULL
+select count(*) from t1;
+count(*)
+7
+# on master:
+update t1 set last_car_no='JJY3786' where id=1;
+update t1 set last_car_no=NULL where id=1;
+update t1 set last_car_no='JJY3786' where id=1;
+update t1 set last_car_no=NULL where id=1;
+update t1 set last_car_no='JJY3786' where id=1;
+insert into t1(id,dev_code,port,server_ip,work_status,port_link_car,last_charge_mode,create_time,update_time) values
+(8,'3301081000000026',0,'172.16.171.219',2,0,0,'2018-08-20 13:46:42','2023-04-02 22:10:30');
+select last_car_no from t1 where id=1;
+last_car_no
+JJY3786
+select count(*) from t1;
+count(*)
+8
+include/sync_slave_sql_with_master.inc
+# on slave:
+select last_car_no from t1 where id=1;
+last_car_no
+JJY3786
+select count(*) from t1;
+count(*)
+8
+# on master:
+insert into t1(id,dev_code,port,server_ip,work_status,port_link_car,last_charge_mode,create_time,update_time) values
+(9,'3301081000000027',0,'172.16.171.219',2,0,0,'2018-08-20 13:46:42','2023-04-02 22:10:30');
+delete from t1 where id=9;
+insert into t1(id,dev_code,port,server_ip,work_status,port_link_car,last_charge_mode,create_time,update_time) values
+(9,'3301081000000027',0,'172.16.171.219',2,0,0,'2018-08-20 13:46:42','2023-04-02 22:10:30');
+select last_car_no from t1 where id=9;
+last_car_no
+NULL
+select count(*) from t1;
+count(*)
+9
+include/sync_slave_sql_with_master.inc
+# on slave:
+select last_car_no from t1 where id=9;
+last_car_no
+NULL
+select count(*) from t1;
+count(*)
+9
+# on master:
+update t1 set last_car_no=NULL where id=1;
+delete from t1 where id =1;
+select last_car_no from t1 where id=1;
+last_car_no
+select count(*) from t1;
+count(*)
+8
+include/sync_slave_sql_with_master.inc
+# on slave:
+select last_car_no from t1 where id=1;
+last_car_no
+select count(*) from t1;
+count(*)
+8
+# on master:
+insert into t1(id,dev_code,port,server_ip,work_status,port_link_car,last_charge_mode,create_time,update_time) values
+(10,'3301081000000028',0,'172.16.171.219',2,0,0,'2018-08-20 13:46:42','2023-04-02 22:10:30');
+update t1 set last_car_no='JJY3786' where id=10;
+select last_car_no from t1 where id=10;
+last_car_no
+JJY3786
+select count(*) from t1;
+count(*)
+9
+include/sync_slave_sql_with_master.inc
+# on slave:
+select last_car_no from t1 where id=10;
+last_car_no
+JJY3786
+select count(*) from t1;
+count(*)
+9
+# on master:
+insert into t1(id,dev_code,port,server_ip,work_status,port_link_car,last_charge_mode,create_time,update_time) values
+(11,'3301081000000029',0,'172.16.171.219',2,0,0,'2018-08-20 13:46:42','2023-04-02 22:10:30');
+update t1 set last_car_no='JJY3786' where id=11;
+delete from t1 where id =11;
+select last_car_no from t1 where id=11;
+last_car_no
+select count(*) from t1;
+count(*)
+9
+include/sync_slave_sql_with_master.inc
+# on slave:
+select last_car_no from t1 where id=11;
+last_car_no
+select count(*) from t1;
+count(*)
+9
+# on master:
+DROP DATABASE issue1523_test;
+include/sync_slave_sql_with_master.inc
+stop slave;

--- a/mysql-test/suite/tianmu/t/issue1523-slave.opt
+++ b/mysql-test/suite/tianmu/t/issue1523-slave.opt
@@ -1,0 +1,3 @@
+--tianmu_mandatory=ON
+--tianmu_no_key_error=ON
+--tianmu_insert_delayed=1

--- a/mysql-test/suite/tianmu/t/issue1523.test
+++ b/mysql-test/suite/tianmu/t/issue1523.test
@@ -1,0 +1,154 @@
+--source include/have_tianmu.inc
+--source include/have_binlog_format_row.inc
+--disable_warnings
+--source include/master-slave.inc
+--enable_warnings
+
+connection master;
+--echo # on master:
+--disable_warnings
+DROP DATABASE IF EXISTS issue1523_test;
+--enable_warnings
+CREATE DATABASE issue1523_test;
+USE issue1523_test;
+--source include/sync_slave_sql_with_master.inc
+--echo # on slave:
+USE issue1523_test;
+
+connection master;
+--echo # on master:
+CREATE TABLE t1 (
+  `id` int(10) NOT NULL AUTO_INCREMENT,
+  `dev_code` varchar(20) NOT NULL,
+  `port` smallint(2) DEFAULT '0',
+  `server_ip` varchar(20) DEFAULT NULL,
+  `work_status` int(1) DEFAULT '2',
+  `port_link_car` int(1) NOT NULL DEFAULT '0',
+  `last_order_sn` varchar(42) DEFAULT NULL,
+  `last_charge_type` smallint(1) DEFAULT NULL,
+  `last_charge_mode` int(2) DEFAULT '0',
+  `last_status` smallint(1) DEFAULT NULL,
+  `last_soc` int(3) DEFAULT NULL,
+  `last_car_no` varchar(42) DEFAULT NULL,
+  `last_vin` varchar(45) DEFAULT NULL,
+  `create_time` timestamp NULL DEFAULT CURRENT_TIMESTAMP,
+  `update_time` timestamp NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `portindex` (`dev_code`,`port`),
+  KEY `dev_code` (`dev_code`)
+) ENGINE=INNODB;
+
+insert into t1(id,dev_code,port,server_ip,work_status,port_link_car,last_charge_mode,create_time,update_time) values
+(1,'3301081000000019',0,'172.16.171.219',2,0,0,'2018-08-20 13:46:42','2023-04-02 22:10:30');
+
+insert into t1(id,dev_code,port,server_ip,work_status,port_link_car,last_charge_mode,create_time,update_time) values
+(2,'3301081000000020',0,'172.16.171.219',3,1,1,'2018-08-20 13:46:42','2023-04-02 22:10:30');
+
+insert into t1(id,dev_code,port,server_ip,work_status,port_link_car,last_charge_mode,create_time,update_time) values
+(3,'3301081000000021',0,'172.16.171.219',4,2,2,'2018-08-20 13:46:42','2023-04-02 22:10:30');
+
+insert into t1 values
+(4,'3301081000000022',1,'172.16.171.219',2,1,'2023040314582504221842260',5,0,5,100,'JJY3786','LKLA6G1M4HA727506','2018-08-20 13:46:42','2023-04-02 22:10:30');
+
+insert into t1 values
+(5,'3301081000000023',1,'172.16.171.219',2,1,'2023040314582504221842261',6,0,6,101,'JJY3787','LKLA6G1M4HA727506','2018-08-20 13:46:42','2023-04-02 22:10:30');
+
+insert into t1 values
+(6,'3301081000000024',1,'172.16.171.219',2,1,'2023040314582504221842262',7,0,7,102,'JJY3788','LKLA6G1M4HA727506','2018-08-20 13:46:42','2023-04-02 22:10:30');
+
+update t1 set last_car_no='JJY3786' where id=1;
+update t1 set last_car_no=NULL where id=1;
+insert into t1(id,dev_code,port,server_ip,work_status,port_link_car,last_charge_mode,create_time,update_time) values
+(7,'3301081000000025',0,'172.16.171.219',2,0,0,'2018-08-20 13:46:42','2023-04-02 22:10:30');
+
+select last_car_no from t1 where id=1;
+select count(*) from t1;
+
+--source include/sync_slave_sql_with_master.inc
+--echo # on slave:
+sleep 1;
+select last_car_no from t1 where id=1;
+select count(*) from t1;
+
+connection master;
+--echo # on master:
+update t1 set last_car_no='JJY3786' where id=1;
+update t1 set last_car_no=NULL where id=1;
+update t1 set last_car_no='JJY3786' where id=1;
+update t1 set last_car_no=NULL where id=1;
+update t1 set last_car_no='JJY3786' where id=1;
+insert into t1(id,dev_code,port,server_ip,work_status,port_link_car,last_charge_mode,create_time,update_time) values
+(8,'3301081000000026',0,'172.16.171.219',2,0,0,'2018-08-20 13:46:42','2023-04-02 22:10:30');
+
+select last_car_no from t1 where id=1;
+select count(*) from t1;
+
+--source include/sync_slave_sql_with_master.inc
+--echo # on slave:
+sleep 1;
+select last_car_no from t1 where id=1;
+select count(*) from t1;
+
+connection master;
+--echo # on master:
+insert into t1(id,dev_code,port,server_ip,work_status,port_link_car,last_charge_mode,create_time,update_time) values
+(9,'3301081000000027',0,'172.16.171.219',2,0,0,'2018-08-20 13:46:42','2023-04-02 22:10:30');
+delete from t1 where id=9;
+insert into t1(id,dev_code,port,server_ip,work_status,port_link_car,last_charge_mode,create_time,update_time) values
+(9,'3301081000000027',0,'172.16.171.219',2,0,0,'2018-08-20 13:46:42','2023-04-02 22:10:30');
+select last_car_no from t1 where id=9;
+select count(*) from t1;
+
+--source include/sync_slave_sql_with_master.inc
+--echo # on slave:
+sleep 1;
+select last_car_no from t1 where id=9;
+select count(*) from t1;
+
+connection master;
+--echo # on master:
+update t1 set last_car_no=NULL where id=1;
+delete from t1 where id =1;
+select last_car_no from t1 where id=1;
+select count(*) from t1;
+
+--source include/sync_slave_sql_with_master.inc
+--echo # on slave:
+sleep 1;
+select last_car_no from t1 where id=1;
+select count(*) from t1;
+
+connection master;
+--echo # on master:
+insert into t1(id,dev_code,port,server_ip,work_status,port_link_car,last_charge_mode,create_time,update_time) values
+(10,'3301081000000028',0,'172.16.171.219',2,0,0,'2018-08-20 13:46:42','2023-04-02 22:10:30');
+update t1 set last_car_no='JJY3786' where id=10;
+select last_car_no from t1 where id=10;
+select count(*) from t1;
+
+--source include/sync_slave_sql_with_master.inc
+--echo # on slave:
+sleep 1;
+select last_car_no from t1 where id=10;
+select count(*) from t1;
+
+connection master;
+--echo # on master:
+insert into t1(id,dev_code,port,server_ip,work_status,port_link_car,last_charge_mode,create_time,update_time) values
+(11,'3301081000000029',0,'172.16.171.219',2,0,0,'2018-08-20 13:46:42','2023-04-02 22:10:30');
+update t1 set last_car_no='JJY3786' where id=11;
+delete from t1 where id =11;
+select last_car_no from t1 where id=11;
+select count(*) from t1;
+
+--source include/sync_slave_sql_with_master.inc
+--echo # on slave:
+sleep 1;
+select last_car_no from t1 where id=11;
+select count(*) from t1;
+
+connection master;
+--echo # on master:
+DROP DATABASE issue1523_test;
+--source include/sync_slave_sql_with_master.inc
+stop slave;

--- a/storage/tianmu/core/pack_int.cpp
+++ b/storage/tianmu/core/pack_int.cpp
@@ -32,7 +32,6 @@ namespace Tianmu {
 namespace core {
 PackInt::PackInt(DPN *dpn, PackCoordinate pc, ColumnShare *s) : Pack(dpn, pc, s) {
   is_real_ = ATI::IsRealType(s->ColType().GetTypeName());
-
   if (dpn_->NotTrivial()) {
     system::TianmuFile f;
     f.OpenReadOnly(s->DataFile());
@@ -177,7 +176,9 @@ void PackInt::ExpandOrShrink(uint64_t maxv, int64_t delta) {
 
 void PackInt::UpdateValueFloat(size_t locationInPack, const Value &v) {
   if (IsNull(locationInPack)) {
-    ASSERT(v.HasValue());
+    if (!v.HasValue())
+      return;
+    // ASSERT(v.HasValue(), col_share_->DataFile() + " locationInPack: " + std::to_string(locationInPack));
 
     // update null to non-null
     dpn_->synced = false;
@@ -344,9 +345,10 @@ void PackInt::DeleteByRow(size_t locationInPack) {
 
 void PackInt::UpdateValueFixed(size_t locationInPack, const Value &v) {
   if (IsNull(locationInPack)) {
-    ASSERT(v.HasValue());
-
-    // update null to non-null
+    if (!v.HasValue())
+      return;
+    // ASSERT(v.HasValue(), col_share_->DataFile() + " locationInPack: " + std::to_string(locationInPack));
+    //  update null to non-null
     dpn_->synced = false;
     UnsetNull(locationInPack);
 

--- a/storage/tianmu/core/pack_str.cpp
+++ b/storage/tianmu/core/pack_str.cpp
@@ -188,6 +188,11 @@ void PackStr::UpdateValue(size_t locationInPack, const Value &v) {
   dpn_->synced = false;
 
   if (IsNull(locationInPack)) {
+    // In the delta layer, there may be situations where null
+    // values are updated with null values, so when encountering this situation, it is directly returned
+    if (!v.HasValue())
+      return;
+
     // update null to non-null
 
     // first non-null value?
@@ -195,7 +200,7 @@ void PackStr::UpdateValue(size_t locationInPack, const Value &v) {
       dpn_->max_i = -1;
     }
 
-    ASSERT(v.HasValue());
+    // ASSERT(v.HasValue(), col_share_->DataFile() + " locationInPack: " + std::to_string(locationInPack));
     UnsetNull(locationInPack);
     dpn_->numOfNulls--;
     auto &str = v.GetString();

--- a/storage/tianmu/core/tianmu_attr.h
+++ b/storage/tianmu/core/tianmu_attr.h
@@ -92,7 +92,7 @@ class TianmuAttr final : public mm::TraceableObject, public PhysicalColumn, publ
 
   mm::TO_TYPE TraceableType() const override { return mm::TO_TYPE::TO_TEMPORARY; }
   void UpdateData(uint64_t row, Value &old_v, Value &new_v);
-  void UpdateBatchData(core::Transaction *tx, const std::unordered_map<uint64_t, Value> &rows);
+  void UpdateBatchData(core::Transaction *tx, const std::unordered_map<uint64_t, std::shared_ptr<Value>> &rows);
   void UpdateIfIndex(core::Transaction *tx, uint64_t row, uint64_t col, const Value &old_v, const Value &new_v);
   void Truncate();
   void DeleteData(uint64_t row);


### PR DESCRIPTION
It is possible to update null values with null values in the delta layer, For example:
update t set name="xiaohua" where id=1;
update t set name=null where id=1;
So when encountering this situation, directly return

<!--

Thank you for contributing to StoneDB!

PR Title Format: <type>(<scope>): description to this pr (#issue_id)
e.g.
fix(util): fix sth..... (#1)

-->

## Summary about this PR
<!--

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".
e.g.:
Issue: close #1

-->

Issue Number: close #1523


## Tests Check List
<!-- At least one of next options must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

## Changelog
<!-- At least one of next options must be included. -->

- [ ] New Feature
- [x] Bug Fix
- [ ] Performance Improvement
- [ ] Build/Testing/CI/CD
- [ ] Documentation
- [ ] Not for changelog (changelog entry is not required)

## Documentation
<!-- At least one of next options must be included. -->

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
