### PR TITLE
fix(tianmu): revert code, mv ret value from try block back to catch block. (#1532)

### DIFF
--- a/storage/tianmu/handler/ha_tianmu.cpp
+++ b/storage/tianmu/handler/ha_tianmu.cpp
@@ -1223,14 +1223,15 @@ int ha_tianmu::create(const char *name, TABLE *table_arg, [[maybe_unused]] HA_CR
 
 int ha_tianmu::truncate() {
   DBUG_ENTER(__PRETTY_FUNCTION__);
-  int ret = 1;
+  int ret = 0;
   try {
     ha_tianmu_engine_->TruncateTable(table_name_, ha_thd());
-    ret = 0;
   } catch (std::exception &e) {
     TIANMU_LOG(LogCtl_Level::ERROR, "An exception is caught: %s", e.what());
+    ret = 1;
   } catch (...) {
     TIANMU_LOG(LogCtl_Level::ERROR, "An unknown system exception error caught.");
+    ret = 1;
   }
   DBUG_RETURN(ret);
 }


### PR DESCRIPTION
The logic of this modification is as follows:
Previously, set ret action has been moved to try block, which is not efficient because every time we do truncate success, ret will be setted to 1. This time we will move the set ret action back to catch block, which will only trigged when truncate failed.

<!--

Thank you for contributing to StoneDB!

PR Title Format: <type>(<scope>): description to this pr (#issue_id)
e.g.
fix(util): fix sth..... (#1)

-->

## Summary about this PR
<!--

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".
e.g.:
Issue: close #1

-->

Issue Number: close #1532


## Tests Check List
<!-- At least one of next options must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

## Changelog
<!-- At least one of next options must be included. -->

- [ ] New Feature
- [x] Bug Fix
- [ ] Performance Improvement
- [ ] Build/Testing/CI/CD
- [ ] Documentation
- [ ] Not for changelog (changelog entry is not required)

## Documentation
<!-- At least one of next options must be included. -->

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
