### PR TITLE
fix(tianmu):remove the warnings when compiling stonedb-8.0-dev(#1556)

### DIFF
--- a/storage/tianmu/core/group_distinct_table.cpp
+++ b/storage/tianmu/core/group_distinct_table.cpp
@@ -56,8 +56,8 @@ void GroupDistinctTable::InitializeVC(int64_t max_no_groups, vcolumn::VirtualCol
   DEBUG_ASSERT(!initialized);
   if (max_bytes > 0)
     max_total_size = max_bytes;
-  if (max_bytes > 2_GB)  // possible for large aggregation settings, but
-                         // not allowed here - limit to 1 GB
+  if (static_cast<size_t>(max_bytes) > 2_GB)  // possible for large aggregation settings, but
+                                              // not allowed here - limit to 1 GB
     max_total_size = 1_GB;
   if (max_no_rows == common::NULL_VALUE_64)
     max_no_rows = 0;  // not known

--- a/storage/tianmu/core/mi_new_contents.cpp
+++ b/storage/tianmu/core/mi_new_contents.cpp
@@ -330,7 +330,8 @@ void MINewContents::CommitNewTableValues()  // set a value (common::NULL_VALUE_6
           if (roughsorter)
             roughsorter->Barrier();
 
-          t_new[dim]->ExpandTo(obj < (2 * 1_KB) ? (2 * 1_KB) : obj * 4);  // enlarge with a safe backup
+          t_new[dim]->ExpandTo(static_cast<size_t>(obj) < (2 * 1_KB) ? (2 * 1_KB)
+                                                                     : obj * 4);  // enlarge with a safe backup
         }
 
         if (new_value[dim] == common::NULL_VALUE_64) {

--- a/storage/tianmu/handler/ha_tianmu.cpp
+++ b/storage/tianmu/handler/ha_tianmu.cpp
@@ -788,7 +788,7 @@ int ha_tianmu::close() {
   DBUG_RETURN(free_share());
 }
 
-uint ha_tianmu::max_supported_key_part_length(HA_CREATE_INFO *create_info) const {
+uint ha_tianmu::max_supported_key_part_length([[maybe_unused]] HA_CREATE_INFO *create_info) const {
   if (tianmu_sysvar_large_prefix)
     return (Tianmu::common::TIANMU_MAX_INDEX_COL_LEN_LARGE);
   else

--- a/storage/tianmu/index/rc_table_index.cpp
+++ b/storage/tianmu/index/rc_table_index.cpp
@@ -209,7 +209,8 @@ common::ErrorCode RCTableIndex::UpdateIndex(core::Transaction *tx, std::string_v
   return rc;
 }
 
-common::ErrorCode RCTableIndex::DeleteIndex(core::Transaction *tx, std::string_view &currentRowKey, uint64_t row) {
+common::ErrorCode RCTableIndex::DeleteIndex(core::Transaction *tx, std::string_view &currentRowKey,
+                                            [[maybe_unused]] uint64_t row) {
   StringWriter value, packkey;
   std::vector<std::string_view> fields;
 

--- a/storage/tianmu/index/rdb_meta_manager.cpp
+++ b/storage/tianmu/index/rdb_meta_manager.cpp
@@ -37,8 +37,8 @@
 namespace Tianmu {
 namespace index {
 
-RdbKey::RdbKey(uint pos, uint keyno, rocksdb::ColumnFamilyHandle *cf_handle, uint16_t index_ver, uchar index_type,
-               bool is_reverse_cf, const char *_name, std::vector<ColAttr> &cols)
+RdbKey::RdbKey(uint pos, [[maybe_unused]] uint keyno, rocksdb::ColumnFamilyHandle *cf_handle, uint16_t index_ver,
+               uchar index_type, bool is_reverse_cf, const char *_name, std::vector<ColAttr> &cols)
     : index_pos_(pos),
       cf_handle_(cf_handle),
       index_ver_(index_ver),
@@ -535,7 +535,7 @@ void DDLManager::put_and_write(std::shared_ptr<RdbTable> tbl, rocksdb::WriteBatc
   key.write_uint32(static_cast<uint32_t>(MetaType::DDL_INDEX));
 
   const std::string &dbname_tablename = tbl->fullname();
-  key.write((uchar *)dbname_tablename.data(), dbname_tablename.length());
+  key.write((const uchar *)dbname_tablename.data(), dbname_tablename.length());
 
   tbl->put_dict(dict_, batch, key.ptr(), key.length());
   put(tbl);
@@ -583,7 +583,7 @@ bool DDLManager::rename(const std::string &from, const std::string &to, rocksdb:
   key.write_uint32(static_cast<uint32_t>(MetaType::DDL_INDEX));
 
   const std::string &dbname_tablename = new_rec->fullname();
-  key.write((uchar *)dbname_tablename.data(), dbname_tablename.length());
+  key.write((const uchar *)dbname_tablename.data(), dbname_tablename.length());
   if (rec->if_exist_cf(dict_)) {
     remove(rec, batch);
     new_rec->put_dict(dict_, batch, key.ptr(), key.length());
@@ -878,7 +878,7 @@ bool DICTManager::get_max_index_id(uint32_t *const index_id) const {
   bool found = false;
   std::string value;
 
-  const rocksdb::Status status = get_value({(char *)max_index_, INDEX_NUMBER_SIZE}, &value);
+  const rocksdb::Status status = get_value({(const char *)max_index_, INDEX_NUMBER_SIZE}, &value);
   if (status.ok()) {
     uint16_t version = 0;
     StringReader reader({value.data(), value.length()});
@@ -903,7 +903,7 @@ bool DICTManager::update_max_index_id(rocksdb::WriteBatch *const batch, const ui
   StringWriter value;
   value.write_uint16(static_cast<uint>(VersionType::MAX_INDEX_ID_VERSION));
   value.write_uint32(index_id);
-  batch->Put(system_cf_, {(char *)max_index_, INDEX_NUMBER_SIZE}, {(char *)value.ptr(), value.length()});
+  batch->Put(system_cf_, {(const char *)max_index_, INDEX_NUMBER_SIZE}, {(char *)value.ptr(), value.length()});
 
   return false;
 }


### PR DESCRIPTION
<!--

Thank you for contributing to StoneDB!

PR Title Format: <type>(<scope>): description to this pr (#issue_id)
e.g.
fix(util): fix sth..... (#1)

-->

## Summary about this PR
<!--

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".
e.g.:
Issue: close #1

-->
There are three kind of warnings:
1. the types of compared two variables are not consistent
2. unused parameter
3. cast away qualifiers 'const'

Issue Number: close #1556 


## Tests Check List
<!-- At least one of next options must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [x] No code

## Changelog
<!-- At least one of next options must be included. -->

- [ ] New Feature
- [ ] Bug Fix
- [ ] Performance Improvement
- [x] Build/Testing/CI/CD
- [ ] Documentation
- [ ] Not for changelog (changelog entry is not required)

## Documentation
<!-- At least one of next options must be included. -->

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [x] Contains variable changes
- [ ] Contains experimental features
