### PR TITLE
feat(tianmu):set system variable "tianmu_large_prefix" default value from OFF to ON. #1426

### DIFF
--- a/storage/tianmu/handler/ha_tianmu.cpp
+++ b/storage/tianmu/handler/ha_tianmu.cpp
@@ -2357,7 +2357,7 @@ static MYSQL_SYSVAR_UINT(result_sender_rows, tianmu_sysvar_result_sender_rows, P
 static MYSQL_SYSVAR_BOOL(large_prefix, tianmu_sysvar_large_prefix, PLUGIN_VAR_RQCMDARG,
                          "Support large index prefix length of 3072 bytes. If off, the maximum "
                          "index prefix length is 767.",
-                         NULL, NULL, false);
+                         NULL, NULL, true);
 
 void debug_update(MYSQL_THD thd, [[maybe_unused]] struct SYS_VAR *var, void *var_ptr, const void *save) {
   if (ha_rcengine_) {


### PR DESCRIPTION
<!--

Thank you for contributing to StoneDB!

PR Title Format: <type>(<scope>): description to this pr (#issue_id)
e.g.
fix(util): fix sth..... (#1)

-->

## Summary about this PR
<!--

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".
e.g.:
Issue: close #1

-->
the variable "tianmu_large_prefix" default value is setted to ON
![2023-04-17 10-01-57 的屏幕截图](https://user-images.githubusercontent.com/107859421/232360810-81695ca9-adb3-4fb1-9a3f-ecedbf980e1f.png)
Issue Number: close #1426


## Tests Check List
<!-- At least one of next options must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code

## Changelog
<!-- At least one of next options must be included. -->

- [x] New Feature
- [ ] Bug Fix
- [ ] Performance Improvement
- [ ] Build/Testing/CI/CD
- [ ] Documentation
- [ ] Not for changelog (changelog entry is not required)

## Documentation
<!-- At least one of next options must be included. -->

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
