### PR TITLE
fix(core): results uncorrect caused by exists subquery #1428

### DIFF
--- a/storage/tianmu/core/dimension_group.cpp
+++ b/storage/tianmu/core/dimension_group.cpp
@@ -92,14 +92,16 @@ DimensionGroupMaterialized::DimensionGroupMaterialized(DimensionVector &dims) {
 DimensionGroup *DimensionGroupMaterialized::Clone(bool shallow) {
   DimensionGroupMaterialized *new_value = new DimensionGroupMaterialized(dims_used);
   new_value->no_obj = no_obj;
-  if (shallow)
-    return new_value;
   for (int i = 0; i < no_dims; i++) {
     if (t[i]) {
       new_value->nulls_possible[i] = nulls_possible[i];
-      t[i]->Lock();
-      new_value->t[i] = new IndexTable(*t[i]);
-      t[i]->Unlock();
+      if (shallow)
+        new_value->t[i] = t[i];
+      else {
+        t[i]->Lock();
+        new_value->t[i] = new IndexTable(*t[i]);
+        t[i]->Unlock();
+      }
     }
   }
   return new_value;

--- a/storage/tianmu/core/multi_index.h
+++ b/storage/tianmu/core/multi_index.h
@@ -199,7 +199,8 @@ class MultiIndex {
   int *group_num_for_dimension_{nullptr};      // an element number of dim_groups, for faster
                                                // dimension identification
 
-  int iterator_lock_{0};  // 0 - unlocked, >0 - normal iterator exists, -1 -updating iterator exists
+  int iterator_lock_{0};             // 0 - unlocked, >0 - normal iterator exists, -1 -updating iterator exists
+  bool shallow_dim_groups_ = false;  // Indicates whether dim_groups is a shallow copy
 };
 
 }  // namespace core


### PR DESCRIPTION
<!--

Thank you for contributing to StoneDB!

PR Title Format: <type>(<scope>): description to this pr (#issue_id)
e.g.
fix(util): fix sth..... (#1)

-->

## Summary about this PR
<!--

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".
e.g.:
Issue: close #1

-->

fix TPCH Q2/Q16/Q17/Q18/Q20/Q22
    Test results for reference:
    https://blog.csdn.net/adofsauron/article/details/127228984?spm=1001.2014.3001.5501

    TODO: Q4 and Q21
    The case is an exists subquery
    because the Tianmu engine converts
    the syntax tree to an inner join
    on an association surface.
    For details, see
    https://blog.csdn.net/adofsauron/article/details/127228984?spm=1001.2014.3001.5501

Issue Number: close #1428 


## Tests Check List
<!-- At least one of next options must be included. -->

- [ ] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

## Changelog
<!-- At least one of next options must be included. -->

- [ ] New Feature
- [x] Bug Fix
- [ ] Performance Improvement
- [ ] Build/Testing/CI/CD
- [ ] Documentation
- [ ] Not for changelog (changelog entry is not required)

## Documentation
<!-- At least one of next options must be included. -->

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
