### PR TITLE
fix(tianmu): fix mysqld crash when exec query with AggregateRough, assert failed on i < m_idx.size() at tianmu_attr.h:387, msg: [bad dpn index 0/0] (#1580)

### DIFF
--- a/storage/tianmu/vc/tianmu_attr.cpp
+++ b/storage/tianmu/vc/tianmu_attr.cpp
@@ -372,6 +372,9 @@ void TianmuAttr::LoadPackInfo([[maybe_unused]] Transaction *trans_) {
 
 PackOntologicalStatus TianmuAttr::GetPackOntologicalStatus(int pack_no) {
   LoadPackInfo();
+  if (m_idx.empty() || (!m_idx.size())) {
+    return PackOntologicalStatus::NULLS_ONLY;
+  }
   DPN const *dpn(pack_no >= 0 ? &get_dpn(pack_no) : nullptr);
   if (pack_no < 0 || dpn->NullOnly())
     return PackOntologicalStatus::NULLS_ONLY;


### PR DESCRIPTION
…sert failed on i < m_idx.size() at tianmu_attr.h:387, msg: [bad dpn index 0/0] (#1580)

<!--

Thank you for contributing to StoneDB!

PR Title Format: <type>(<scope>): description to this pr (#issue_id)
e.g.
fix(util): fix sth..... (#1)

-->

## Summary about this PR
<!--

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".
e.g.:
Issue: close #1

-->

Issue Number: close #1580 


## Tests Check List
<!-- At least one of next options must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

## Changelog
<!-- At least one of next options must be included. -->

- [ ] New Feature
- [x] Bug Fix
- [ ] Performance Improvement
- [ ] Build/Testing/CI/CD
- [ ] Documentation
- [ ] Not for changelog (changelog entry is not required)

## Documentation
<!-- At least one of next options must be included. -->

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
