### PR TITLE
fix(tianmu):mysqld crash when select from multitable #1657

### DIFF
--- a/mysql-test/suite/tianmu/r/delete.result
+++ b/mysql-test/suite/tianmu/r/delete.result
@@ -280,6 +280,11 @@ CREATE TABLE t3 (a int not null, b int not null, primary key (a,b))ENGINE=TIANMU
 insert into t1 values (1,1),(2,1),(1,3);
 insert into t2 values (1,1),(2,2),(3,3);
 insert into t3 values (1,1),(2,1),(1,3);
+select * from t1,t2,t3 where t1.a=t2.a AND t2.b=t3.a and t1.b=t3.b;
+a	b	a	b	a	b
+1	1	1	1	1	1
+2	1	2	2	2	1
+1	3	1	1	1	3
 delete t2.*,t3.* from t1,t2,t3 where t1.a=t2.a AND t2.b=t3.a and t1.b=t3.b;
 select * from t3;
 a	b

--- a/mysql-test/suite/tianmu/t/delete.test
+++ b/mysql-test/suite/tianmu/t/delete.test
@@ -226,8 +226,7 @@ CREATE TABLE t3 (a int not null, b int not null, primary key (a,b))ENGINE=TIANMU
 insert into t1 values (1,1),(2,1),(1,3);
 insert into t2 values (1,1),(2,2),(3,3);
 insert into t3 values (1,1),(2,1),(1,3);
-#TODO(stonedb8): and logical not correct, wait to backport
-#select * from t1,t2,t3 where t1.a=t2.a AND t2.b=t3.a and t1.b=t3.b;
+select * from t1,t2,t3 where t1.a=t2.a AND t2.b=t3.a and t1.b=t3.b;
 delete t2.*,t3.* from t1,t2,t3 where t1.a=t2.a AND t2.b=t3.a and t1.b=t3.b;
 # This should be empty
 select * from t3;

--- a/storage/tianmu/core/multi_index.cpp
+++ b/storage/tianmu/core/multi_index.cpp
@@ -91,7 +91,7 @@ MultiIndex::MultiIndex(MultiIndex &s, bool shallow) : m_conn(s.m_conn) {
     group_num_for_dimension_ = nullptr;
   }
   iterator_lock_ = 0;
-  shallow_dim_groups_ = false;
+  shallow_dim_groups_ = shallow;
 }
 
 MultiIndex::~MultiIndex() {


### PR DESCRIPTION
<!--

Thank you for contributing to StoneDB!

PR Title Format: <type>(<scope>): description to this pr (#issue_id)
e.g.
fix(util): fix sth..... (#1)

-->

## Summary about this PR
<!--

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".
e.g.:
Issue: close #1

-->

Issue Number: close #1657 


## Tests Check List
<!-- At least one of next options must be included. -->

- [ ] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

## Changelog
<!-- At least one of next options must be included. -->

- [ ] New Feature
- [x] Bug Fix
- [ ] Performance Improvement
- [ ] Build/Testing/CI/CD
- [ ] Documentation
- [ ] Not for changelog (changelog entry is not required)

## Documentation
<!-- At least one of next options must be included. -->

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
