### PR TITLE
feat(tianmu): remove DBUG_OFF and repalce DEBUG_ASSERT with assert

### DIFF
--- a/storage/tianmu/common/assert.h
+++ b/storage/tianmu/common/assert.h
@@ -42,13 +42,5 @@ namespace Tianmu {
 #define ASSERT(...) GET_MACRO(__VA_ARGS__, ASSERT_2, ASSERT_1)(__VA_ARGS__)
 #define TIANMU_ERROR(message) ASSERT(false, message)
 
-#ifdef DBUG_OFF
-#define DEBUG_ASSERT(condition) \
-  do {                          \
-  } while (false)
-#else
-#define DEBUG_ASSERT(...) assert(__VA_ARGS__)
-#endif
-
 }  // namespace Tianmu
 #endif  // TIANMU_COMMON_ASSERT_H_

--- a/storage/tianmu/compress/arith_coder.cpp
+++ b/storage/tianmu/compress/arith_coder.cpp
@@ -61,15 +61,15 @@ CprsErr ArithCoder::ScaleRange(BitStream *dest, BaseT s_low, BaseT s_high, BaseT
 
 template <class T>
 CprsErr ArithCoder::EncodeUniform(BitStream *dest, T val, T maxval, uint bitmax) {
-  DEBUG_ASSERT((val <= maxval) && (val >= 0));
+  assert((val <= maxval) && (val >= 0));
   if (maxval == 0)
     return CprsErr::CPRS_SUCCESS;
-  DEBUG_ASSERT((maxval _SHR_ bitmax) == 0);
+  assert((maxval _SHR_ bitmax) == 0);
 
   // encode groups of 'uni_nbit' bits, from the least significant
   BaseT v;
   CprsErr err;
-  DEBUG_ASSERT(uni_total_ <= MAX_TOTAL_);
+  assert(uni_total_ <= MAX_TOTAL_);
   while (bitmax > uni_nbit_) {
     v = (BaseT)(val & uni_mask_);
     err = ScaleRange(dest, v, v + (BaseT)1, uni_total_);
@@ -80,7 +80,7 @@ CprsErr ArithCoder::EncodeUniform(BitStream *dest, T val, T maxval, uint bitmax)
     bitmax -= uni_nbit_;
   }
   // encode the most significant group
-  DEBUG_ASSERT(maxval < MAX_TOTAL_);
+  assert(maxval < MAX_TOTAL_);
   err = ScaleRange(dest, (BaseT)val, (BaseT)val + (BaseT)1, (BaseT)maxval + (BaseT)1);
   if (static_cast<int>(err))
     return err;
@@ -185,33 +185,33 @@ CprsErr ArithCoder::DecodeUniform(BitStream *src, T &val, T maxval, uint bitmax)
   val = 0;
   if (maxval == 0)
     return CprsErr::CPRS_SUCCESS;
-  DEBUG_ASSERT((maxval _SHR_ bitmax) == 0);
+  assert((maxval _SHR_ bitmax) == 0);
 
   // decode groups of 'uni_nbit' bits, from the least significant
   BaseT v;
   CprsErr err;
-  DEBUG_ASSERT(uni_total_ <= MAX_TOTAL_);
+  assert(uni_total_ <= MAX_TOTAL_);
   uint shift = 0;
   while (shift + uni_nbit_ < bitmax) {
     v = GetCount(uni_total_);
     err = RemoveSymbol(src, v, v + (BaseT)1, uni_total_);
     if (static_cast<int>(err))
       return err;
-    DEBUG_ASSERT(shift < 64);
+    assert(shift < 64);
     val |= (uint64_t)v << shift;
     shift += uni_nbit_;
   }
 
   // decode the most significant group
   BaseT total = (BaseT)(maxval _SHR_ shift) + (BaseT)1;
-  DEBUG_ASSERT(total <= MAX_TOTAL_);
+  assert(total <= MAX_TOTAL_);
   v = GetCount(total);
   err = RemoveSymbol(src, v, v + (BaseT)1, total);
   if (static_cast<int>(err))
     return err;
-  DEBUG_ASSERT(shift < 64);
+  assert(shift < 64);
   val |= (uint64_t)v << shift;
-  DEBUG_ASSERT(val <= maxval);
+  assert(val <= maxval);
 
   return CprsErr::CPRS_SUCCESS;
 }

--- a/storage/tianmu/compress/basic_data_filt.cpp
+++ b/storage/tianmu/compress/basic_data_filt.cpp
@@ -119,7 +119,7 @@ void DataFilt_RLE<T>::Merge(DataSet<T> *dataset) {
   while (nblk_ > 0) {
     T val = data[--nblk_];
     for (ushort i = lens_[nblk_]; i > 0; i--) {
-      DEBUG_ASSERT(nrec > 0);
+      assert(nrec > 0);
       data[--nrec] = val;
     }
   }
@@ -257,13 +257,13 @@ double DataFilt_Diff<T>::Measure(DataSet<T> *dataset, bool diff) {
   if (diff) {
     T maxval1 = dataset->maxval + 1;
     for (; j < nsamp; i += step, j++) {
-      DEBUG_ASSERT(i < nrec);
+      assert(i < nrec);
       if ((sample_[j] = data[i] - data[i - 1]) > data[i])
         sample_[j] += maxval1;
     }
   } else
     for (; j < nsamp; i += step, j++) {
-      DEBUG_ASSERT(i < nrec);
+      assert(i < nrec);
       sample_[j] = data[i];
     }
 
@@ -305,7 +305,7 @@ bool DataFilt_Diff<T>::Encode(RangeCoder *coder, DataSet<T> *dataset) {
     data[i] = (curr = data[i]) - last;
     if (last > curr)
       data[i] += maxval1;
-    DEBUG_ASSERT(data[i] <= dataset->maxval);
+    assert(data[i] <= dataset->maxval);
     last = curr;
   }
 
@@ -332,7 +332,7 @@ void DataFilt_Diff<T>::Merge(DataSet<T> *dataset) {
     curr = last + data[i];
     if ((curr > maxval) || (curr < last))
       curr -= maxval1;
-    DEBUG_ASSERT(curr <= maxval);
+    assert(curr <= maxval);
     last = data[i] = curr;
   }
 }

--- a/storage/tianmu/compress/data_stream.h
+++ b/storage/tianmu/compress/data_stream.h
@@ -199,14 +199,14 @@ inline uchar BitStream::GetByte() {
 }
 
 inline void BitStream::PutUInt(uint n, unsigned short int no_bits) {
-  DEBUG_ASSERT(no_bits <= 32);
+  assert(no_bits <= 32);
   int i = 0;  // no. of bits already stored
   for (; no_bits - i >= 8; i += 8) PutByte((uchar)(n >> i));
   for (; i < no_bits; i++) PutBit((uchar)(n >> i));
 }
 
 inline uint BitStream::GetUInt(unsigned short int no_bits) {
-  DEBUG_ASSERT(no_bits <= 32);
+  assert(no_bits <= 32);
   uint result = 0;
   int i = 0;  // no. of bits already read
   for (; no_bits - i >= 8; i += 8) result |= (((uint)GetByte()) << i);
@@ -215,14 +215,14 @@ inline uint BitStream::GetUInt(unsigned short int no_bits) {
 }
 
 inline void BitStream::PutUInt64(uint64_t n, unsigned short int no_bits) {
-  DEBUG_ASSERT(no_bits <= 64);
+  assert(no_bits <= 64);
   int i = 0;  // no. of bits already stored
   for (; no_bits - i >= 8; i += 8) PutByte((uchar)(n >> i));
   for (; i < no_bits; i++) PutBit((uchar)(n >> i));
 }
 
 inline unsigned long long BitStream::GetUInt64(unsigned short int no_bits) {
-  DEBUG_ASSERT(no_bits <= 64);
+  assert(no_bits <= 64);
   uint64_t result = 0;
   int i = 0;  // no. of bits already read
   for (; no_bits - i >= 8; i += 8) result |= (((uint64_t)GetByte()) << i);

--- a/storage/tianmu/compress/dictionary.cpp
+++ b/storage/tianmu/compress/dictionary.cpp
@@ -48,14 +48,14 @@ void Dictionary<T>::SetLows() {
   for (short i = 0; i < n_keys_; i++) {
     order_[i] = &keys_[i];
     sumcnt += keys_[i].count;
-    DEBUG_ASSERT(keys_[i].count > 0);
+    assert(keys_[i].count > 0);
   }
   qsort_tianmu(order_, n_keys_, sizeof(*order_), compare);
 
   ASSERT(sumcnt <= MAX_TOTAL_, "should be 'sumcnt <= MAX_TOTAL_'");
   // set short counts
   //	if(sumcnt > MAX_TOTAL_) {
-  //		DEBUG_ASSERT(0);
+  //		assert(0);
   //		uint shift = GetShift(sumcnt, MAX_TOTAL_ - n_keys_);
   //		for(short i = 0; i < n_keys_; i++) {
   //			if((order_[i]->count _SHR_ASSIGN_ shift) == 0)

--- a/storage/tianmu/compress/dictionary.h
+++ b/storage/tianmu/compress/dictionary.h
@@ -121,19 +121,19 @@ class Dictionary final {
 
   // returns true when ESC was encoded ('key' is not in dictionary)
   bool Encode(RangeCoder *dest, T key) {
-    DEBUG_ASSERT(compress_);
+    assert(compress_);
 
     // find the 'key' in the hash
     uint b = hash(key);
     short k = buckets_[b];
     while ((k >= 0) && (keys_[k].key != key)) k = next_[k];
-    DEBUG_ASSERT(k >= 0);  // TODO: handle ESC encoding
+    assert(k >= 0);  // TODO: handle ESC encoding
 
     dest->EncodeShift(keys_[k].low, keys_[k].count, tot_shift_);
     return false;
   }
   bool Decode(RangeCoder *src, T &key) {
-    DEBUG_ASSERT(decompress_);
+    assert(decompress_);
     uint count = src->GetCountShift(tot_shift_);
     short k = cnt2val_[count];  // TODO: handle ESC decoding
     key = keys_[k].key;

--- a/storage/tianmu/compress/inc_alloc.cpp
+++ b/storage/tianmu/compress/inc_alloc.cpp
@@ -59,11 +59,11 @@ void *IncAlloc::_alloc_search(uint size) {
   }
 
   // allocate a new block
-  DEBUG_ASSERT(blk_ == blocks_.size());
+  assert(blk_ == blocks_.size());
   uint bsize = firstsize_;
   if (blk_ > 0) {
     bsize = (uint)(blocks_[blk_ - 1].size * GROW_SIZE_ + ROUNDUP_) / ROUNDUP_ * ROUNDUP_;
-    DEBUG_ASSERT(bsize > blocks_[blk_ - 1].size);
+    assert(bsize > blocks_[blk_ - 1].size);
     if (bsize < size)
       bsize = size;
   }

--- a/storage/tianmu/compress/inc_alloc.h
+++ b/storage/tianmu/compress/inc_alloc.h
@@ -58,7 +58,7 @@ class IncAlloc {
   // currently, 'size' must be at most MAX_FRAG_SIZE_
   void *_alloc(uint size) {
     // find a fragment...
-    DEBUG_ASSERT(size && (size <= MAX_FRAG_SIZE_));
+    assert(size && (size <= MAX_FRAG_SIZE_));
     auto &frag = frags_[size];
     if (frag.size()) {
       void *mem = frag.back();
@@ -79,7 +79,7 @@ class IncAlloc {
   void *_alloc_search(uint size);  // more complicated part of _alloc, executed rarely
   // put 'p' into frags_[size]; does NOT check if p points into a block!
   void _free(void *p, uint size) {
-    DEBUG_ASSERT(size && (size <= MAX_FRAG_SIZE_));
+    assert(size && (size <= MAX_FRAG_SIZE_));
     frags_[size].push_back(p);
   }
 

--- a/storage/tianmu/compress/inc_wgraph.cpp
+++ b/storage/tianmu/compress/inc_wgraph.cpp
@@ -184,7 +184,7 @@ void IncWGraph::EncodeRec(ushort rec, bool &repeated) {
   // middle of an edge, go by suffix links, adding nodes if necessary, to obtain
   // active.proj==0
   while (restlen) {
-    DEBUG_ASSERT(proj == 0);
+    assert(proj == 0);
 
     // (1)
     while (1) {
@@ -251,7 +251,7 @@ void IncWGraph::DecodeRec(ushort rec, uint dlen, bool &repeated) {
     p_mask_->Reset();
 
   while (restlen) {
-    DEBUG_ASSERT(proj == 0);
+    assert(proj == 0);
 
     // (1)
     while (1) {
@@ -297,14 +297,14 @@ void IncWGraph::DecodeRec(ushort rec, uint dlen, bool &repeated) {
       records_[rec] = s - len;           // set correct index for repeated record
     } else if (proj < edge->GetLen()) {  // it appears that the record is not a
                                          // repetition
-      DEBUG_ASSERT(base != NIL_);
+      assert(base != NIL_);
       if (len > dlen)
         throw CprsErr::CPRS_ERR_BUF;
       declen = len - restlen;
       LabelCopy(s, edge->target->endpos - edgelen + proj - declen,
                 declen);  // copy at once all labels passed till now
       repeated = false;
-      DEBUG_ASSERT(recent_.empty());
+      assert(recent_.empty());
     }
 
     // set 'fsym' of recently created edges
@@ -316,7 +316,7 @@ void IncWGraph::DecodeRec(ushort rec, uint dlen, bool &repeated) {
   }
   if (final && !final->suf)
     final->suf = base;
-  DEBUG_ASSERT(recent_.empty());
+  assert(recent_.empty());
 }
 
 //-------------------------------------------------------------------------------------------
@@ -358,7 +358,7 @@ inline void IncWGraph::Traverse(Node *&base, Edge *&edge, ushort &proj, uchar *s
           solid = false;
         } else if (final && !final->suf) {
           final->suf = node;
-          DEBUG_ASSERT(!last);
+          assert(!last);
         }
         if (last)
           last->suf = node;  // initialize 'suf' link of the previously created node
@@ -380,7 +380,7 @@ inline void IncWGraph::Traverse(Node *&base, Edge *&edge, ushort &proj, uchar *s
 
 ushort IncWGraph::Node::AllocEdge(IncAlloc &mem) {
   ushort n = GetNEdge(), m = RoundNEdge(n), m1 = RoundNEdge(n + 1);
-  DEBUG_ASSERT((n <= 255) && (n <= m) && (m1 <= 256));
+  assert((n <= 255) && (n <= m) && (m1 <= 256));
   if (m == m1)
     return n;
 
@@ -418,12 +418,12 @@ IncWGraph::Node *IncWGraph::Node::Duplicate(Node *base, Edge *e, IncAlloc &mem) 
   e->SetSolid(true);
   ushort proj = e->GetLen();
   do {
-    DEBUG_ASSERT(proj && (proj == e->GetLen()));
+    assert(proj && (proj == e->GetLen()));
     e->target = n;
     base = Canonize(base->suf, e, proj, endpos,
                     false);  // move 'q' along suffix link, don't canonize the last edge
   } while (e->target == this);
-  DEBUG_ASSERT(e->target == n->suf);
+  assert(e->target == n->suf);
 
   return n;
 }
@@ -432,7 +432,7 @@ inline IncWGraph::Node *IncWGraph::Node::Canonize(Node *n, Edge *&e, ushort &pro
   ushort len;
   while (proj) {
     e = n->FindEdge(*(s - proj));
-    DEBUG_ASSERT(e);
+    assert(e);
     // if(canonlast) n->UpdateCount(e, 1);
     len = e->GetLen();
     if ((proj < len) || (!canonlast && (proj == len)))
@@ -469,7 +469,7 @@ IncWGraph::Node *IncWGraph::InsertNode([[maybe_unused]] Node *base, Edge *edge, 
   Node *node;
   memory_.alloc(node);
   memory_.alloc(node->edge, node->RoundNEdge(node->nedge = 1));
-  DEBUG_ASSERT(node->RoundNEdge(1) == node->RoundNEdge(2));
+  assert(node->RoundNEdge(1) == node->RoundNEdge(2));
 
   // edge from 'node' to 'edge->target'
   Node *target = edge->target;
@@ -524,7 +524,7 @@ inline bool IncWGraph::Node::FindEdge(uchar s, Edge *&e, Count &low, Mask *mask)
   return false;
 }
 inline bool IncWGraph::Node::FindEdge(Count c, Edge *&e, Count &low, Mask *mask) {
-  DEBUG_ASSERT(c < total);
+  assert(c < total);
   low = 0;
   if (!edge)
     return false;
@@ -559,7 +559,7 @@ inline IncWGraph::Edge *IncWGraph::Node::FindEdge(uchar s) {
 }
 
 inline IncWGraph::Edge *IncWGraph::Node::AddEdge(uchar s, ushort len, bool solid, Node *final, Count esc, ushort e) {
-  DEBUG_ASSERT(e <= 255);
+  assert(e <= 255);
   Count t = total;
   total -= esc;
   edge[e].Init(s, len, solid, final, init_count);
@@ -592,7 +592,7 @@ inline Count IncWGraph::Node::GetMaskTotal(Mask *mask) {
 
 inline void IncWGraph::Node::UpdateCount(Edge *&e, Count update) {
   // increase count and total, do rescaling if necessary
-  DEBUG_ASSERT((e >= edge) && (e - edge < GetNEdge()));
+  assert((e >= edge) && (e - edge < GetNEdge()));
   Count t = total + update;
   if ((t <= total)
       //  || (t > MAX_TOTAL)) FIXME: always false
@@ -624,11 +624,11 @@ inline void IncWGraph::Edge::Init(uchar fs, ushort l, bool s, Node *t, Count c) 
 }
 
 inline ushort IncWGraph::Edge::NumMatch(uchar *s, ushort maxlen) {
-  DEBUG_ASSERT(maxlen && (maxlen <= GetLen()));
+  assert(maxlen && (maxlen <= GetLen()));
   if (maxlen == 1)
     return 1;
   uchar *q = target->endpos - GetLen();
-  DEBUG_ASSERT(*s == *q);
+  assert(*s == *q);
   ushort m = 1;
   while (m < maxlen)
     if (s[m] != q[m])

--- a/storage/tianmu/compress/inc_wgraph.h
+++ b/storage/tianmu/compress/inc_wgraph.h
@@ -64,7 +64,7 @@ class IncWGraph {
     Count GetMaskTotal(Mask *mask);
     uchar EscCount() { return 3; }  // edge ? 2+nedge/4 : 1; }
     void EncodeEsc(RangeCoder *cod, Count low, Count tot) {
-      DEBUG_ASSERT(low + EscCount() == tot);
+      assert(low + EscCount() == tot);
       cod->Encode(low, EscCount(), tot);
     }
     void DecodeEsc(RangeCoder *cod, Count low, Count tot) {
@@ -112,7 +112,7 @@ class IncWGraph {
    public:
     bool Masked(uchar s) { return map_.test(s); }
     void Add(uchar s) {
-      DEBUG_ASSERT(!Masked(s));
+      assert(!Masked(s));
       map_.set(s);
       n_set_++;
     }

--- a/storage/tianmu/compress/ppm.cpp
+++ b/storage/tianmu/compress/ppm.cpp
@@ -72,7 +72,7 @@ CprsErr PPM::CompressArith(char *dest, int &dlen, Symb *src, int slen) {
   if (wg)
     ASSERT(wg->insatend_ == false, "should be 'wg->insatend_ == false'");
 
-  // DEBUG_ASSERT(src[slen-1] == 0);
+  // assert(src[slen-1] == 0);
   ArithCoder coder;
   BitStream bs_dest(dest, dlen * 8);
   bool overflow = false;
@@ -106,7 +106,7 @@ CprsErr PPM::CompressArith(char *dest, int &dlen, Symb *src, int slen) {
       // model_->FindEdgeS(stt, edge, src + i, slen - i);
       // model_->GetRange(stt, edge, rng);
       // total = model_->GetTotal(stt);
-      // DEBUG_ASSERT(rng.high <= total);
+      // assert(rng.high <= total);
       // len = model_->GetLen(stt, edge);
 
       // encode 'rng'
@@ -211,7 +211,7 @@ CprsErr PPM::DecompressArith(Symb *dest, int dlen, char *src, int slen) {
 
       // remove the decoded data from the source
       // model_->GetRange(stt, edge, rng);
-      // DEBUG_ASSERT(rng.high <= total);
+      // assert(rng.high <= total);
       coder.RemoveSymbol(&bs_src, rng.low, rng.high, total);
 
       // get label of the edge, put it into 'dest'

--- a/storage/tianmu/compress/range_code.h
+++ b/storage/tianmu/compress/range_code.h
@@ -78,8 +78,8 @@ class RangeCoder {
   }
 
   void Encode(uint cumFreq, uint freq, uint total) {
-    DEBUG_ASSERT(freq && cumFreq + freq <= total && total <= MAX_TOTAL_);
-    DEBUG_ASSERT(range_ >= BOT_ && low_ + range_ - 1 >= low_);
+    assert(freq && cumFreq + freq <= total && total <= MAX_TOTAL_);
+    assert(range_ >= BOT_ && low_ + range_ - 1 >= low_);
     low_ += (range_ /= total) * cumFreq;
     range_ *= freq;
     while (((low_ ^ (low_ + range_)) < TOP_) || ((range_ < BOT_) && ((range_ = -low_ & (BOT_ - 1)), 1)))
@@ -90,16 +90,16 @@ class RangeCoder {
 #if defined(_DEBUG) || !defined(NDEBUG)
     _tot_ = total;
 #endif
-    DEBUG_ASSERT(range_ >= BOT_ && low_ + range_ - 1 >= code_ && code_ >= low_);
+    assert(range_ >= BOT_ && low_ + range_ - 1 >= code_ && code_ >= low_);
     uint tmp = (code_ - low_) / (range_ /= total);
-    DEBUG_ASSERT(tmp < total);
+    assert(tmp < total);
     if (tmp >= total)
       throw CprsErr::CPRS_ERR_COR;
     return tmp;
   }
 
   void Decode(uint cumFreq, uint freq, [[maybe_unused]] uint total) {
-    DEBUG_ASSERT(_tot_ == total && freq && cumFreq + freq <= total && total <= MAX_TOTAL_);
+    assert(_tot_ == total && freq && cumFreq + freq <= total && total <= MAX_TOTAL_);
     low_ += range_ * cumFreq;
     range_ *= freq;
     while (((low_ ^ (low_ + range_)) < TOP_) || ((range_ < BOT_) && ((range_ = -low_ & (BOT_ - 1)), 1)))
@@ -108,8 +108,8 @@ class RangeCoder {
   }
 
   void EncodeShift(uint cumFreq, uint freq, uint shift) {
-    DEBUG_ASSERT(cumFreq + freq <= (1u _SHL_ shift) && freq && (1u _SHL_ shift) <= MAX_TOTAL_);
-    DEBUG_ASSERT(range_ >= BOT_ && low_ + range_ - 1 >= low_);
+    assert(cumFreq + freq <= (1u _SHL_ shift) && freq && (1u _SHL_ shift) <= MAX_TOTAL_);
+    assert(range_ >= BOT_ && low_ + range_ - 1 >= low_);
     low_ += (range_ _SHR_ASSIGN_ shift)*cumFreq;
     range_ *= freq;
     while ((low_ ^ (low_ + range_)) < TOP_ || (range_ < BOT_ && ((range_ = -low_ & (BOT_ - 1)), 1)))
@@ -120,7 +120,7 @@ class RangeCoder {
 #if defined(_DEBUG) || !defined(NDEBUG)
     _sh_ = shift;
 #endif
-    DEBUG_ASSERT(range_ >= BOT_ && low_ + range_ - 1 >= code_ && code_ >= low_);
+    assert(range_ >= BOT_ && low_ + range_ - 1 >= code_ && code_ >= low_);
     uint tmp = (code_ - low_) / (range_ _SHR_ASSIGN_ shift);
     if (tmp >= (1u << shift))
       throw CprsErr::CPRS_ERR_COR;
@@ -128,7 +128,7 @@ class RangeCoder {
   }
 
   void DecodeShift(uint cumFreq, uint freq, [[maybe_unused]] uint shift) {
-    DEBUG_ASSERT(_sh_ == shift && cumFreq + freq <= (1u _SHL_ shift) && freq && (1u _SHL_ shift) <= MAX_TOTAL_);
+    assert(_sh_ == shift && cumFreq + freq <= (1u _SHL_ shift) && freq && (1u _SHL_ shift) <= MAX_TOTAL_);
     low_ += range_ * cumFreq;
     range_ *= freq;
     while (((low_ ^ (low_ + range_)) < TOP_) || ((range_ < BOT_) && ((range_ = -low_ & (BOT_ - 1)), 1)))
@@ -138,16 +138,16 @@ class RangeCoder {
   // uniform compression and decompression (must be: val <= maxval)
   template <class T>
   void EncodeUniform(T val, T maxval, uint bitmax) {
-    DEBUG_ASSERT((val <= maxval));
-    DEBUG_ASSERT((((uint64_t)maxval >> bitmax) == 0) || bitmax >= 64);
+    assert((val <= maxval));
+    assert((((uint64_t)maxval >> bitmax) == 0) || bitmax >= 64);
     if (maxval == 0)
       return;
 
     // encode groups of 'uni_nbit_' bits, from the least significant
-    DEBUG_ASSERT(uni_total_ <= MAX_TOTAL_);
+    assert(uni_total_ <= MAX_TOTAL_);
     while (bitmax > uni_nbit_) {
       EncodeShift((uint)(val & uni_mask_), 1, uni_nbit_);
-      DEBUG_ASSERT(uni_nbit_ < sizeof(T) * 8);
+      assert(uni_nbit_ < sizeof(T) * 8);
       val >>= uni_nbit_;
       maxval >>= uni_nbit_;
       bitmax -= uni_nbit_;
@@ -169,27 +169,27 @@ class RangeCoder {
     val = 0;
     if (maxval == 0)
       return;
-    DEBUG_ASSERT((((uint64_t)maxval >> bitmax) == 0) || bitmax >= 64);
+    assert((((uint64_t)maxval >> bitmax) == 0) || bitmax >= 64);
 
     // decode groups of 'uni_nbit_' bits, from the least significant
-    DEBUG_ASSERT(uni_total_ <= MAX_TOTAL_);
+    assert(uni_total_ <= MAX_TOTAL_);
     uint v, shift = 0;
     while (shift + uni_nbit_ < bitmax) {
       v = GetCountShift(uni_nbit_);
       DecodeShift(v, 1, uni_nbit_);
-      DEBUG_ASSERT(shift < 64);
+      assert(shift < 64);
       val |= (uint64_t)v << shift;
       shift += uni_nbit_;
     }
 
     // decode the most significant group
-    DEBUG_ASSERT(shift < sizeof(maxval) * 8);
+    assert(shift < sizeof(maxval) * 8);
     uint total = (uint)(maxval >> shift) + 1;
-    DEBUG_ASSERT(total <= MAX_TOTAL_);
+    assert(total <= MAX_TOTAL_);
     v = GetCount(total);
     Decode(v, 1, total);
     val |= (uint64_t)v << shift;
-    DEBUG_ASSERT(val <= maxval);
+    assert(val <= maxval);
   }
 
   template <class T>
@@ -217,7 +217,7 @@ class RangeCoder {
       uint tmp = GetCountShift(uni_nbit_);
       DecodeShift(tmp, 1, uni_nbit_);
       DecodeUniShift(x, shift - uni_nbit_);
-      DEBUG_ASSERT(uni_nbit_ < sizeof(x) * 8);
+      assert(uni_nbit_ < sizeof(x) * 8);
       x = (x << uni_nbit_) | (T)tmp;
     }
   }
@@ -225,13 +225,13 @@ class RangeCoder {
 
 template <>
 inline void RangeCoder::EncodeUniShift<uchar>(uchar x, uint shift) {
-  DEBUG_ASSERT(shift <= uni_nbit_);
+  assert(shift <= uni_nbit_);
   EncodeShift((uint)x, 1, shift);
 }
 
 template <>
 inline void RangeCoder::EncodeUniShift<ushort>(ushort x, uint shift) {
-  DEBUG_ASSERT(shift <= uni_nbit_);
+  assert(shift <= uni_nbit_);
   EncodeShift((uint)x, 1, shift);
 }
 

--- a/storage/tianmu/compress/suffix_tree.cpp
+++ b/storage/tianmu/compress/suffix_tree.cpp
@@ -91,9 +91,9 @@ void SuffixTree<Symb, NSymb>::Create() {
           last_leaf = NIL_;
         }
         do {
-          DEBUG_ASSERT(*(s - 1) == '\0');
-          DEBUG_ASSERT(IsLeaf(active.n));
-          DEBUG_ASSERT(active.proj == 0);
+          assert(*(s - 1) == '\0');
+          assert(IsLeaf(active.n));
+          assert(active.proj == 0);
           GetNode(active.n).count++;
           MoveSuffix(active, s);
         } while (active.n != ROOT_);  // TODO: time - optimize the leaf counting
@@ -115,7 +115,7 @@ void SuffixTree<Symb, NSymb>::Create() {
 
 template <class Symb, int NSymb>
 void SuffixTree<Symb, NSymb>::MoveDown(Point &p, const uchar *&s) {
-  DEBUG_ASSERT(p.proj == 0);
+  assert(p.proj == 0);
   uchar *lbl;
   uint len;
   uint &proj = p.proj;
@@ -132,7 +132,7 @@ void SuffixTree<Symb, NSymb>::MoveDown(Point &p, const uchar *&s) {
     //	s++;
     //	p.n = p.next;
     //	p.proj = 0;
-    //	DEBUG_ASSERT(GetNode(p.n).len == 1);
+    //	assert(GetNode(p.n).len == 1);
     //	return true;
     //}
     // s++;
@@ -228,7 +228,7 @@ void SuffixTree<Symb, NSymb>::Canonize(Point &p, const uchar *s) {
   int len;
   while (p.proj > 0) {
     ch = GetChild(p.n, *(s - p.proj));
-    DEBUG_ASSERT(ch != NIL_);
+    assert(ch != NIL_);
     len = GetNode(ch).len;
     if (p.proj < (uint)len) {
       p.next = ch;
@@ -452,7 +452,7 @@ bool SuffixTree<Symb, NSymb>::IsValid(PNode n) {
   // count children
   int num = 0;
   PNode ch = GetNode(n).child;
-  DEBUG_ASSERT(ch != NIL_);
+  assert(ch != NIL_);
   do {
     num++;
     ch = NxtChild(ch);
@@ -487,12 +487,12 @@ void SuffixTree<Symb, NSymb>::SetSums() {
       Node &child = GetNode(ch);
       cnt = child.count;       // real count, wide-represented
       scnt = cnt _SHR_ shift;  // short count, reduced
-      DEBUG_ASSERT(cnt > 0);
+      assert(cnt > 0);
       if (scnt == 0)
         scnt = 1;
 
-      DEBUG_ASSERT(scnt <= COUNT_MAX);
-      DEBUG_ASSERT(sum <= sum + (Count)scnt);
+      assert(scnt <= COUNT_MAX);
+      assert(sum <= sum + (Count)scnt);
       sum += (Count)scnt;
       child.sum = sum;
 
@@ -505,18 +505,18 @@ void SuffixTree<Symb, NSymb>::SetSums() {
 // template <class Symb, int NSymb>
 // Count SuffixTree<Symb,NSymb>::SetSums(PNode n, Count prev, int shift)
 //{
-//	DEBUG_ASSERT(n != NIL);
+//	assert(n != NIL);
 //
 //	// set 'sum' of this node
 //	Node& node = GetNode(n);
 //	int cnt = node.count;			// real count, wide-represented
 //	int scnt = cnt >> shift;		// short count, reduced
-//	DEBUG_ASSERT(cnt > 0);
+//	assert(cnt > 0);
 //	if(scnt == 0) scnt = 1;
 //
-//	DEBUG_ASSERT(scnt <= COUNT_MAX);
+//	assert(scnt <= COUNT_MAX);
 //	node.sum = prev + (Count)scnt;
-//	DEBUG_ASSERT(prev <= node.sum);
+//	assert(prev <= node.sum);
 //
 //	// recursively set 'sum' of descendants
 //	PNode ch = node.child;
@@ -554,7 +554,7 @@ void SuffixTree<Symb, NSymb>::SetSuffix() {
     n = stack.back();
     stack.pop_back();
     Node &node = GetNode(n);
-    DEBUG_ASSERT(n != NIL_);
+    assert(n != NIL_);
 
     // put children on stack
     for (ch = node.child; ch != NIL_; ch = NxtChild(ch)) stack.push_back(ch);
@@ -578,7 +578,7 @@ void SuffixTree<Symb, NSymb>::SetSuffix() {
 // void SuffixTree<Symb,NSymb>::SetSuffix(PNode n)
 //{
 //	// TODO: more sophisticated choose of long suffix link
-//	DEBUG_ASSERT(n != NIL);
+//	assert(n != NIL);
 //	Node& node = GetNode(n);
 //
 //	// recursion
@@ -631,7 +631,7 @@ void SuffixTree<Symb, NSymb>::FindEdge(Edge &e, Symb *str, int len) {
 template <class Symb, int NSymb>
 void SuffixTree<Symb, NSymb>::FindEdge(Edge &e, Count c) {
   if (state_ == NIL_) {
-    DEBUG_ASSERT(c < NSymb);
+    assert(c < NSymb);
     e.n = ROOT_;
     e.s = (Symb)c;
     return;
@@ -646,7 +646,7 @@ void SuffixTree<Symb, NSymb>::FindEdge(Edge &e, Count c) {
   // count
   PNode ch = GetNode(state_).child;
   for (;;) {
-    DEBUG_ASSERT(ch != NIL_);
+    assert(ch != NIL_);
     if (c < GetNode(ch).sum) {
       e.n = ch;
       return;
@@ -696,7 +696,7 @@ void SuffixTree<Symb, NSymb>::GetRange(PNode stt, Edge e, Range &r) {
     r.low = GetNode(PrvChild(e.n)).sum;
   r.high = GetNode(e.n).sum;
 
-  DEBUG_ASSERT(r.low < r.high);
+  assert(r.low < r.high);
 }
 
 template <class Symb, int NSymb>
@@ -706,7 +706,7 @@ void SuffixTree<Symb, NSymb>::Move(Symb *str, int &len, Range &rng, Count &total
   len = GetLen(e);
   GetRange(state_, e, rng);
   total = GetTotal(state_);
-  DEBUG_ASSERT(rng.high <= total);
+  assert(rng.high <= total);
   Move(e);
 }
 

--- a/storage/tianmu/compress/text_compressor.cpp
+++ b/storage/tianmu/compress/text_compressor.cpp
@@ -48,8 +48,8 @@ namespace compress {
 TextCompressor::TextCompressor() : BLD_START_(0), BLD_RATIO_(0.0), graph_() {}
 
 void TextCompressor::SetSplit(int len) {
-  DEBUG_ASSERT(len > 0);
-  DEBUG_ASSERT(BLD_RATIO_ > 1.01);
+  assert(len > 0);
+  assert(BLD_RATIO_ > 1.01);
   double ratio = len / (double)BLD_START_;
   if (ratio < 1.0)
     ratio = 1.0;
@@ -67,11 +67,11 @@ void TextCompressor::SetSplit(int len) {
   double next = BLD_START_;
   for (int i = 1; i < n; i++) {
     split_[i] = (int)next;
-    DEBUG_ASSERT(split_[i] > split_[i - 1]);
+    assert(split_[i] > split_[i - 1]);
     next *= bld_ratio;
   }
   split_[n] = len;
-  DEBUG_ASSERT(split_[n] > split_[n - 1]);
+  assert(split_[n] > split_[n - 1]);
 }
 
 void TextCompressor::SetParams(PPMParam &p, int ver, [[maybe_unused]] int lev, int len) {
@@ -305,8 +305,8 @@ CprsErr TextCompressor::CompressVer2(char *dest, int &dlen, char **index, const 
     }
     PermNext(i, nrec);
   }
-  DEBUG_ASSERT(sdata == mem);
-  DEBUG_ASSERT(i == PermFirst(nrec));
+  assert(sdata == mem);
+  assert(i == PermFirst(nrec));
 
   // header
   dest[0] = 1;                 // data is encoded

--- a/storage/tianmu/compress/top_bit_dict.cpp
+++ b/storage/tianmu/compress/top_bit_dict.cpp
@@ -62,7 +62,7 @@ uint TopBitDict<T>::FindOptimum(DataSet<T> *dataset, uint nbit, uint &opt_bit, D
       break;
 
     // make prediction
-    DEBUG_ASSERT(nrec <= MAX_TOTAL_);
+    assert(nrec <= MAX_TOTAL_);
     double uplen = 0.0;
     short nkey;
     auto keys = dict->GetKeys(nkey);
@@ -102,7 +102,7 @@ uint TopBitDict<T>::FindOptimum(DataSet<T> *dataset, uint nbit, uint &opt_bit, D
     return INF_;
   if (opt_skip > 1) {
     bool ok = Insert(opt_dict, data, nbit, opt_bit, nrec, 1);
-    // DEBUG_ASSERT(ok);
+    // assert(ok);
     if (ok == false)
       return INF_;
     // don't recalculate prediction
@@ -115,7 +115,7 @@ inline bool TopBitDict<T>::Insert(Dictionary<T> *dict, T *data, uint nbit, uint 
   dict->InitInsert();
   if (top_bottom_ == TopBottom::tbTop) {  // top bits
     uchar bitlow = (uchar)(nbit - bit);
-    DEBUG_ASSERT(bitlow < sizeof(T) * 8);
+    assert(bitlow < sizeof(T) * 8);
     for (uint i = 0; i < nrec; i += skiprec)
       if (!dict->Insert(data[i] >> bitlow))
         return false;
@@ -140,7 +140,7 @@ bool TopBitDict<T>::Encode(RangeCoder *coder, DataSet<T> *dataset) {
   uint nbit = core::GetBitLen(maxval), bitdict;
   if (FindOptimum(dataset, nbit, bitdict, dict) >= 0.98 * this->PredictUni(dataset))
     return false;
-  DEBUG_ASSERT(bitdict);
+  assert(bitdict);
 
   dict->SetLows();
 
@@ -153,7 +153,7 @@ bool TopBitDict<T>::Encode(RangeCoder *coder, DataSet<T> *dataset) {
   coder->EncodeUniform(bitlow_, (T)64);
 
   // save dictionary
-  DEBUG_ASSERT(bitlow_ < sizeof(maxval) * 8);
+  assert(bitlow_ < sizeof(maxval) * 8);
   T maxhigh = maxval >> bitlow_, maxlow = ((T)1 _SHL_ bitlow_) - (T)1;
   T dictmax = (top_bottom_ == TopBottom::tbTop) ? maxhigh : maxlow;
   dict->Save(coder, dictmax);
@@ -165,7 +165,7 @@ bool TopBitDict<T>::Encode(RangeCoder *coder, DataSet<T> *dataset) {
   bool esc;
 
   // encode data
-  DEBUG_ASSERT(bitlow_ < sizeof(T) * 8);
+  assert(bitlow_ < sizeof(T) * 8);
   if (top_bottom_ == TopBottom::tbTop)
     for (uint i = 0; i < nrec; i++) {
       esc = dict->Encode(coder, data[i] >> bitlow_);
@@ -197,7 +197,7 @@ void TopBitDict<T>::Decode(RangeCoder *coder, DataSet<T> *dataset) {
 
   // load dictionary
   Dictionary<T> *dict = counters_;
-  DEBUG_ASSERT(bitlow_ < sizeof(dataset->maxval) * 8);
+  assert(bitlow_ < sizeof(dataset->maxval) * 8);
   T maxhigh = dataset->maxval >> bitlow_, maxlow = ((T)1 _SHL_ bitlow_) - (T)1;
   T dictmax = (top_bottom_ == TopBottom::tbTop) ? maxhigh : maxlow;
   dict->Load(coder, dictmax);
@@ -218,7 +218,7 @@ template <class T>
 void TopBitDict<T>::Merge(DataSet<T> *dataset) {
   T *data = dataset->data;
   uint nrec = dataset->nrec;
-  DEBUG_ASSERT(bitlow_ < sizeof(T) * 8);
+  assert(bitlow_ < sizeof(T) * 8);
   if (top_bottom_ == TopBottom::tbTop)
     for (uint i = 0; i < nrec; i++) data[i] |= decoded_[i] << bitlow_;
   else

--- a/storage/tianmu/compress/word_graph.cpp
+++ b/storage/tianmu/compress/word_graph.cpp
@@ -32,7 +32,7 @@ WordGraph::WordGraph(const Symb *data, int dlen, bool insatend) {
     dlen_ = (int)std::strlen((const char *)data) + 1;
   else
     dlen_ = dlen;
-  DEBUG_ASSERT(dlen_ > 0);
+  assert(dlen_ > 0);
 
   data_ = data;  // the data_ are NOT copied!
   insatend_ = insatend;
@@ -108,7 +108,7 @@ void WordGraph::Create() {
         last = NIL_;
       }
     }
-    DEBUG_ASSERT(last == NIL_);
+    assert(last == NIL_);
   }
 }
 
@@ -124,8 +124,8 @@ WordGraph::PNode WordGraph::NewFinal(int endpos) {
 }
 
 void WordGraph::MoveDown(Point &p, const uchar *&s, const uchar *sstop) {
-  DEBUG_ASSERT(p.proj == 0);
-  DEBUG_ASSERT(s != sstop);
+  assert(p.proj == 0);
+  assert(s != sstop);
   const uchar *lbl;
   uint len;
   uint &proj = p.proj;
@@ -194,8 +194,8 @@ void WordGraph::Duplicate(Point &p) {
   const Symb *s = data_ + n1.endpos;
   Point q = p;
   do {
-    DEBUG_ASSERT(q.proj == GE(q.edge).GetLen());
-    DEBUG_ASSERT(q.proj > 0);
+    assert(q.proj == GE(q.edge).GetLen());
+    assert(q.proj > 0);
     GE(q.edge).n = pn2;
     MoveSuffix(q, s,
                false);  // move 'q' along suffix link, don't canonize the last edge
@@ -209,7 +209,7 @@ void WordGraph::MoveSuffix(Point &p, const uchar *s, bool canonlast) {
   uint len;
   while (p.proj > 0) {
     e = FindEdge(p.n, *(s - p.proj));
-    DEBUG_ASSERT(e != ENIL_);
+    assert(e != ENIL_);
 
     len = GE(e).GetLen();
     if ((p.proj < len) || (!canonlast && (p.proj == len))) {
@@ -523,12 +523,12 @@ void WordGraph::SetSums() {
 
       cnt = GN(e.n).count;     // real count, wide-represented
       scnt = cnt _SHR_ shift;  // short count, reduced
-      DEBUG_ASSERT(cnt > 0);
+      assert(cnt > 0);
       if (scnt == 0)
         scnt = 1;
 
-      DEBUG_ASSERT(scnt <= COUNT_MAX / 4);
-      DEBUG_ASSERT(sum <= sum + (Count)scnt);
+      assert(scnt <= COUNT_MAX / 4);
+      assert(sum <= sum + (Count)scnt);
       sum += (Count)scnt;
 
       stack.push_back(e.n);
@@ -550,7 +550,7 @@ void WordGraph::SetShadow([[maybe_unused]] PNode pn) {
     return;  // don't make shadow edges_ for leaves
 
   // fill in the 'shlen_' array of edge lengths
-  DEBUG_ASSERT(sizeof(shlen_) == N_Symb_ * sizeof(*shlen_));
+  assert(sizeof(shlen_) == N_Symb_ * sizeof(*shlen_));
   std::memset(shlen_, 0, sizeof(shlen_));  // isn't it faster to clear only the
                                            // used cells of 'shlen_' at the end?
   do {
@@ -563,7 +563,7 @@ void WordGraph::SetShadow([[maybe_unused]] PNode pn) {
   // TODO: try to do it approximately but faster
   Node &n2 = GN(n1.suf);
   pe = n2.edge;
-  DEBUG_ASSERT(pe != ENIL_);
+  assert(pe != ENIL_);
   int totcnt = 0;
   do {
     Edge &e = GE(pe);
@@ -585,7 +585,7 @@ void WordGraph::SetShadow([[maybe_unused]] PNode pn) {
   do {
     Edge &e = GE(pe);
     if (shlen_[e.fsym] != e.GetLen()) {
-      DEBUG_ASSERT((shlen_[e.fsym] == 0) || (shlen_[e.fsym] > e.GetLen()));
+      assert((shlen_[e.fsym] == 0) || (shlen_[e.fsym] > e.GetLen()));
       sedges_.resize(n1.sedge + ++n1.nshadow);
       SEdge &se = sedges_.back();
       se.fsym = e.fsym;
@@ -593,12 +593,12 @@ void WordGraph::SetShadow([[maybe_unused]] PNode pn) {
 
       cnt = GN(e.n).count;     // real count, wide-represented
       scnt = cnt _SHR_ shift;  // short count, reduced
-      DEBUG_ASSERT(cnt > 0);
+      assert(cnt > 0);
       if (scnt == 0)
         scnt = 1;
 
-      DEBUG_ASSERT(scnt <= COUNT_MAX / 4);
-      DEBUG_ASSERT(stotal <= stotal + (Count)scnt);
+      assert(scnt <= COUNT_MAX / 4);
+      assert(stotal <= stotal + (Count)scnt);
       stotal += (Count)scnt;
     }
     pe = e.next;
@@ -624,7 +624,7 @@ int WordGraph::Shift(int c) {
 
 void WordGraph::FindEdge(PEdge &e, PSEdge &se, Symb *str, int len) {
   // find the edge beginning with symbol str[0]
-  DEBUG_ASSERT(len > 0);
+  assert(len > 0);
   if (state_.prev == NIL_) {  // the last transition was forward
     se = SENIL_;
     e = FindEdge(state_.n, str[0]);
@@ -638,7 +638,7 @@ void WordGraph::FindEdge(PEdge &e, PSEdge &se, Symb *str, int len) {
     }
     e = FindEdge(state_.n, str[0]);
   }
-  DEBUG_ASSERT(e != ENIL_);
+  assert(e != ENIL_);
 
   // check if the rest of the edge label is the same as 'str'
   PNode n = GE(e).n;
@@ -672,7 +672,7 @@ void WordGraph::FindEdge(PEdge &e, PSEdge &se, Count c) {
       e = ENIL_;
     } else {
       e = FindEdge(state_.n, GSE(se).fsym);
-      DEBUG_ASSERT(e != ENIL_);
+      assert(e != ENIL_);
     }
 
 #else
@@ -728,7 +728,7 @@ void WordGraph::GetRange(PEdge e, [[maybe_unused]] PSEdge se, Range &r) {
 #endif
   }
 
-  DEBUG_ASSERT(r.low < r.high);
+  assert(r.low < r.high);
 }
 
 void WordGraph::Move(PEdge e) {
@@ -781,7 +781,7 @@ void WordGraph::Move(Symb *str, int &len, Range &rng, Count &total) {
   len = (e == ENIL_ ? 0 : GE(e).GetLen());
   GetRange(e, se, rng);
   total = GetTotal_();
-  DEBUG_ASSERT(rng.high <= total);
+  assert(rng.high <= total);
 
 #ifdef MAKELOG
   MakeLog(state_.n, e);
@@ -886,7 +886,7 @@ WordGraph::PEdge WordGraph::AddEdge(PNode n, Symb s, int len, bool solid, PNode 
 //}
 
 Count WordGraph::GetEscCount([[maybe_unused]] PNode n, [[maybe_unused]] int c) {
-  DEBUG_ASSERT(c >= 0);
+  assert(c >= 0);
 #ifdef EXP_ESC_COUNT
   return (int)(param_.esc_coef * pow(c, param_.esc_exp)) + param_.esc_count;
 #else
@@ -895,7 +895,7 @@ Count WordGraph::GetEscCount([[maybe_unused]] PNode n, [[maybe_unused]] int c) {
 }
 
 Count WordGraph::GetShEscCount([[maybe_unused]] PNode n, [[maybe_unused]] int c) {
-  DEBUG_ASSERT(c >= 0);
+  assert(c >= 0);
 #ifdef EXP_ESC_COUNT
   return (int)(param_.esc_coef * pow(c, param_.esc_exp)) + param_.esc_count;
 #else

--- a/storage/tianmu/compress/word_graph.h
+++ b/storage/tianmu/compress/word_graph.h
@@ -187,9 +187,9 @@ class WordGraph : public PPMModel {
 
   Count GetEscCount(PNode n, int c = 0);
   Count GetShEscCount(PNode n, int c = 0);
-  // Count GetEscCount(PNode n)	{ DEBUG_ASSERT(n != NIL_); return
+  // Count GetEscCount(PNode n)	{ assert(n != NIL_); return
   // param_.esc_count; }
-  // Count GetShEscCount(PNode n)	{ DEBUG_ASSERT(n != NIL_); return
+  // Count GetShEscCount(PNode n)	{ assert(n != NIL_); return
   // param_.esc_count; }
 
   //-------------------------------------------------------------------------

--- a/storage/tianmu/core/blocked_mem_table.cpp
+++ b/storage/tianmu/core/blocked_mem_table.cpp
@@ -26,7 +26,7 @@ MemBlockManager::~MemBlockManager() {
 }
 
 void *MemBlockManager::GetBlock() {
-  DEBUG_ASSERT(block_size != -1);
+  assert(block_size != -1);
 
   if (hard_size_limit != -1 && hard_size_limit <= current_size)
     return nullptr;
@@ -89,7 +89,7 @@ void MemBlockManager::FreeBlock(void *b) {
 
 void BlockedRowMemStorage::Init(int rowl, std::shared_ptr<MemBlockManager> mbm, uint64_t initial_size,
                                 int min_block_len) {
-  DEBUG_ASSERT(no_rows == 0);
+  assert(no_rows == 0);
   CalculateBlockSize(rowl, min_block_len);
   bman = mbm;
   bman->SetBlockSize(block_size);
@@ -159,7 +159,7 @@ int64_t BlockedRowMemStorage::AddEmptyRow() {
 }
 
 void BlockedRowMemStorage::Rewind(bool rel) {
-  DEBUG_ASSERT(!release);
+  assert(!release);
   release = rel;
   if (no_rows == 0) {
     current = -1;

--- a/storage/tianmu/core/blocked_mem_table.h
+++ b/storage/tianmu/core/blocked_mem_table.h
@@ -49,7 +49,7 @@ class MemBlockManager final : public mm::TraceableObject {
    */
   void SetBlockSize(int bsize) {
     std::scoped_lock guard(mx);
-    DEBUG_ASSERT((current_size == 0 || block_size == bsize));
+    assert((current_size == 0 || block_size == bsize));
     block_size = bsize;
   }
 
@@ -123,7 +123,7 @@ class BlockedRowMemStorage {
 
   //! provide the pointer to the requested row bytes
   void *GetRow(int64_t r) {
-    DEBUG_ASSERT(r < no_rows);
+    assert(r < no_rows);
     int64_t b = r >> npower;
     return ((char *)blocks[b]) + row_len * (r & ndx_mask);
   }
@@ -139,7 +139,7 @@ class BlockedRowMemStorage {
   int64_t AddEmptyRow();
 
   void Set(uint64_t idx, const void *r) {
-    DEBUG_ASSERT(idx < static_cast<uint64_t>(no_rows));
+    assert(idx < static_cast<uint64_t>(no_rows));
     std::memcpy(((char *)blocks[idx >> npower]) + (idx & ndx_mask) * row_len, r, row_len);
   }
 

--- a/storage/tianmu/core/bloom_block.cpp
+++ b/storage/tianmu/core/bloom_block.cpp
@@ -138,7 +138,7 @@ FilterBlockBuilder::FilterBlockBuilder(const FilterPolicy *policy) : policy_(pol
 
 void FilterBlockBuilder::StartBlock(uint64_t block_offset) {
   uint64_t filter_index = (block_offset / kFilterBase);
-  DEBUG_ASSERT(filter_index >= filter_offsets_.size());
+  assert(filter_index >= filter_offsets_.size());
   while (filter_index > filter_offsets_.size()) {
     GenerateFilter();
   }

--- a/storage/tianmu/core/bloom_block.h
+++ b/storage/tianmu/core/bloom_block.h
@@ -53,7 +53,7 @@ class Slice {
   // Return the ith byte in the referenced data.
   // REQUIRES: n < size()
   char operator[](size_t n) const {
-    DEBUG_ASSERT(n < size());
+    assert(n < size());
     return data_[n];
   }
 
@@ -65,7 +65,7 @@ class Slice {
 
   // Drop the first "n" bytes from this slice.
   void remove_prefix(size_t n) {
-    DEBUG_ASSERT(n <= size());
+    assert(n <= size());
     data_ += n;
     size_ -= n;
   }

--- a/storage/tianmu/core/cached_buffer.cpp
+++ b/storage/tianmu/core/cached_buffer.cpp
@@ -36,7 +36,7 @@ CachedBuffer<T>::CachedBuffer(uint page_size, uint _elem_size, Transaction *conn
 
 CachedBuffer<types::BString>::CachedBuffer(uint page_size, uint elem_size, Transaction *conn)
     : system::CacheableItem("PS", "CB"), page_size(page_size), elem_size(elem_size), m_conn(conn) {
-  // DEBUG_ASSERT(elem_size);
+  // assert(elem_size);
   CI_SetDefaultSize(page_size * (elem_size + 4));
 
   size_t buf_size = sizeof(char) * (size_t)page_size * (elem_size + 4);
@@ -58,7 +58,7 @@ CachedBuffer<types::BString>::~CachedBuffer() { dealloc(buf); }
 
 template <class T>
 T &CachedBuffer<T>::Get(uint64_t idx) {
-  DEBUG_ASSERT(page_size > 0);
+  assert(page_size > 0);
   if (idx / page_size != loaded_page)
     LoadPage((uint)(idx / page_size));
   return buf[idx % page_size];
@@ -91,7 +91,7 @@ void CachedBuffer<T>::Set(uint64_t idx, const T &value) {
 }
 
 void CachedBuffer<types::BString>::Set(uint64_t idx, const types::BString &value) {
-  DEBUG_ASSERT(value.len_ <= elem_size);
+  assert(value.len_ <= elem_size);
   if (idx / page_size != loaded_page)
     LoadPage((uint)(idx / page_size));
   uint pos = (uint)(idx % page_size) * (elem_size + 4);

--- a/storage/tianmu/core/cached_buffer.h
+++ b/storage/tianmu/core/cached_buffer.h
@@ -44,9 +44,7 @@ class CachedBuffer : public system::CacheableItem, public mm::TraceableObject {
   uint64_t PageSize() { return page_size; }
   void SetNewPageSize(uint new_page_size);
   T &Get(uint64_t idx);
-  void Get([[maybe_unused]] types::BString &s, [[maybe_unused]] uint64_t idx) {
-    assert("use only for BString" && 0);
-  }
+  void Get([[maybe_unused]] types::BString &s, [[maybe_unused]] uint64_t idx) { assert("use only for BString" && 0); }
   void Set(uint64_t idx, const T &value);
 
   mm::TO_TYPE TraceableType() const override { return mm::TO_TYPE::TO_CACHEDBUFFER; }

--- a/storage/tianmu/core/cached_buffer.h
+++ b/storage/tianmu/core/cached_buffer.h
@@ -45,7 +45,7 @@ class CachedBuffer : public system::CacheableItem, public mm::TraceableObject {
   void SetNewPageSize(uint new_page_size);
   T &Get(uint64_t idx);
   void Get([[maybe_unused]] types::BString &s, [[maybe_unused]] uint64_t idx) {
-    DEBUG_ASSERT("use only for BString" && 0);
+    assert("use only for BString" && 0);
   }
   void Set(uint64_t idx, const T &value);
 

--- a/storage/tianmu/core/data_cache.h
+++ b/storage/tianmu/core/data_cache.h
@@ -251,7 +251,7 @@ class DataCache final {
         obj->TrackAccess();
       }
       m_packLoadInProgress--;
-      DEBUG_ASSERT(c.find(coord_) == c.end());
+      assert(c.find(coord_) == c.end());
       c.insert(std::make_pair(coord_, obj));
       w.erase(coord_);
     }

--- a/storage/tianmu/core/dimension_group.cpp
+++ b/storage/tianmu/core/dimension_group.cpp
@@ -44,13 +44,13 @@ DimensionGroupFilter::DimensionGroupFilter(int dim, Filter *f_source, int copy_m
 DimensionGroupFilter::~DimensionGroupFilter() { delete f; }
 
 DimensionGroup::Iterator *DimensionGroupFilter::NewIterator([[maybe_unused]] DimensionVector &dim, uint32_t power) {
-  DEBUG_ASSERT(dim[base_dim]);
+  assert(dim[base_dim]);
   return new DGFilterIterator(f, power);
 }
 
 DimensionGroup::Iterator *DimensionGroupFilter::NewOrderedIterator([[maybe_unused]] DimensionVector &dim,
                                                                    PackOrderer *po, uint32_t power) {
-  DEBUG_ASSERT(dim[base_dim]);
+  assert(dim[base_dim]);
   return new DGFilterOrderedIterator(f, po, power);
 }
 
@@ -125,7 +125,7 @@ void DimensionGroupMaterialized::NewDimensionContent(int dim, IndexTable *tnew,
                                                      bool nulls)  // tnew will be added (as a pointer to be deleted by
                                                                   // destructor) on a dimension dim
 {
-  DEBUG_ASSERT(dims_used[dim]);
+  assert(dims_used[dim]);
   delete t[dim];
   t[dim] = tnew;
   nulls_possible[dim] = nulls;
@@ -141,7 +141,7 @@ void DimensionGroupMaterialized::FillCurrentPos(DimensionGroup::Iterator *it, in
 }
 
 DimensionGroup::Iterator *DimensionGroupMaterialized::NewIterator(DimensionVector &dim, uint32_t power) {
-  DEBUG_ASSERT(no_dims == dim.Size());  // otherwise incompatible dimensions
+  assert(no_dims == dim.Size());  // otherwise incompatible dimensions
   return new DGMaterializedIterator(no_obj, dim, t, nulls_possible, power);
 }
 
@@ -257,7 +257,7 @@ void DimensionGroupMaterialized::DGMaterializedIterator::InitPackrow() {
   cur_pack_start = cur_pos;
   if (cur_pos == 0 && pack_size_left == no_obj)
     inside_one_pack = true;
-  DEBUG_ASSERT(pack_size_left > 0);
+  assert(pack_size_left > 0);
 }
 
 bool DimensionGroupMaterialized::DGMaterializedIterator::NextInsidePack() {
@@ -339,7 +339,7 @@ void DimensionGroupMaterialized::DGMaterializedIterator::FindPackEnd(int dim) {
     cur_pack[dim] = loc_pack;
     next_pack[dim] = loc_iterator;
   }
-  DEBUG_ASSERT(next_pack[dim] > cur_pos);
+  assert(next_pack[dim] > cur_pos);
 }
 
 int DimensionGroupMaterialized::DGMaterializedIterator::GetNextPackrow(int dim, int ahead) {

--- a/storage/tianmu/core/dimension_group.h
+++ b/storage/tianmu/core/dimension_group.h
@@ -150,12 +150,12 @@ class DimensionGroupFilter : public DimensionGroup {
   }
   void UpdateNumOfTuples() override { no_obj = f->NumOfOnes(); }
   Filter *GetFilter([[maybe_unused]] int dim) const override {
-    DEBUG_ASSERT(dim == base_dim || dim == -1);
+    assert(dim == base_dim || dim == -1);
     return f;
   }
   // For this type of filter: dim == -1 means the only existing one
   Filter *GetUpdatableFilter([[maybe_unused]] int dim) const override {
-    DEBUG_ASSERT(dim == base_dim || dim == -1);
+    assert(dim == base_dim || dim == -1);
     return f;
   }
   bool DimUsed(int dim) override { return base_dim == dim; }
@@ -176,7 +176,7 @@ class DimensionGroupFilter : public DimensionGroup {
     DGFilterIterator(const Iterator &sec, uint32_t power);
 
     void operator++() override {
-      DEBUG_ASSERT(valid);
+      assert(valid);
       ++fi;
       valid = fi.IsValid();
     }
@@ -194,7 +194,7 @@ class DimensionGroupFilter : public DimensionGroup {
     bool InsideOnePack() override { return fi.InsideOnePack(); }
     bool NullsExist([[maybe_unused]] int dim) override { return false; }
     void NextPackrow() override {
-      DEBUG_ASSERT(valid);
+      assert(valid);
       fi.NextPack();
       valid = fi.IsValid();
     }
@@ -240,7 +240,7 @@ class DimensionGroupFilter : public DimensionGroup {
     DGFilterOrderedIterator(const Iterator &sec, uint32_t power);
 
     void operator++() override {
-      DEBUG_ASSERT(valid);
+      assert(valid);
       ++fi;
       valid = fi.IsValid();
     }
@@ -258,7 +258,7 @@ class DimensionGroupFilter : public DimensionGroup {
     bool InsideOnePack() override { return fi.InsideOnePack(); }
     bool NullsExist([[maybe_unused]] int dim) override { return false; }
     void NextPackrow() override {
-      DEBUG_ASSERT(valid);
+      assert(valid);
       fi.NextPack();
       valid = fi.IsValid();
     }

--- a/storage/tianmu/core/dimension_group_multiple.cpp
+++ b/storage/tianmu/core/dimension_group_multiple.cpp
@@ -82,8 +82,8 @@ void MultiIndexTable::Iterator::Increment() {
 }
 
 int64_t MultiIndexTable::Iterator::GetCurPos() {
-  DEBUG_ASSERT(table_index_ < index_table_->table_items_.size());
-  DEBUG_ASSERT(cur_pos_ >= 0);
+  assert(table_index_ < index_table_->table_items_.size());
+  assert(cur_pos_ >= 0);
   IndexTableItem &table(index_table_->table_items_[table_index_]);
   if (cur_pos_ >= table.GetCount())
     return common::NULL_VALUE_64;
@@ -91,7 +91,7 @@ int64_t MultiIndexTable::Iterator::GetCurPos() {
 }
 
 void MultiIndexTable::Iterator::Skip(int64_t offset) {
-  DEBUG_ASSERT(offset <= pack_size_left_);
+  assert(offset <= pack_size_left_);
 
   cur_pos_ += offset;
   pack_size_left_ -= offset;
@@ -119,7 +119,7 @@ bool MultiIndexTable::Iterator::BarrierAfterPackrow() {
 }
 
 void MultiIndexTable::Iterator::SetFixedBlockIndex(size_t index) {
-  DEBUG_ASSERT(index < index_table_->table_items_.size());
+  assert(index < index_table_->table_items_.size());
   valid_ = true;
   table_index_ = index;
   cur_pos_ = 0;
@@ -150,7 +150,7 @@ void MultiIndexTable::Iterator::InitPackrow() {
   pack_size_left_ = next_pack_pos - cur_pos_;
   cur_pack_start_ = cur_pos_;
 
-  DEBUG_ASSERT(pack_size_left_ > 0);
+  assert(pack_size_left_ > 0);
 }
 
 //-------------------------------MultiIndexTable------------------------------------------
@@ -231,7 +231,7 @@ void DimensionGroupMultiMaterialized::Empty() {
 }
 
 void DimensionGroupMultiMaterialized::AddDimensionContent(int dim, IndexTable *table, int count, bool nulls) {
-  DEBUG_ASSERT(dims_used_[dim]);
+  assert(dims_used_[dim]);
 
   MultiIndexTable *tables = dim_tables_[dim];
   if (!tables) {
@@ -269,7 +269,7 @@ int DimensionGroupMultiMaterialized::NumOfLocks(int dim) {
 }
 
 DimensionGroup::Iterator *DimensionGroupMultiMaterialized::NewIterator(DimensionVector &dim, uint32_t power) {
-  DEBUG_ASSERT(dims_count_ == dim.Size());  // Otherwise incompatible dimensions.
+  assert(dims_count_ == dim.Size());  // Otherwise incompatible dimensions.
   return new DGIterator(no_obj, dim, dim_tables_, power);
 }
 

--- a/storage/tianmu/core/dimension_group_virtual.cpp
+++ b/storage/tianmu/core/dimension_group_virtual.cpp
@@ -88,7 +88,7 @@ void DimensionGroupVirtual::NewDimensionContent(int dim, IndexTable *tnew,
                                                 bool nulls)  // tnew will be added (as a pointer to be deleted by
                                                              // destructor) on a dimension dim
 {
-  DEBUG_ASSERT(dims_used[dim]);
+  assert(dims_used[dim]);
   delete t[dim];
   t[dim] = tnew;
   nulls_possible[dim] = nulls;
@@ -136,7 +136,7 @@ void DimensionGroupVirtual::UpdateNumOfTuples() {
   no_obj = f->NumOfOnes();
   for (int d = 0; d < no_dims; d++)
     if (t[d])
-      DEBUG_ASSERT((uint64_t)no_obj <= t[d]->N());  // N() is an upper size of buffer
+      assert((uint64_t)no_obj <= t[d]->N());  // N() is an upper size of buffer
 }
 
 bool DimensionGroupVirtual::IsOrderable() {
@@ -199,7 +199,7 @@ DimensionGroupVirtual::DGVirtualIterator::DGVirtualIterator(const Iterator &sec,
 }
 
 void DimensionGroupVirtual::DGVirtualIterator::operator++() {
-  DEBUG_ASSERT(valid);
+  assert(valid);
   ++fi;
   valid = fi.IsValid();
   dim_pos++;
@@ -217,7 +217,7 @@ bool DimensionGroupVirtual::DGVirtualIterator::NextInsidePack() {
 }
 
 void DimensionGroupVirtual::DGVirtualIterator::NextPackrow() {
-  DEBUG_ASSERT(valid);
+  assert(valid);
   dim_pos += fi.GetPackSizeLeft();
   cur_pack_start = dim_pos;
   fi.NextPack();
@@ -225,7 +225,7 @@ void DimensionGroupVirtual::DGVirtualIterator::NextPackrow() {
 }
 
 int64_t DimensionGroupVirtual::DGVirtualIterator::GetCurPos(int dim) {
-  DEBUG_ASSERT(dim_pos < no_obj);
+  assert(dim_pos < no_obj);
   if (dim == base_dim)
     return (*fi);
   int64_t res = t[dim]->Get64(dim_pos);
@@ -305,7 +305,7 @@ DimensionGroupVirtual::DGVirtualOrderedIterator::~DGVirtualOrderedIterator() {
 }
 
 void DimensionGroupVirtual::DGVirtualOrderedIterator::operator++() {
-  DEBUG_ASSERT(valid);
+  assert(valid);
   bool new_pack = (fi.GetPackSizeLeft() <= 1);
   ++fi;
   valid = fi.IsValid();
@@ -334,7 +334,7 @@ void DimensionGroupVirtual::DGVirtualOrderedIterator::Rewind() {
 }
 
 void DimensionGroupVirtual::DGVirtualOrderedIterator::NextPackrow() {
-  DEBUG_ASSERT(valid);
+  assert(valid);
   fi.NextPack();
   valid = fi.IsValid();
   if (valid)

--- a/storage/tianmu/core/dimension_vector.h
+++ b/storage/tianmu/core/dimension_vector.h
@@ -41,7 +41,7 @@ class DimensionVector {
   }
 
   bool operator==(const DimensionVector &d2) const {
-    DEBUG_ASSERT(Size() == d2.Size());
+    assert(Size() == d2.Size());
     for (int i = 0; i < Size(); ++i)
       if (v[i] != d2.v[i])
         return false;
@@ -63,7 +63,7 @@ class DimensionVector {
 
   // true if any common dimension present
   bool Intersects(DimensionVector &sec) {
-    DEBUG_ASSERT(v.size() == sec.v.size());
+    assert(v.size() == sec.v.size());
     for (size_t i = 0; i < v.size(); i++)
       if (v[i] && sec.v[i])
         return true;
@@ -73,7 +73,7 @@ class DimensionVector {
 
   // true if all dimensions from sec are present in *this
   bool Includes(DimensionVector &sec) {
-    DEBUG_ASSERT(v.size() == sec.v.size());
+    assert(v.size() == sec.v.size());
     for (size_t i = 0; i < v.size(); i++)
       if (sec.v[i] && !v[i])
         return false;
@@ -83,7 +83,7 @@ class DimensionVector {
 
   // exclude from *this all dimensions present in sec
   void Minus(DimensionVector &sec) {
-    DEBUG_ASSERT(v.size() == sec.v.size());
+    assert(v.size() == sec.v.size());
     for (size_t i = 0; i < v.size(); i++)
       if (sec.v[i])
         v[i] = false;
@@ -91,7 +91,7 @@ class DimensionVector {
 
   // include in *this all dimensions present in sec
   void Plus(DimensionVector &sec) {
-    DEBUG_ASSERT(v.size() == sec.v.size());
+    assert(v.size() == sec.v.size());
     for (size_t i = 0; i < v.size(); i++)
       if (sec.v[i])
         v[i] = true;

--- a/storage/tianmu/core/engine.cpp
+++ b/storage/tianmu/core/engine.cpp
@@ -1167,8 +1167,7 @@ int Engine::SetUpCacheFolder(const std::string &cachefolder_path) {
 }
 
 std::string get_parameter_name(enum tianmu_param_name vn) {
-  assert(static_cast<int>(vn) >= 0 &&
-               static_cast<int>(vn) <= static_cast<int>(tianmu_param_name::TIANMU_VAR_LIMIT));
+  assert(static_cast<int>(vn) >= 0 && static_cast<int>(vn) <= static_cast<int>(tianmu_param_name::TIANMU_VAR_LIMIT));
   return tianmu_var_name_strings[static_cast<int>(vn)];
 }
 

--- a/storage/tianmu/core/engine.cpp
+++ b/storage/tianmu/core/engine.cpp
@@ -1167,7 +1167,7 @@ int Engine::SetUpCacheFolder(const std::string &cachefolder_path) {
 }
 
 std::string get_parameter_name(enum tianmu_param_name vn) {
-  DEBUG_ASSERT(static_cast<int>(vn) >= 0 &&
+  assert(static_cast<int>(vn) >= 0 &&
                static_cast<int>(vn) <= static_cast<int>(tianmu_param_name::TIANMU_VAR_LIMIT));
   return tianmu_var_name_strings[static_cast<int>(vn)];
 }

--- a/storage/tianmu/core/engine_convert.cpp
+++ b/storage/tianmu/core/engine_convert.cpp
@@ -34,7 +34,7 @@ bool Engine::ConvertToField(Field *field, types::TianmuDataType &tianmu_item, st
 
   switch (field->type()) {
     case MYSQL_TYPE_VARCHAR: {
-      DEBUG_ASSERT(dynamic_cast<types::BString *>(&tianmu_item));
+      assert(dynamic_cast<types::BString *>(&tianmu_item));
       types::BString &str_val = (types::BString &)tianmu_item;
       if (str_val.size() > field->field_length)
         throw common::DatabaseException("Incorrect field size: " + std::to_string(str_val.size()));
@@ -52,7 +52,7 @@ bool Engine::ConvertToField(Field *field, types::TianmuDataType &tianmu_item, st
       }
       break;
     case MYSQL_TYPE_BLOB: {
-      DEBUG_ASSERT(dynamic_cast<types::BString *>(&tianmu_item));
+      assert(dynamic_cast<types::BString *>(&tianmu_item));
       Field_blob *blob = (Field_blob *)field;
       if (blob_buf == nullptr) {
         blob->set_ptr(((types::BString &)tianmu_item).len_, (uchar *)((types::BString &)tianmu_item).val_);
@@ -130,7 +130,7 @@ bool Engine::ConvertToField(Field *field, types::TianmuDataType &tianmu_item, st
               *reinterpret_cast<double *>(field->ptr) = (double)((types::TianmuNum &)(tianmu_item));
               break;
             default:
-              DEBUG_ASSERT(!"No data types conversion available!");
+              assert(!"No data types conversion available!");
               break;
           }
           break;
@@ -649,9 +649,9 @@ AttributeTypeInfo Engine::GetCorrespondingATI(Field &field) {
   common::ColumnType at = GetCorrespondingType(field);
 
   if (ATI::IsNumericType(at)) {
-    DEBUG_ASSERT(dynamic_cast<Field_num *>(&field));
+    assert(dynamic_cast<Field_num *>(&field));
     if (at == common::ColumnType::NUM) {
-      DEBUG_ASSERT(dynamic_cast<Field_new_decimal *>(&field));
+      assert(dynamic_cast<Field_new_decimal *>(&field));
       return AttributeTypeInfo(at, !field.maybe_null(), static_cast<Field_new_decimal &>(field).precision,
                                static_cast<Field_num &>(field).decimals());
     }

--- a/storage/tianmu/core/engine_execute.cpp
+++ b/storage/tianmu/core/engine_execute.cpp
@@ -358,7 +358,7 @@ int optimize_select(THD *thd, ulong select_options, Query_result *result, SELECT
 QueryRouteTo handle_exceptions(THD *, Transaction *, bool with_error = false);
 
 QueryRouteTo Engine::Execute(THD *thd, LEX *lex, Query_result *result_output, SELECT_LEX_UNIT *unit_for_union) {
-  DEBUG_ASSERT(thd->lex == lex);
+  assert(thd->lex == lex);
   SELECT_LEX *selects_list = lex->select_lex;
   SELECT_LEX *last_distinct = nullptr;
   if (unit_for_union != nullptr)
@@ -622,7 +622,7 @@ int st_select_lex_unit::optimize_for_tianmu() {
       }
       // re-enabling indexes for next subselect iteration
       if (union_distinct && table->file->ha_enable_indexes(HA_KEY_SWITCH_ALL))
-        DEBUG_ASSERT(0);
+        assert(0);
     }
     for (SELECT_LEX *sl = select_cursor; sl; sl = sl->next_select()) {
       thd->lex->set_current_select(sl);
@@ -686,7 +686,7 @@ int st_select_lex_unit::optimize_for_tianmu() {
         join = fake_select_lex->join;
       else {
         if (!(join = new JOIN(thd, fake_select_lex)))
-          DEBUG_ASSERT(0);
+          assert(0);
         // fake_select_lex->set_join(join);
       }
 

--- a/storage/tianmu/core/engine_results.cpp
+++ b/storage/tianmu/core/engine_results.cpp
@@ -367,7 +367,7 @@ void ResultSender::SendRecord(const std::vector<std::unique_ptr<types::TianmuDat
 }
 
 void ResultSender::Send(TempTable *t) {
-  DEBUG_ASSERT(t->IsMaterialized());
+  assert(t->IsMaterialized());
   t->CreateDisplayableAttrP();
   TempTable::RecordIterator iter = t->begin();
   TempTable::RecordIterator iter_end = t->end();
@@ -405,7 +405,7 @@ ResultSender::~ResultSender() { delete[] buf_lens; }
 ResultExportSender::ResultExportSender(THD *thd, Query_result *result, List<Item> &fields)
     : ResultSender(thd, result, fields) {
   export_res_ = dynamic_cast<exporter::select_tianmu_export *>(result);
-  DEBUG_ASSERT(export_res_);
+  assert(export_res_);
 }
 
 void ResultExportSender::SendEof() {
@@ -467,7 +467,7 @@ AttributeTypeInfo create_ati(THD *&thd, TABLE &tmp_table, Item *&item) {
 void ResultExportSender::Init(TempTable *t) {
   thd->proc_info = "Exporting data";
   DBUG_PRINT("info", ("%s", thd->proc_info));
-  DEBUG_ASSERT(t);
+  assert(t);
 
   thd->lex->unit->offset_limit_cnt = 0;
 

--- a/storage/tianmu/core/hash_table.cpp
+++ b/storage/tianmu/core/hash_table.cpp
@@ -117,7 +117,7 @@ void HashTable::Initialize(int64_t max_table_size, [[maybe_unused]] bool easy_ro
 }
 
 int64_t HashTable::AddKeyValue(const std::string &key_buffer, bool *too_many_conflicts) {
-  DEBUG_ASSERT(key_buffer.size() == key_buf_width_);
+  assert(key_buffer.size() == key_buf_width_);
 
   if (rows_of_occupied_ >= rows_limit_)  // no more space
     return common::NULL_VALUE_64;
@@ -136,7 +136,7 @@ int64_t HashTable::AddKeyValue(const std::string &key_buffer, bool *too_many_con
       if (std::memcmp(cur_t, key_buffer.c_str(), key_buf_width_) == 0) {
         // i.e. identical row found
         int64_t last_multiplier = *multiplier;
-        DEBUG_ASSERT(last_multiplier > 0);
+        assert(last_multiplier > 0);
         (*multiplier)++;
         if (for_count_only_)
           return row;
@@ -160,7 +160,7 @@ int64_t HashTable::AddKeyValue(const std::string &key_buffer, bool *too_many_con
       return row;
     }
   } while (row != startrow);
-  DEBUG_ASSERT("Never reach here!");
+  assert("Never reach here!");
   return common::NULL_VALUE_64;  // search deadlock (we returned to the same
                                  // position)
 }
@@ -195,7 +195,7 @@ int64_t HashTable::GetTupleValue(int col, int64_t row) {
 
 HashTable::Finder::Finder(HashTable *hash_table, std::string *key_buffer)
     : hash_table_(hash_table), key_buffer_(key_buffer) {
-  DEBUG_ASSERT(key_buffer_->size() == hash_table_->key_buf_width_);
+  assert(key_buffer_->size() == hash_table_->key_buf_width_);
   LocateMatchedPosition();
 }
 
@@ -243,7 +243,7 @@ int64_t HashTable::Finder::GetNextRow() {
   if (current_row_ >= hash_table_->rows_count_)
     current_row_ = current_row_ % hash_table_->rows_count_;
   do {
-    DEBUG_ASSERT(
+    assert(
         *((int *)(hash_table_->buffer_ + current_row_ * hash_table_->total_width_ + hash_table_->multi_offset_)) != 0);
     if (std::memcmp(hash_table_->buffer_ + current_row_ * hash_table_->total_width_, key_buffer_->data(),
                     key_buffer_->size()) == 0) {

--- a/storage/tianmu/core/hash_table.cpp
+++ b/storage/tianmu/core/hash_table.cpp
@@ -243,8 +243,8 @@ int64_t HashTable::Finder::GetNextRow() {
   if (current_row_ >= hash_table_->rows_count_)
     current_row_ = current_row_ % hash_table_->rows_count_;
   do {
-    assert(
-        *((int *)(hash_table_->buffer_ + current_row_ * hash_table_->total_width_ + hash_table_->multi_offset_)) != 0);
+    assert(*((int *)(hash_table_->buffer_ + current_row_ * hash_table_->total_width_ + hash_table_->multi_offset_)) !=
+           0);
     if (std::memcmp(hash_table_->buffer_ + current_row_ * hash_table_->total_width_, key_buffer_->data(),
                     key_buffer_->size()) == 0) {
       // i.e. identical row found - keep the current_row_

--- a/storage/tianmu/core/item_tianmu_field.h
+++ b/storage/tianmu/core/item_tianmu_field.h
@@ -188,7 +188,7 @@ class Item_tianmuyear : public Item_tianmudatetime_base {
   int length;
 
  public:
-  Item_tianmuyear(int len) : length(len) { DEBUG_ASSERT(length == 2 || length == 4); }
+  Item_tianmuyear(int len) : length(len) { assert(length == 2 || length == 4); }
   longlong val_int() override;
   String *val_str(String *s) override;
   bool get_date(MYSQL_TIME *ltime, uint fuzzydate) override;

--- a/storage/tianmu/core/mysql_expression.cpp
+++ b/storage/tianmu/core/mysql_expression.cpp
@@ -163,7 +163,7 @@ bool MysqlExpression::SanityAggregationCheck(Item *item, std::set<Item *> &field
 
 Item_tianmufield *MysqlExpression::GetTianmufieldItem(Item_field *ifield) {
   auto key = item2varid->find(ifield);
-  DEBUG_ASSERT(key != item2varid->end());
+  assert(key != item2varid->end());
   auto it = tianmu_fields_cache.find(key->second);
   Item_tianmufield *tianmufield = nullptr;
   if (it != tianmu_fields_cache.end()) {
@@ -353,7 +353,7 @@ Item *MysqlExpression::TransformTree(Item *root, TransformDirection dir) {
 MysqlExpression::SetOfVars &MysqlExpression::GetVars() { return vars; }
 
 void MysqlExpression::SetBufsOrParams(var_buf_t *bufs) {
-  DEBUG_ASSERT(bufs);
+  assert(bufs);
   for (auto &it : tianmu_fields_cache) {
     auto buf_set = bufs->find(it.first);
     if (buf_set != bufs->end()) {
@@ -435,7 +435,7 @@ DataType MysqlExpression::EvalType(TypOfVars *tv) {
       // the bug inside common::TxtDataFormat::StaticExtrnalSize.
       break;
     case ROW_RESULT:
-      DEBUG_ASSERT(0 && "unexpected type: ROW_RESULT");
+      assert(0 && "unexpected type: ROW_RESULT");
       break;
   }
   return type;
@@ -464,7 +464,7 @@ std::shared_ptr<ValueOrNull> MysqlExpression::Evaluate() {
     case STRING_RESULT:
       return ItemString2ValueOrNull(item, type.precision, type.attrtype);
     default:
-      DEBUG_ASSERT(0 && "unexpected value");
+      assert(0 && "unexpected value");
   }
   return std::make_shared<ValueOrNull>();
 }
@@ -540,7 +540,7 @@ std::shared_ptr<ValueOrNull> MysqlExpression::ItemString2ValueOrNull(Item *item,
       }
     } else {
       uint len = ret->length();
-      DEBUG_ASSERT(p[len] == 0);
+      assert(p[len] == 0);
       if (maxstrlen >= 0 && len > uint(maxstrlen)) {
         len = maxstrlen;
         p[len] = 0;

--- a/storage/tianmu/core/parallel_hash_join.cpp
+++ b/storage/tianmu/core/parallel_hash_join.cpp
@@ -102,7 +102,7 @@ class MILinearRowTaskIterator : public MITaskIterator {
   }
 
   bool IsValid(MIIterator *iter) const override {
-    DEBUG_ASSERT(iter->GetOneFilterDim() > -1);
+    assert(iter->GetOneFilterDim() > -1);
     int64_t cur_pos = (*iter)[iter->GetOneFilterDim()];
     // If not set rows_ended, the rows_ended_ is -1.
     // If the rows_ended_ isn't -1, here should compare with cur_pos.
@@ -189,7 +189,7 @@ void TraversedHashTable::GetColumnEncoder(std::vector<ColumnBinEncoder> *column_
 }
 
 ColumnBinEncoder *TraversedHashTable::GetColumnEncoder(size_t col) {
-  DEBUG_ASSERT(col < column_bin_encoder_.size());
+  assert(col < column_bin_encoder_.size());
   return &column_bin_encoder_[col];
 }
 
@@ -493,7 +493,7 @@ int64_t ParallelHashJoiner::TraverseDim(MIIterator &mit, int64_t *outer_tuples) 
   std::vector<MITaskIterator *> task_iterators;
   MIIterator::SliceCapability slice_capability = mit.GetSliceCapability();
   if (slice_capability.type == MIIterator::SliceCapability::Type::kFixed) {
-    DEBUG_ASSERT(!slice_capability.slices.empty());
+    assert(!slice_capability.slices.empty());
     splitting_type = "fixed";
     size_t slices_size = slice_capability.slices.size();
     int64_t rows_started = 0;
@@ -706,7 +706,7 @@ bool ParallelHashJoiner::CreateMatchingTasks(MIIterator &mit, int64_t rows_count
     }
   }
   if (slice_capability.type == MIIterator::SliceCapability::Type::kFixed) {
-    DEBUG_ASSERT(!slice_capability.slices.empty());
+    assert(!slice_capability.slices.empty());
     size_t slices_size = slice_capability.slices.size();
     int64_t rows_started = 0;
     for (size_t index = 0; index < slices_size; ++index) {
@@ -860,7 +860,7 @@ int64_t ParallelHashJoiner::MatchDim(MIIterator &mit) {
 int64_t ParallelHashJoiner::AsyncMatchDim(MatchTaskParams *params) {
   MEASURE_FET("ParallelHashJoiner::AsyncMatchDim(...)");
 
-  DEBUG_ASSERT(!traversed_hash_tables_.empty());
+  assert(!traversed_hash_tables_.empty());
 
   // ftht: first_traversed_hash_table.
   auto &ftht = traversed_hash_tables_[0];
@@ -1097,7 +1097,7 @@ int64_t ParallelHashJoiner::SubmitOuterTraversed() {
   MEASURE_FET("ParallelHashJoiner::SubmitOuterTraversed(...)");
 
   std::shared_ptr<MultiIndexBuilder::BuildItem> build_item = multi_index_builder_->CreateBuildItem();
-  DEBUG_ASSERT(build_item);
+  assert(build_item);
 
   int64_t outer_added = 0;
   for (auto &it : traversed_hash_tables_) {
@@ -1168,7 +1168,7 @@ void ParallelHashJoiner::AsyncSubmitOuterMatched(OuterMatchedParams *params, Mut
 int64_t ParallelHashJoiner::SubmitOuterMatched(MIIterator &miter) {
   MEASURE_FET("ParallelHashJoiner::SubmitOuterMatched(...)");
   // miter - an iterator through the matched dimensions
-  DEBUG_ASSERT(outer_matched_filter_ && watch_matched_);
+  assert(outer_matched_filter_ && watch_matched_);
   if (tips.count_only)
     return outer_matched_filter_->GetOnesCount();
 

--- a/storage/tianmu/core/parameterized_filter.cpp
+++ b/storage/tianmu/core/parameterized_filter.cpp
@@ -906,7 +906,7 @@ void ParameterizedFilter::SyntacticalDescriptorListPreprocessing(bool for_rough_
   // descriptor preparation (normalization etc.)
   for (uint i = 0; i < no_desc; i++) {            // Note that desc.size() may enlarge
                                                   // when joining with BETWEEN occur
-    DEBUG_ASSERT(descriptors_[i].done == false);  // If not false, check it carefully.
+    assert(descriptors_[i].done == false);  // If not false, check it carefully.
     if (descriptors_[i].IsTrue()) {
       if (descriptors_[i].IsInner())
         descriptors_[i].done = true;
@@ -917,7 +917,7 @@ void ParameterizedFilter::SyntacticalDescriptorListPreprocessing(bool for_rough_
     if (descriptors_[i].IsDelayed())
       continue;
 
-    DEBUG_ASSERT(descriptors_[i].lop == common::LogicalOperator::O_AND);
+    assert(descriptors_[i].lop == common::LogicalOperator::O_AND);
     // if(descriptors_[i].lop != common::LogicalOperator::O_AND && descriptors_[i].IsType_Join() &&
     // (descriptors_[i].op == common::Operator::O_BETWEEN || descriptors_[i].op ==
     // common::Operator::O_NOT_BETWEEN))

--- a/storage/tianmu/core/parameterized_filter.cpp
+++ b/storage/tianmu/core/parameterized_filter.cpp
@@ -904,8 +904,8 @@ void ParameterizedFilter::SyntacticalDescriptorListPreprocessing(bool for_rough_
   bool false_desc = false;
 
   // descriptor preparation (normalization etc.)
-  for (uint i = 0; i < no_desc; i++) {            // Note that desc.size() may enlarge
-                                                  // when joining with BETWEEN occur
+  for (uint i = 0; i < no_desc; i++) {      // Note that desc.size() may enlarge
+                                            // when joining with BETWEEN occur
     assert(descriptors_[i].done == false);  // If not false, check it carefully.
     if (descriptors_[i].IsTrue()) {
       if (descriptors_[i].IsInner())

--- a/storage/tianmu/core/proxy_hash_joiner.cpp
+++ b/storage/tianmu/core/proxy_hash_joiner.cpp
@@ -60,7 +60,7 @@ class MIIteratorPoller {
         if (tianmu_sysvar_async_join_setting.pack_per_step > 0)
           slice_type_ = base::sprint("per %d packs", tianmu_sysvar_async_join_setting.pack_per_step);
         else {
-          DEBUG_ASSERT(tianmu_sysvar_async_join_setting.rows_per_step > 0);
+          assert(tianmu_sysvar_async_join_setting.rows_per_step > 0);
           slice_type_ = base::sprint("per %d rows", tianmu_sysvar_async_join_setting.rows_per_step);
         }
       } else {
@@ -81,7 +81,7 @@ class MIIteratorPoller {
       size_t step = 1;
       int64_t sentry_pos = slice_capability_.slices.size();
       if (slice_capability_.type == MIIterator::SliceCapability::Type::kLinear) {
-        DEBUG_ASSERT(tianmu_sysvar_async_join_setting.pack_per_step > 0 ||
+        assert(tianmu_sysvar_async_join_setting.pack_per_step > 0 ||
                      tianmu_sysvar_async_join_setting.rows_per_step > 0);
         // Preferred iterating by pack.
         if (tianmu_sysvar_async_join_setting.pack_per_step > 0) {
@@ -96,7 +96,7 @@ class MIIteratorPoller {
             }
           }
         } else {
-          DEBUG_ASSERT(tianmu_sysvar_async_join_setting.rows_per_step > 0);
+          assert(tianmu_sysvar_async_join_setting.rows_per_step > 0);
 
           sentry_pos = origin_size_;
 
@@ -115,7 +115,7 @@ class MIIteratorPoller {
           }
         }
       } else {
-        DEBUG_ASSERT(slice_capability_.type == MIIterator::SliceCapability::Type::kFixed);
+        assert(slice_capability_.type == MIIterator::SliceCapability::Type::kFixed);
         pack_iter.reset(new MIStepIterator(cur_pos_, tianmu_sysvar_async_join_setting.pack_per_step, *miter_));
       }
 

--- a/storage/tianmu/core/proxy_hash_joiner.cpp
+++ b/storage/tianmu/core/proxy_hash_joiner.cpp
@@ -82,7 +82,7 @@ class MIIteratorPoller {
       int64_t sentry_pos = slice_capability_.slices.size();
       if (slice_capability_.type == MIIterator::SliceCapability::Type::kLinear) {
         assert(tianmu_sysvar_async_join_setting.pack_per_step > 0 ||
-                     tianmu_sysvar_async_join_setting.rows_per_step > 0);
+               tianmu_sysvar_async_join_setting.rows_per_step > 0);
         // Preferred iterating by pack.
         if (tianmu_sysvar_async_join_setting.pack_per_step > 0) {
           pack_iter.reset(new MIPackStepIterator(cur_pos_, tianmu_sysvar_async_join_setting.pack_per_step, *miter_));

--- a/storage/tianmu/core/query.cpp
+++ b/storage/tianmu/core/query.cpp
@@ -461,9 +461,9 @@ void Query::ExtractOperatorType(Item *&conds, common::Operator &op, bool &negati
 vcolumn::VirtualColumn *Query::CreateColumnFromExpression(std::vector<MysqlExpression *> const &exprs,
                                                           TempTable *temp_table, int temp_table_alias,
                                                           MultiIndex *mind) {
-  DEBUG_ASSERT(exprs.size() > 0);
+  assert(exprs.size() > 0);
   if (exprs.size() != 1) {
-    DEBUG_ASSERT(0);
+    assert(0);
   }
 
   vcolumn::VirtualColumn *vc = nullptr;
@@ -526,7 +526,7 @@ bool Query::IsParameterFromWhere(const TabID &params_table) {
     if (it.first == params_table)
       return it.second;
   }
-  DEBUG_ASSERT(!"Subquery not properly placed on compilation stack");
+  assert(!"Subquery not properly placed on compilation stack");
   return true;
 }
 
@@ -624,14 +624,14 @@ TempTable *Query::Preexecute(CompiledQuery &qu, ResultSender *sender, [[maybe_un
           ta[-step.t1.n - 1] = t2_ptr;
           break;
         case CompiledQuery::StepType::TMP_TABLE:
-          DEBUG_ASSERT(step.t1.n < 0);
+          assert(step.t1.n < 0);
           ta[-step.t1.n - 1] = step.n1
                                    ? TempTable::Create(ta[-step.tables1[0].n - 1].get(), step.tables1[0].n, this, true)
                                    : TempTable::Create(ta[-step.tables1[0].n - 1].get(), step.tables1[0].n, this);
           ((TempTable *)ta[-step.t1.n - 1].get())->ReserveVirtColumns(qu.NumOfVirtualColumns(step.t1));
           break;
         case CompiledQuery::StepType::CREATE_CONDS:
-          DEBUG_ASSERT(step.t1.n < 0);
+          assert(step.t1.n < 0);
           if (step.ex_op == common::ExtraOperation::EX_COND_PUSH) {
             ((TempTable *)ta[-step.t1.n - 1].get())->MarkCondPush();
           }
@@ -652,7 +652,7 @@ TempTable *Query::Preexecute(CompiledQuery &qu, ResultSender *sender, [[maybe_un
                   (step.op == common::Operator::O_LIKE || step.op == common::Operator::O_NOT_LIKE) ? char(step.n2)
                                                                                                    : '\\');
             } else {
-              DEBUG_ASSERT(conds[step.c2.n]->IsType_Tree());
+              assert(conds[step.c2.n]->IsType_Tree());
               conds[step.c1.n]->AddDescriptor(static_cast<SingleTreeCondition *>(conds[step.c2.n])->GetTree(),
                                               (TempTable *)ta[-step.t1.n - 1].get(), qu.GetNumOfDimens(step.t1));
             }
@@ -662,7 +662,7 @@ TempTable *Query::Preexecute(CompiledQuery &qu, ResultSender *sender, [[maybe_un
                   new SingleTreeCondition(step.e1, step.op, step.e2, step.e3, (TempTable *)ta[-step.t1.n - 1].get(),
                                           qu.GetNumOfDimens(step.t1), char(step.n2));
             else {
-              DEBUG_ASSERT(conds[step.c2.n]->IsType_Tree());
+              assert(conds[step.c2.n]->IsType_Tree());
               conds[step.c1.n] = new Condition();
               conds[step.c1.n]->AddDescriptor(((SingleTreeCondition *)conds[step.c2.n])->GetTree(),
                                               (TempTable *)ta[-step.t1.n - 1].get(), qu.GetNumOfDimens(step.t1));
@@ -692,14 +692,14 @@ TempTable *Query::Preexecute(CompiledQuery &qu, ResultSender *sender, [[maybe_un
               }
             }
           } else if (conds[step.c1.n]->IsType_Tree()) {  // on result = false
-            DEBUG_ASSERT(conds[step.c2.n]->IsType_Tree());
+            assert(conds[step.c2.n]->IsType_Tree());
             common::LogicalOperator lop = (step.type == CompiledQuery::StepType::AND_F ? common::LogicalOperator::O_AND
                                                                                        : common::LogicalOperator::O_OR);
             static_cast<SingleTreeCondition *>(conds[step.c1.n])
                 ->AddTree(lop, static_cast<SingleTreeCondition *>(conds[step.c2.n])->GetTree(),
                           qu.GetNumOfDimens(step.t1));
           } else {
-            DEBUG_ASSERT(conds[step.c2.n]->IsType_Tree());
+            assert(conds[step.c2.n]->IsType_Tree());
             conds[step.c1.n]->AddDescriptor(static_cast<SingleTreeCondition *>(conds[step.c2.n])->GetTree(),
                                             (TempTable *)ta[-qu.GetTableOfCond(step.c1).n - 1].get(),
                                             qu.GetNumOfDimens(qu.GetTableOfCond(step.c1)));
@@ -720,7 +720,7 @@ TempTable *Query::Preexecute(CompiledQuery &qu, ResultSender *sender, [[maybe_un
                            ? ((TempTable *)ta[-step.t1.n - 1].get())->GetVirtualColumn(step.e3.vc_id)
                            : nullptr;
           if (!conds[step.c1.n]->IsType_Tree()) {
-            DEBUG_ASSERT(conds[step.c1.n]);
+            assert(conds[step.c1.n]);
             conds[step.c1.n]->AddDescriptor(
                 step.e1, step.op, step.e2, step.e3, (TempTable *)ta[-step.t1.n - 1].get(), qu.GetNumOfDimens(step.t1),
                 (step.op == common::Operator::O_LIKE || step.op == common::Operator::O_NOT_LIKE) ? char(step.n2)
@@ -735,15 +735,15 @@ TempTable *Query::Preexecute(CompiledQuery &qu, ResultSender *sender, [[maybe_un
           break;
         }
         case CompiledQuery::StepType::T_MODE:
-          DEBUG_ASSERT(step.t1.n < 0 && ta[-step.t1.n - 1]->TableType() == TType::TEMP_TABLE);
+          assert(step.t1.n < 0 && ta[-step.t1.n - 1]->TableType() == TType::TEMP_TABLE);
           ((TempTable *)ta[-step.t1.n - 1].get())->SetMode(step.tmpar, step.n1, step.n2);
           break;
         case CompiledQuery::StepType::JOIN_T:
-          DEBUG_ASSERT(step.t1.n < 0 && ta[-step.t1.n - 1]->TableType() == TType::TEMP_TABLE);
+          assert(step.t1.n < 0 && ta[-step.t1.n - 1]->TableType() == TType::TEMP_TABLE);
           ((TempTable *)ta[-step.t1.n - 1].get())->JoinT(t2_ptr.get(), step.t2.n, step.jt);
           break;
         case CompiledQuery::StepType::ADD_CONDS: {
-          DEBUG_ASSERT(step.t1.n < 0 && ta[-step.t1.n - 1]->TableType() == TType::TEMP_TABLE);
+          assert(step.t1.n < 0 && ta[-step.t1.n - 1]->TableType() == TType::TEMP_TABLE);
           if (step.c1.n == common::NULL_VALUE_32)
             break;
           if (step.n1 != static_cast<int64_t>(CondType::HAVING_COND))
@@ -752,14 +752,14 @@ TempTable *Query::Preexecute(CompiledQuery &qu, ResultSender *sender, [[maybe_un
           break;
         }
         case CompiledQuery::StepType::LEFT_JOIN_ON: {
-          DEBUG_ASSERT(step.t1.n < 0 && ta[-step.t1.n - 1]->TableType() == TType::TEMP_TABLE);
+          assert(step.t1.n < 0 && ta[-step.t1.n - 1]->TableType() == TType::TEMP_TABLE);
           if (step.c1.n == common::NULL_VALUE_32)
             break;
           ((TempTable *)ta[-step.t1.n - 1].get())->AddLeftConds(conds[step.c1.n], step.tables1, step.tables2);
           break;
         }
         case CompiledQuery::StepType::INNER_JOIN_ON: {
-          DEBUG_ASSERT(step.t1.n < 0 && ta[-step.t1.n - 1]->TableType() == TType::TEMP_TABLE);
+          assert(step.t1.n < 0 && ta[-step.t1.n - 1]->TableType() == TType::TEMP_TABLE);
           if (step.c1.n == common::NULL_VALUE_32)
             break;
           ((TempTable *)ta[-step.t1.n - 1].get())->AddInnerConds(conds[step.c1.n], step.tables1);
@@ -798,7 +798,7 @@ TempTable *Query::Preexecute(CompiledQuery &qu, ResultSender *sender, [[maybe_un
           break;
         }
         case CompiledQuery::StepType::ADD_COLUMN: {
-          DEBUG_ASSERT(step.t1.n < 0 && ta[-step.t1.n - 1]->TableType() == TType::TEMP_TABLE);
+          assert(step.t1.n < 0 && ta[-step.t1.n - 1]->TableType() == TType::TEMP_TABLE);
           CQTerm e(step.e1);
           if (e.vc_id != common::NULL_VALUE_32)
             e.vc =
@@ -808,13 +808,13 @@ TempTable *Query::Preexecute(CompiledQuery &qu, ResultSender *sender, [[maybe_un
           break;
         }
         case CompiledQuery::StepType::CREATE_VC: {
-          DEBUG_ASSERT(step.t1.n < 0 && ta[-step.t1.n - 1]->TableType() == TType::TEMP_TABLE);
+          assert(step.t1.n < 0 && ta[-step.t1.n - 1]->TableType() == TType::TEMP_TABLE);
           TempTable *t = (TempTable *)ta[-step.t1.n - 1].get();
 
-          DEBUG_ASSERT(t);
+          assert(t);
           if (step.mysql_expr.size() > 0) {
             // vcolumn::VirtualColumn for Expression
-            DEBUG_ASSERT(step.mysql_expr.size() == 1);
+            assert(step.mysql_expr.size() == 1);
             MultiIndex *mind = (step.t2.n == step.t1.n) ? t->GetOutputMultiIndexP() : t->GetMultiIndexP();
             int c = ((TempTable *)ta[-step.t1.n - 1].get())
                         ->AddVirtColumn(CreateColumnFromExpression(step.mysql_expr, t, step.t1.n, mind), step.a1.n);
@@ -844,7 +844,7 @@ TempTable *Query::Preexecute(CompiledQuery &qu, ResultSender *sender, [[maybe_un
             ASSERT(c == step.a1.n, "AddVirtColumn failed");
           } else {
             // vcolumn::VirtualColumn for Subquery
-            DEBUG_ASSERT(ta[-step.t2.n - 1]->TableType() == TType::TEMP_TABLE);
+            assert(ta[-step.t2.n - 1]->TableType() == TType::TEMP_TABLE);
             int c =
                 ((TempTable *)ta[-step.t1.n - 1].get())
                     ->AddVirtColumn(new vcolumn::SubSelectColumn(
@@ -856,17 +856,17 @@ TempTable *Query::Preexecute(CompiledQuery &qu, ResultSender *sender, [[maybe_un
           break;
         }
         case CompiledQuery::StepType::ADD_ORDER: {
-          DEBUG_ASSERT(step.t1.n < 0 && ta[-step.t1.n - 1]->TableType() == TType::TEMP_TABLE && step.n1 >= 0 &&
-                       step.n1 < 2);
-          DEBUG_ASSERT(step.a1.n >= 0 && step.a1.n < qu.NumOfVirtualColumns(step.t1));
+          assert(step.t1.n < 0 && ta[-step.t1.n - 1]->TableType() == TType::TEMP_TABLE && step.n1 >= 0 &&
+                 step.n1 < 2);
+          assert(step.a1.n >= 0 && step.a1.n < qu.NumOfVirtualColumns(step.t1));
           TempTable *loc_t = (TempTable *)ta[-step.t1.n - 1].get();
           loc_t->AddOrder(loc_t->GetVirtualColumn(step.a1.n),
                           (int)step.n1);  // step.n1 = 0 for asc, 1 for desc
           break;
         }
         case CompiledQuery::StepType::UNION:
-          DEBUG_ASSERT(step.t1.n < 0 && step.t2.n < 0 && step.t3.n < 0);
-          DEBUG_ASSERT(ta[-step.t2.n - 1]->TableType() == TType::TEMP_TABLE &&
+          assert(step.t1.n < 0 && step.t2.n < 0 && step.t3.n < 0);
+          assert(ta[-step.t2.n - 1]->TableType() == TType::TEMP_TABLE &&
                        (step.t3.n == common::NULL_VALUE_32 || ta[-step.t3.n - 1]->TableType() == TType::TEMP_TABLE));
           if (step.t1.n != step.t2.n)
             ta[-step.t1.n - 1] = TempTable::Create(*(TempTable *)ta[-step.t2.n - 1].get(), false);
@@ -891,7 +891,7 @@ TempTable *Query::Preexecute(CompiledQuery &qu, ResultSender *sender, [[maybe_un
           }
           break;
         case CompiledQuery::StepType::RESULT:
-          DEBUG_ASSERT(step.t1.n < 0 && static_cast<size_t>(-step.t1.n - 1) < ta.size() &&
+          assert(step.t1.n < 0 && static_cast<size_t>(-step.t1.n - 1) < ta.size() &&
                        ta[-step.t1.n - 1]->TableType() == TType::TEMP_TABLE);
           output_table = (TempTable *)ta[-step.t1.n - 1].get();
           break;
@@ -923,7 +923,7 @@ QueryRouteTo Query::Item2CQTerm(Item *an_arg, CQTerm &term, const TabID &tmp_tab
   an_arg = UnRef(an_arg);
   if (an_arg->type() == Item::SUBSELECT_ITEM) {
     Item_subselect *item_subs = dynamic_cast<Item_subselect *>(an_arg);
-    DEBUG_ASSERT(item_subs && "The cast to (Item_subselect*) was unsuccessful");
+    assert(item_subs && "The cast to (Item_subselect*) was unsuccessful");
 
     bool ignore_limit = false;
     if (dynamic_cast<Item_maxmin_subselect *>(item_subs) != nullptr ||
@@ -1061,7 +1061,7 @@ QueryRouteTo Query::Item2CQTerm(Item *an_arg, CQTerm &term, const TabID &tmp_tab
           tab_id2expression.insert(std::make_pair(tmp_table, std::make_pair(vc.n, expr)));
         }
       } else if (IsAggregationItem(an_arg)) {
-        DEBUG_ASSERT(expr->GetItem()->type() == Item_tianmufield::get_tianmuitem_type());
+        assert(expr->GetItem()->type() == Item_tianmufield::get_tianmuitem_type());
         int col_num =
             ((Item_tianmufield *)expr->GetItem())->varID[((Item_tianmufield *)expr->GetItem())->varID.size() - 1].col;
         auto phys_vc = VirtualColumnAlreadyExists(tmp_table, tmp_table, AttrID(-col_num - 1));
@@ -1470,7 +1470,7 @@ CondID Query::ConditionNumber(Item *conds, const TabID &tmp_table, CondType filt
           if (!item_func)
             continue;
           Item **args = item_func->arguments();
-          DEBUG_ASSERT(item_func->arg_count == 2);
+          assert(item_func->arg_count == 2);
           Item *first_arg = UnRef(args[0]);
           Item *sec_arg = UnRef(args[1]);
           if (IsConstItem(first_arg) && IsFieldItem(sec_arg))
@@ -1922,7 +1922,7 @@ QueryRouteTo Query::BuildCondsIfPossible(Item *conds, CondID &cond_id, const Tab
     if (filter_type == CondType::ON_RIGHT_FILTER) {
       filter_type = CondType::ON_LEFT_FILTER;
     }
-    DEBUG_ASSERT(PrefixCheck(conds) != TableStatus::TABLE_YET_UNSEEN_INVOLVED &&
+    assert(PrefixCheck(conds) != TableStatus::TABLE_YET_UNSEEN_INVOLVED &&
                  "Table not yet seen was involved in this condition");
 
     bool zero_result = conds->type() == Item::INT_ITEM && !conds->val_bool();

--- a/storage/tianmu/core/query.cpp
+++ b/storage/tianmu/core/query.cpp
@@ -856,8 +856,7 @@ TempTable *Query::Preexecute(CompiledQuery &qu, ResultSender *sender, [[maybe_un
           break;
         }
         case CompiledQuery::StepType::ADD_ORDER: {
-          assert(step.t1.n < 0 && ta[-step.t1.n - 1]->TableType() == TType::TEMP_TABLE && step.n1 >= 0 &&
-                 step.n1 < 2);
+          assert(step.t1.n < 0 && ta[-step.t1.n - 1]->TableType() == TType::TEMP_TABLE && step.n1 >= 0 && step.n1 < 2);
           assert(step.a1.n >= 0 && step.a1.n < qu.NumOfVirtualColumns(step.t1));
           TempTable *loc_t = (TempTable *)ta[-step.t1.n - 1].get();
           loc_t->AddOrder(loc_t->GetVirtualColumn(step.a1.n),
@@ -867,7 +866,7 @@ TempTable *Query::Preexecute(CompiledQuery &qu, ResultSender *sender, [[maybe_un
         case CompiledQuery::StepType::UNION:
           assert(step.t1.n < 0 && step.t2.n < 0 && step.t3.n < 0);
           assert(ta[-step.t2.n - 1]->TableType() == TType::TEMP_TABLE &&
-                       (step.t3.n == common::NULL_VALUE_32 || ta[-step.t3.n - 1]->TableType() == TType::TEMP_TABLE));
+                 (step.t3.n == common::NULL_VALUE_32 || ta[-step.t3.n - 1]->TableType() == TType::TEMP_TABLE));
           if (step.t1.n != step.t2.n)
             ta[-step.t1.n - 1] = TempTable::Create(*(TempTable *)ta[-step.t2.n - 1].get(), false);
           if (IsRoughQuery()) {
@@ -892,7 +891,7 @@ TempTable *Query::Preexecute(CompiledQuery &qu, ResultSender *sender, [[maybe_un
           break;
         case CompiledQuery::StepType::RESULT:
           assert(step.t1.n < 0 && static_cast<size_t>(-step.t1.n - 1) < ta.size() &&
-                       ta[-step.t1.n - 1]->TableType() == TType::TEMP_TABLE);
+                 ta[-step.t1.n - 1]->TableType() == TType::TEMP_TABLE);
           output_table = (TempTable *)ta[-step.t1.n - 1].get();
           break;
         case CompiledQuery::StepType::STEP_ERROR:
@@ -1923,7 +1922,7 @@ QueryRouteTo Query::BuildCondsIfPossible(Item *conds, CondID &cond_id, const Tab
       filter_type = CondType::ON_LEFT_FILTER;
     }
     assert(PrefixCheck(conds) != TableStatus::TABLE_YET_UNSEEN_INVOLVED &&
-                 "Table not yet seen was involved in this condition");
+           "Table not yet seen was involved in this condition");
 
     bool zero_result = conds->type() == Item::INT_ITEM && !conds->val_bool();
     if (BuildConditions(conds, cond_id, cq, tmp_table, filter_type, zero_result, join_type) == QueryRouteTo::kToMySQL)

--- a/storage/tianmu/core/query_compile.cpp
+++ b/storage/tianmu/core/query_compile.cpp
@@ -381,8 +381,8 @@ QueryRouteTo Query::AddJoins(List<TABLE_LIST> &join, TabID &tmp_table, std::vect
       if (first_table) {
         left_tables.push_back(tab);
         assert(!join_ptr->join_cond() &&
-                     "It is not possible to join the first table with the LEFT "
-                     "direction");
+               "It is not possible to join the first table with the LEFT "
+               "direction");
         cq->TmpTable(tmp_table, tab, for_subq_in_where);
         first_table = false;
       } else {

--- a/storage/tianmu/core/query_compile.cpp
+++ b/storage/tianmu/core/query_compile.cpp
@@ -357,7 +357,7 @@ QueryRouteTo Query::AddJoins(List<TABLE_LIST> &join, TabID &tmp_table, std::vect
       } else if (join_ptr->join_cond() && !join_ptr->outer_join)
         cq->InnerJoinOn(tmp_table, left_tables, right_tables, cond_id);
     } else {
-      DEBUG_ASSERT(join_ptr->table && "We require that the table is defined if it is not a nested join");
+      assert(join_ptr->table && "We require that the table is defined if it is not a nested join");
       const char *database_name = 0;
       const char *table_name = 0;
       const char *table_alias = 0;
@@ -380,7 +380,7 @@ QueryRouteTo Query::AddJoins(List<TABLE_LIST> &join, TabID &tmp_table, std::vect
       table_alias2index_ptr.insert(std::make_pair(ext_alias, std::make_pair(tab.n, join_ptr->table)));
       if (first_table) {
         left_tables.push_back(tab);
-        DEBUG_ASSERT(!join_ptr->join_cond() &&
+        assert(!join_ptr->join_cond() &&
                      "It is not possible to join the first table with the LEFT "
                      "direction");
         cq->TmpTable(tmp_table, tab, for_subq_in_where);
@@ -614,7 +614,7 @@ QueryRouteTo Query::AddOrderByFields(ORDER *order_by, TabID const &tmp_table, Ta
       WrapStatus ws = WrapMysqlExpression(item, tmp_table, expr, false, false);
       if (ws == WrapStatus::FAILURE)
         return QueryRouteTo::kToMySQL;
-      DEBUG_ASSERT(!expr->IsDeterministic());
+      assert(!expr->IsDeterministic());
       int col_num = AddColumnForMysqlExpression(expr, tmp_table, nullptr, common::ColOperation::LISTING, false, true);
       vc = VirtualColumnAlreadyExists(tmp_table, tmp_table, AttrID(-col_num - 1));
       if (vc.first == common::NULL_VALUE_32) {
@@ -636,7 +636,7 @@ QueryRouteTo Query::AddOrderByFields(ORDER *order_by, TabID const &tmp_table, Ta
         WrapStatus ws = WrapMysqlExpression(item, tmp_table, expr, false, delayed);
         if (ws == WrapStatus::FAILURE)
           return QueryRouteTo::kToMySQL;
-        DEBUG_ASSERT(expr->IsDeterministic());
+        assert(expr->IsDeterministic());
         int col_num = AddColumnForMysqlExpression(
             expr, tmp_table, nullptr, delayed ? common::ColOperation::DELAYED : common::ColOperation::LISTING, false,
             true);
@@ -763,7 +763,7 @@ Query::WrapStatus Query::WrapMysqlExpression(Item *item, const TabID &tmp_table,
           item2varid[it] = VarID(tab.n, col.n);
       } else {
         // aggregation in WHERE not possible unless it is a parameter
-        DEBUG_ASSERT(!IsAggregationItem(it));
+        assert(!IsAggregationItem(it));
         item2varid[it] = VarID(tab.n, col.n);
       }
     }
@@ -828,7 +828,7 @@ Query::WrapStatus Query::WrapMysqlExpression(Item *item, const TabID &tmp_table,
           item2varid[it] = VarID(tab.n, col.n);
         }
       } else
-        DEBUG_ASSERT(0);  // unknown item type?
+        assert(0);  // unknown item type?
     }
   }
   gc_expressions.push_back(expr = new MysqlExpression(item, item2varid));
@@ -848,7 +848,7 @@ int Query::AddColumnForPhysColumn(Item *item, const TabID &tmp_table, TabID cons
                       // temp_table
 
   if (base_table.IsNullID()) {
-    DEBUG_ASSERT(cq->ExistsInTempTable(tab, tmp_table));
+    assert(cq->ExistsInTempTable(tab, tmp_table));
     if (item->type() == Item_tianmufield::get_tianmuitem_type() &&
         IsAggregationItem(dynamic_cast<Item_tianmufield *>(item)->OriginalItem())) {
       return ((Item_tianmufield *)item)->varID[0].col;
@@ -967,7 +967,7 @@ int Query::AddColumnForMysqlExpression(MysqlExpression *mysql_expression, const 
 }
 
 bool Query::IsLocalColumn(Item *item, const TabID &tmp_table) {
-  DEBUG_ASSERT(IsFieldItem(item) || IsAggregationItem(item));
+  assert(IsFieldItem(item) || IsAggregationItem(item));
   AttrID col;
   TabID tab;
   if (!FieldUnmysterify(item, tab, col))

--- a/storage/tianmu/core/quick_math.h
+++ b/storage/tianmu/core/quick_math.h
@@ -51,23 +51,23 @@ class QuickMath {
      // initialization
   static const double logof2;
   static double nlog2n(uint n) {
-    DEBUG_ASSERT(n <= MAX_NLOG2N);
+    assert(n <= MAX_NLOG2N);
     return tab_nlog2n[n];
   }
-  // static double log(uint n)			{ DEBUG_ASSERT(n <= MAX_LOG);
+  // static double log(uint n)			{ assert(n <= MAX_LOG);
   // return tab_log[n]; }
   static double log2(uint n) {
-    DEBUG_ASSERT(n <= MAX_LOG2);
+    assert(n <= MAX_LOG2);
     return tab_log2[n];
   }
   static double log2(double x) { return std::log(x) / logof2; }
   // returns 10^n
   static double power10f(uint n) {
-    DEBUG_ASSERT(n <= MAX_POW10);
+    assert(n <= MAX_POW10);
     return tab_pow10f[n];
   }
   static int64_t power10i(uint n) {
-    DEBUG_ASSERT(n <= MAX_POW10);
+    assert(n <= MAX_POW10);
     return tab_pow10i[n];
   }
 

--- a/storage/tianmu/core/temp_table.cpp
+++ b/storage/tianmu/core/temp_table.cpp
@@ -71,7 +71,7 @@ TempTable::Attr::Attr(const Attr &a) : PhysicalColumn(a) {
   if (term.vc)
     term.vc->ResetLocalStatistics();
   dim = a.dim;
-  // DEBUG_ASSERT(a.buffer == nullptr); // otherwise we cannot copy Attr !
+  // assert(a.buffer == nullptr); // otherwise we cannot copy Attr !
   buffer = nullptr;
   no_obj = a.no_obj;
   no_power = a.no_power;
@@ -122,7 +122,7 @@ TempTable::Attr &TempTable::Attr::operator=(const TempTable::Attr &a) {
   if (term.vc)
     term.vc->ResetLocalStatistics();
   dim = a.dim;
-  // DEBUG_ASSERT(a.buffer == nullptr); // otherwise we cannot copy Attr !
+  // assert(a.buffer == nullptr); // otherwise we cannot copy Attr !
   buffer = nullptr;
   no_obj = a.no_obj;
   no_power = a.no_power;
@@ -332,13 +332,13 @@ void TempTable::Attr::SetValueInt64(int64_t obj, int64_t val) {
         ((AttrBuffer<double> *)buffer)->Set(obj, *(double *)&val);
       break;
     default:
-      DEBUG_ASSERT(0);
+      assert(0);
       break;
   }
 }
 
 void TempTable::Attr::InvalidateRow([[maybe_unused]] int64_t obj) {
-  DEBUG_ASSERT(obj + 1 == no_materialized);
+  assert(obj + 1 == no_materialized);
   no_obj--;
   no_materialized--;
 }
@@ -380,7 +380,7 @@ void TempTable::Attr::SetNull(int64_t obj) {
       ((AttrBuffer<types::BString> *)buffer)->Set(obj, types::BString());
       break;
     default:
-      DEBUG_ASSERT(0);
+      assert(0);
       break;
   }
 }
@@ -539,7 +539,7 @@ void TempTable::Attr::GetValueString(types::BString &value, int64_t obj) {
 }
 
 int64_t TempTable::Attr::GetSum(int pack, bool &nonnegative) {
-  DEBUG_ASSERT(ATI::IsNumericType(ct.GetTypeName()));
+  assert(ATI::IsNumericType(ct.GetTypeName()));
   int64_t start = pack * (1 << no_power);
   int64_t stop = (1 << no_power);
   stop = stop > no_obj ? no_obj : stop;
@@ -669,7 +669,7 @@ int64_t TempTable::Attr::GetValueInt64(int64_t obj) const {
       break;
     case common::ColumnType::STRING:
     case common::ColumnType::VARCHAR:
-      DEBUG_ASSERT(0);
+      assert(0);
       break;
     case common::ColumnType::REAL:
     case common::ColumnType::FLOAT:
@@ -682,7 +682,7 @@ int64_t TempTable::Attr::GetValueInt64(int64_t obj) const {
     case common::ColumnType::BYTE:
     case common::ColumnType::VARBYTE:
     case common::ColumnType::LONGTEXT:
-      DEBUG_ASSERT(0);
+      assert(0);
       break;
     default:
       break;
@@ -718,7 +718,7 @@ int64_t TempTable::Attr::GetNotNullValueInt64(int64_t obj) const {
       res = *(int64_t *)&(*(AttrBuffer<double> *)buffer)[obj];
       break;
     default:
-      DEBUG_ASSERT(0);
+      assert(0);
       break;
   }
   return res;
@@ -770,7 +770,7 @@ bool TempTable::Attr::IsNull(const int64_t obj) const {
 }
 
 void TempTable::Attr::ApplyFilter(MultiIndex &mind_, int64_t offset, int64_t last_index) {
-  DEBUG_ASSERT(mind_.NumOfDimensions() == 1);
+  assert(mind_.NumOfDimensions() == 1);
 
   if (mind_.NumOfDimensions() != 1)
     throw common::NotImplementedException("MultiIndex has too many dimensions.");
@@ -791,7 +791,7 @@ void TempTable::Attr::ApplyFilter(MultiIndex &mind_, int64_t offset, int64_t las
   uint64_t idx = 0;
   for (int64_t i = 0; i < last_index - offset; i++, ++mit) {
     idx = mit[0];
-    DEBUG_ASSERT(idx != static_cast<uint64_t>(common::NULL_VALUE_64));  // null object should never appear
+    assert(idx != static_cast<uint64_t>(common::NULL_VALUE_64));  // null object should never appear
                                                                         // in a materialized temp. table
     switch (TypeName()) {
       case common::ColumnType::INT:
@@ -827,7 +827,7 @@ void TempTable::Attr::ApplyFilter(MultiIndex &mind_, int64_t offset, int64_t las
         ((AttrBuffer<double> *)buffer)->Set(i, (*(AttrBuffer<double> *)old_buffer)[idx]);
         break;
       default:
-        DEBUG_ASSERT(0);
+        assert(0);
         break;
     }
   }
@@ -866,7 +866,7 @@ void TempTable::Attr::ApplyFilter(MultiIndex &mind_, int64_t offset, int64_t las
       delete (AttrBuffer<double> *)old_buffer;
       break;
     default:
-      DEBUG_ASSERT(0);
+      assert(0);
       break;
   }
 }
@@ -1120,7 +1120,7 @@ void TempTable::MoveVC(vcolumn::VirtualColumn *vc, std::vector<vcolumn::VirtualC
 }
 
 void TempTable::ReserveVirtColumns(int no) {
-  DEBUG_ASSERT((no == 0 && virt_cols.size() == 0) || static_cast<size_t>(no) > virt_cols.size());
+  assert((no == 0 && virt_cols.size() == 0) || static_cast<size_t>(no) > virt_cols.size());
   no_global_virt_cols = -1;  // usable value only in TempTable copies and in subq
   virt_cols.resize(no);
   virt_cols_for_having.resize(no);
@@ -1150,7 +1150,7 @@ uint TempTable::GetDisplayableAttrIndex(uint attr) {
       if (idx == attr)
         break;
     }
-  DEBUG_ASSERT(i < attrs.size());
+  assert(i < attrs.size());
   return i;
 }
 
@@ -1165,13 +1165,13 @@ void TempTable::AddConds(Condition *cond, CondType type) {
 
     case CondType::HAVING_COND: {
       Descriptor &desc = cond->operator[](0);
-      DEBUG_ASSERT(desc.tree);
+      assert(desc.tree);
       having_conds.AddDescriptor(desc.tree, this, desc.left_dims.Size());
       break;
     }
 
     default:
-      DEBUG_ASSERT(0);
+      assert(0);
   }
 }
 
@@ -1204,7 +1204,7 @@ void TempTable::SetMode(TMParameter mode, int64_t mode_param1, int64_t mode_para
       this->mode.exists = true;
       break;
     default:
-      DEBUG_ASSERT(false);
+      assert(false);
       break;
   }
 }
@@ -1219,7 +1219,7 @@ int TempTable::AddColumn(CQTerm e, common::ColOperation mode, char *alias, bool 
 
   // new code for vcolumn::VirtualColumn
   if (e.vc_id != common::NULL_VALUE_32) {
-    DEBUG_ASSERT(e.vc);
+    assert(e.vc);
     // enum common::ColOperation {LISTING, COUNT, SUM, MIN, MAX, AVG, GROUP_BY};
     if (mode == common::ColOperation::COUNT) {
       type = common::ColumnType::NUM;  // 64 bit, Decimal(18,0)
@@ -1279,7 +1279,7 @@ int TempTable::AddColumn(CQTerm e, common::ColOperation mode, char *alias, bool 
   } else {
     // illegal execution path: neither VC is set nor mode is
     // common::ColOperation::COUNT
-    DEBUG_ASSERT(!"wrong execution path");
+    assert(!"wrong execution path");
     // throw common::NotImplementedException("Invalid column on SELECT list.");
   }
 
@@ -1312,7 +1312,7 @@ void TempTable::Union(TempTable *t, int all) {
     this->Materialize();
     return;
   }
-  DEBUG_ASSERT(NumOfDisplaybleAttrs() == t->NumOfDisplaybleAttrs());
+  assert(NumOfDisplaybleAttrs() == t->NumOfDisplaybleAttrs());
   if (NumOfDisplaybleAttrs() != t->NumOfDisplaybleAttrs())
     throw common::NotImplementedException("UNION of tables with different number of columns.");
   if (this->IsParametrized() || t->IsParametrized())
@@ -1554,7 +1554,7 @@ void TempTable::Union(TempTable *t, [[maybe_unused]] int all, ResultSender *send
                       int64_t &g_limit) {
   MEASURE_FET("TempTable::UnionSender(...)");
 
-  DEBUG_ASSERT(NumOfDisplaybleAttrs() == t->NumOfDisplaybleAttrs());
+  assert(NumOfDisplaybleAttrs() == t->NumOfDisplaybleAttrs());
   if (NumOfDisplaybleAttrs() != t->NumOfDisplaybleAttrs())
     throw common::NotImplementedException("UNION of tables with different number of columns.");
   if (this->IsParametrized() || t->IsParametrized())
@@ -1631,7 +1631,7 @@ int TempTable::GetDimension(TabID alias) {
 int64_t TempTable::GetTable64(int64_t obj, int attr) {
   if (no_obj == 0)
     return common::NULL_VALUE_64;
-  DEBUG_ASSERT(obj < no_obj && (uint)attr < attrs.size());
+  assert(obj < no_obj && (uint)attr < attrs.size());
   return attrs[attr]->GetValueInt64(obj);
 }
 
@@ -1641,14 +1641,14 @@ void TempTable::GetTable_S(types::BString &s, int64_t obj, int _attr) {
     return;
   }
   uint attr = (uint)_attr;
-  DEBUG_ASSERT(obj < no_obj && attr < attrs.size());
+  assert(obj < no_obj && attr < attrs.size());
   attrs[attr]->GetValueString(s, obj);
 }
 
 bool TempTable::IsNull(int64_t obj, int attr) {
   if (no_obj == 0)
     return true;
-  DEBUG_ASSERT(obj < no_obj && (uint)attr < attrs.size());
+  assert(obj < no_obj && (uint)attr < attrs.size());
   return attrs[attr]->IsNull(obj);
 }
 
@@ -1668,14 +1668,14 @@ uint64_t TempTable::ApproxAnswerSize([[maybe_unused]] int attr,
 void TempTable::GetTableString(types::BString &s, int64_t obj, uint attr) {
   if (no_obj == 0)
     s = types::BString();
-  DEBUG_ASSERT(obj < no_obj && (uint)attr < attrs.size());
+  assert(obj < no_obj && (uint)attr < attrs.size());
   attrs[attr]->GetValueString(s, obj);
 }
 
 types::TianmuValueObject TempTable::GetValueObject(int64_t obj, uint attr) {
   if (no_obj == 0)
     return types::TianmuValueObject();
-  DEBUG_ASSERT(obj < no_obj && (uint)attr < attrs.size());
+  assert(obj < no_obj && (uint)attr < attrs.size());
   return attrs[attr]->GetValue(obj);
 }
 
@@ -1847,7 +1847,7 @@ int TempTable::AddVirtColumn(vcolumn::VirtualColumn *vc) {
 }
 
 int TempTable::AddVirtColumn(vcolumn::VirtualColumn *vc, int no) {
-  DEBUG_ASSERT(static_cast<size_t>(no) < virt_cols.size());
+  assert(static_cast<size_t>(no) < virt_cols.size());
   virt_cols_for_having[no] = (vc->GetMultiIndex() == &output_mind);
   virt_cols[no] = vc;
   return no;
@@ -2025,7 +2025,7 @@ void TempTable::Materialize(bool in_subq, ResultSender *sender, bool lazy) {
   // the case when there is no grouping of attributes, check also DISTINCT
   // modifier of TT
   if (!group_by && !table_distinct) {
-    DEBUG_ASSERT(!distinct_on_materialized);  // should by false here, otherwise must be
+    assert(!distinct_on_materialized);  // should by false here, otherwise must be
                                               // added to conditions below
 
     if (limits_present) {
@@ -2202,7 +2202,7 @@ void TempTable::RecordIterator::PrepareValues() {
 }
 
 TempTable::RecordIterator &TempTable::RecordIterator::operator++() {
-  DEBUG_ASSERT(_currentRNo < uint64_t(table->NumOfObj()));
+  assert(_currentRNo < uint64_t(table->NumOfObj()));
   is_prepared = false;
   ++_currentRNo;
   return (*this);
@@ -2216,8 +2216,8 @@ TempTable::RecordIterator::RecordIterator() : table(nullptr), _currentRNo(0), _c
 
 TempTable::RecordIterator::RecordIterator(TempTable *table_, Transaction *conn_, uint64_t rowNo_)
     : table(table_), _currentRNo(rowNo_), _conn(conn_), is_prepared(false) {
-  DEBUG_ASSERT(table != 0);
-  DEBUG_ASSERT(_currentRNo <= uint64_t(table->NumOfObj()));
+  assert(table != 0);
+  assert(_currentRNo <= uint64_t(table->NumOfObj()));
   for (uint att = 0; att < table->NumOfDisplaybleAttrs(); att++) {
     common::ColumnType att_type = table->GetDisplayableAttrP(att)->TypeName();
     if (att_type == common::ColumnType::INT || att_type == common::ColumnType::MEDIUMINT ||
@@ -2244,12 +2244,12 @@ TempTable::RecordIterator::RecordIterator(RecordIterator const &it)
 }
 
 bool TempTable::RecordIterator::operator==(RecordIterator const &it) const {
-  DEBUG_ASSERT((!(table || it.table)) || (table == it.table));
+  assert((!(table || it.table)) || (table == it.table));
   return (_currentRNo == it._currentRNo);
 }
 
 bool TempTable::RecordIterator::operator!=(RecordIterator const &it) const {
-  DEBUG_ASSERT((!(table || it.table)) || (table == it.table));
+  assert((!(table || it.table)) || (table == it.table));
   return (_currentRNo != it._currentRNo);
 }
 

--- a/storage/tianmu/core/temp_table.cpp
+++ b/storage/tianmu/core/temp_table.cpp
@@ -792,7 +792,7 @@ void TempTable::Attr::ApplyFilter(MultiIndex &mind_, int64_t offset, int64_t las
   for (int64_t i = 0; i < last_index - offset; i++, ++mit) {
     idx = mit[0];
     assert(idx != static_cast<uint64_t>(common::NULL_VALUE_64));  // null object should never appear
-                                                                        // in a materialized temp. table
+                                                                  // in a materialized temp. table
     switch (TypeName()) {
       case common::ColumnType::INT:
       case common::ColumnType::MEDIUMINT:
@@ -2026,7 +2026,7 @@ void TempTable::Materialize(bool in_subq, ResultSender *sender, bool lazy) {
   // modifier of TT
   if (!group_by && !table_distinct) {
     assert(!distinct_on_materialized);  // should by false here, otherwise must be
-                                              // added to conditions below
+                                        // added to conditions below
 
     if (limits_present) {
       if (no_rows_too_large && order_by.size() == 0)

--- a/storage/tianmu/core/temp_table.h
+++ b/storage/tianmu/core/temp_table.h
@@ -160,7 +160,7 @@ class TempTable : public JustATable {
     // called
     void EvaluatePack(MIUpdatingIterator &mit [[maybe_unused]], int dim [[maybe_unused]],
                       Descriptor &desc [[maybe_unused]]) override {
-      DEBUG_ASSERT(0);
+      assert(0);
     }
     common::ErrorCode EvaluateOnIndex(MIUpdatingIterator &mit [[maybe_unused]], int dim [[maybe_unused]],
                                       Descriptor &desc [[maybe_unused]], int64_t limit [[maybe_unused]]) override {
@@ -168,11 +168,11 @@ class TempTable : public JustATable {
       return common::ErrorCode::FAILED;
     }
     types::BString DecodeValue_S(int64_t code [[maybe_unused]]) override {
-      DEBUG_ASSERT(0);
+      assert(0);
       return types::BString();
     }  // TianmuAttr only
     int EncodeValue_S(types::BString &v [[maybe_unused]]) override {
-      DEBUG_ASSERT(0);
+      assert(0);
       return -1;
     }  // lookup (physical) only
   };
@@ -282,42 +282,42 @@ class TempTable : public JustATable {
   int GetDimension(TabID alias);
   std::vector<AttributeTypeInfo> GetATIs(bool orig = false) override;
   int GetAttrScale(int a) {
-    DEBUG_ASSERT(a >= 0 && (uint)a < NumOfAttrs());
+    assert(a >= 0 && (uint)a < NumOfAttrs());
     return attrs[a]->Type().GetScale();
   }
 
   int GetAttrSize(int a) {
-    DEBUG_ASSERT(a >= 0 && (uint)a < NumOfAttrs());
+    assert(a >= 0 && (uint)a < NumOfAttrs());
     return attrs[a]->Type().GetDisplaySize();
   }
 
   uint GetFieldSize(int a) {
-    DEBUG_ASSERT(a >= 0 && (uint)a < NumOfAttrs());
+    assert(a >= 0 && (uint)a < NumOfAttrs());
     return attrs[a]->Type().GetInternalSize();
   }
 
   int GetNumOfDigits(int a) {
-    DEBUG_ASSERT(a >= 0 && (uint)a < NumOfAttrs());
+    assert(a >= 0 && (uint)a < NumOfAttrs());
     return attrs[a]->Type().GetPrecision();
   }
 
   const ColumnType &GetColumnType(int a) override {
-    DEBUG_ASSERT(a >= 0 && (uint)a < NumOfAttrs());
+    assert(a >= 0 && (uint)a < NumOfAttrs());
     return attrs[a]->Type();
   }
 
   PhysicalColumn *GetColumn(int a) override {
-    DEBUG_ASSERT(a >= 0 && (uint)a < NumOfAttrs());
+    assert(a >= 0 && (uint)a < NumOfAttrs());
     return attrs[a];
   }
 
   Attr *GetAttrP(uint a) {
-    DEBUG_ASSERT(a < (uint)NumOfAttrs());
+    assert(a < (uint)NumOfAttrs());
     return attrs[a];
   }
 
   Attr *GetDisplayableAttrP(uint i) {
-    DEBUG_ASSERT(!displayable_attr.empty());
+    assert(!displayable_attr.empty());
     return displayable_attr[i];
   }
   void CreateDisplayableAttrP();
@@ -338,7 +338,7 @@ class TempTable : public JustATable {
   MultiIndex *GetOutputMultiIndexP() { return &output_mind; }
   ParameterizedFilter *GetFilterP() { return &filter; }
   JustATable *GetTableP(uint dim) {
-    DEBUG_ASSERT(dim < tables.size());
+    assert(dim < tables.size());
     return tables[dim];
   }
 
@@ -355,7 +355,7 @@ class TempTable : public JustATable {
   void SetOneOutputRecordSize(uint size) { size_of_one_record = size; }
   uint GetOneOutputRecordSize() { return size_of_one_record; }
   int64_t GetPageSize() {
-    DEBUG_ASSERT(attrs[0]);
+    assert(attrs[0]);
     return attrs[0]->page_size;
   }
 
@@ -371,7 +371,7 @@ class TempTable : public JustATable {
   uint NumOfVirtColumns() { return uint(virt_cols.size()); }
   void ReserveVirtColumns(int no);
   vcolumn::VirtualColumn *GetVirtualColumn(uint col_num) {
-    DEBUG_ASSERT(col_num < virt_cols.size());
+    assert(col_num < virt_cols.size());
     return virt_cols[col_num];
   }
   void SetVCDistinctVals(int dim, int64_t val);  // set dist. vals for all vc of this dimension

--- a/storage/tianmu/core/temp_table_com.cpp
+++ b/storage/tianmu/core/temp_table_com.cpp
@@ -102,7 +102,7 @@ vcolumn::VirtualColumn *CreateVCCopy(vcolumn::VirtualColumn *vc) {
   } else if (dynamic_cast<vcolumn::TypeCastColumn *>(vc))
     return new vcolumn::TypeCastColumn(*static_cast<const vcolumn::TypeCastColumn *>(vc));
   else {
-    DEBUG_ASSERT(0 && "Cannot copy VC");
+    assert(0 && "Cannot copy VC");
     return vc;
   }
 }

--- a/storage/tianmu/core/temp_table_low.cpp
+++ b/storage/tianmu/core/temp_table_low.cpp
@@ -47,7 +47,7 @@ bool TempTable::OrderByAndMaterialize(
   // "limit=10; offset=20" means that the first 10 positions of sorted table will contain objects 21...30.
   MEASURE_FET("TempTable::OrderBy(...)");
   thd_proc_info(m_conn->Thd(), "order by");
-  DEBUG_ASSERT(limit >= 0 && offset >= 0);
+  assert(limit >= 0 && offset >= 0);
   no_obj = limit;
   if ((int)ord.size() == 0 || filter.mind_->NumOfTuples() < 2 || limit == 0) {
     ord.clear();
@@ -103,7 +103,7 @@ bool TempTable::OrderByAndMaterialize(
   for (auto &j : attrs) {
     if (j->alias != nullptr) {
       vcolumn::VirtualColumn *vc = j->term.vc;
-      DEBUG_ASSERT(vc);
+      assert(vc);
       sort_order = 0;
       for (uint i = 0; i < ord.size(); i++)
         if (ord[i].vc == vc) {

--- a/storage/tianmu/core/temp_table_roughquery.cpp
+++ b/storage/tianmu/core/temp_table_roughquery.cpp
@@ -770,7 +770,7 @@ void TempTable::RoughUnion(TempTable *t, ResultSender *sender) {
     return;
   }
 
-  DEBUG_ASSERT(NumOfDisplaybleAttrs() == t->NumOfDisplaybleAttrs());
+  assert(NumOfDisplaybleAttrs() == t->NumOfDisplaybleAttrs());
 
   if (NumOfDisplaybleAttrs() != t->NumOfDisplaybleAttrs())
     throw common::NotImplementedException("UNION of tables with different number of columns.");

--- a/storage/tianmu/core/tianmu_table.cpp
+++ b/storage/tianmu/core/tianmu_table.cpp
@@ -733,32 +733,32 @@ int64_t TianmuTable::NumOfValues() const { return NumOfObj(); }
 uint64_t TianmuTable::NextRowId() { return m_delta->row_id++; }
 
 void TianmuTable::GetTable_S(types::BString &s, int64_t obj, int attr) {
-  DEBUG_ASSERT(static_cast<size_t>(attr) <= m_attrs.size());
-  DEBUG_ASSERT(static_cast<uint64_t>(obj) <= m_attrs[attr]->NumOfObj());
+  assert(static_cast<size_t>(attr) <= m_attrs.size());
+  assert(static_cast<uint64_t>(obj) <= m_attrs[attr]->NumOfObj());
   s = m_attrs[attr]->GetValueString(obj);
 }
 
 int64_t TianmuTable::GetTable64(int64_t obj, int attr) {
-  DEBUG_ASSERT(static_cast<size_t>(attr) <= m_attrs.size());
-  DEBUG_ASSERT(static_cast<uint64_t>(obj) <= m_attrs[attr]->NumOfObj());
+  assert(static_cast<size_t>(attr) <= m_attrs.size());
+  assert(static_cast<uint64_t>(obj) <= m_attrs[attr]->NumOfObj());
   return m_attrs[attr]->GetValueInt64(obj);
 }
 
 bool TianmuTable::IsNull(int64_t obj, int attr) {
-  DEBUG_ASSERT(static_cast<size_t>(attr) <= m_attrs.size());
-  DEBUG_ASSERT(static_cast<uint64_t>(obj) <= m_attrs[attr]->NumOfObj());
+  assert(static_cast<size_t>(attr) <= m_attrs.size());
+  assert(static_cast<uint64_t>(obj) <= m_attrs[attr]->NumOfObj());
   return (m_attrs[attr]->IsNull(obj) ? true : false);
 }
 
 types::TianmuValueObject TianmuTable::GetValue(int64_t obj, int attr, [[maybe_unused]] Transaction *conn) {
-  DEBUG_ASSERT(static_cast<size_t>(attr) <= m_attrs.size());
-  DEBUG_ASSERT(static_cast<uint64_t>(obj) <= m_attrs[attr]->NumOfObj());
+  assert(static_cast<size_t>(attr) <= m_attrs.size());
+  assert(static_cast<uint64_t>(obj) <= m_attrs[attr]->NumOfObj());
   return m_attrs[attr]->GetValue(obj, false);
 }
 
 bool TianmuTable::IsDelete(int64_t row) const { return m_attrs[0]->IsDelete(row); }
 uint TianmuTable::MaxStringSize(int n_a, Filter *f) {
-  DEBUG_ASSERT(n_a >= 0 && static_cast<size_t>(n_a) <= m_attrs.size());
+  assert(n_a >= 0 && static_cast<size_t>(n_a) <= m_attrs.size());
   if (NumOfObj() == 0)
     return 1;
   return m_attrs[n_a]->MaxStringSize(f);

--- a/storage/tianmu/core/value_matching_hashtable.cpp
+++ b/storage/tianmu/core/value_matching_hashtable.cpp
@@ -50,7 +50,7 @@ void ValueMatching_HashTable::Init(int64_t mem_available, int64_t max_no_groups,
   total_width = _total_width;
   matching_width = _match_width;
   input_buffer_width = _input_buf_width;
-  DEBUG_ASSERT(input_buffer_width > 0);  // otherwise another class should be used
+  assert(input_buffer_width > 0);  // otherwise another class should be used
   one_pass = false;
 
   // add 4 bytes for offset
@@ -93,7 +93,7 @@ void ValueMatching_HashTable::Init(int64_t mem_available, int64_t max_no_groups,
   }
 
   // initialize structures
-  DEBUG_ASSERT(mem_available > 0);
+  assert(mem_available > 0);
   size_t min_block_len = max_no_rows * total_width;
   if (min_block_len > 1_GB && size_t(mem_available) > 256_MB)  // very large space needed (>1 GB) and
                                                                // substantial memory available
@@ -142,7 +142,7 @@ bool ValueMatching_HashTable::FindCurrentRow(unsigned char *input_buffer, int64_
         *next_pos = no_rows;
       row_no = no_rows;
     } else {
-      DEBUG_ASSERT(row_no < *next_pos);
+      assert(row_no < *next_pos);
       row_no = *next_pos;
     }
   }
@@ -184,7 +184,7 @@ bool ValueMatching_HashTable::FindCurrentRow(unsigned char *input_buffer, int64_
         *next_pos = no_rows;
       row_no = no_rows;
     } else {
-      DEBUG_ASSERT(row_no < *next_pos);
+      assert(row_no < *next_pos);
       row_no = *next_pos;
     }
   }

--- a/storage/tianmu/core/value_matching_table.cpp
+++ b/storage/tianmu/core/value_matching_table.cpp
@@ -72,7 +72,7 @@ ValueMatching_OnePosition::ValueMatching_OnePosition() {
 }
 
 ValueMatching_OnePosition::ValueMatching_OnePosition(ValueMatching_OnePosition &sec) : ValueMatchingTable(sec) {
-  DEBUG_ASSERT(total_width > 0);
+  assert(total_width > 0);
   iterator_valid = sec.iterator_valid;
 
   t_aggr = nullptr;
@@ -83,7 +83,7 @@ ValueMatching_OnePosition::ValueMatching_OnePosition(ValueMatching_OnePosition &
 ValueMatching_OnePosition::~ValueMatching_OnePosition() { delete[] t_aggr; }
 
 void ValueMatching_OnePosition::Init(int _total_width) {
-  DEBUG_ASSERT(_total_width > 0);
+  assert(_total_width > 0);
   total_width = _total_width;
   matching_width = input_buffer_width = 0;
   t_aggr = new unsigned char[total_width];
@@ -154,7 +154,7 @@ void ValueMatching_LookupTable::Init(int64_t max_group_code, int _total_width, i
   total_width = _total_width;
   matching_width = _match_width;
   input_buffer_width = _input_buf_width;
-  DEBUG_ASSERT(matching_width > 0);  // else another class should be used
+  assert(matching_width > 0);  // else another class should be used
 
   max_no_rows = max_group_code + 1;  // easy case: the row number is just the coded value
 
@@ -170,7 +170,7 @@ void ValueMatching_LookupTable::Init(int64_t max_group_code, int _total_width, i
 bool ValueMatching_LookupTable::FindCurrentRow(unsigned char *input_buffer, int64_t &row, bool add_if_new) {
   row = 0;
   std::memcpy(&row, input_buffer, matching_width);
-  DEBUG_ASSERT(row < max_no_rows);
+  assert(row < max_no_rows);
   if (occupied->Get(row))
     return true;
   if (!add_if_new) {

--- a/storage/tianmu/core/value_matching_table.h
+++ b/storage/tianmu/core/value_matching_table.h
@@ -151,11 +151,11 @@ class ValueMatching_LookupTable : public mm::TraceableObject, public ValueMatchi
   // TO BE OPTIMIZED: actually we don't need any grouping buffer if there's no
   // UTF part
   unsigned char *GetGroupingRow(int64_t row) override {
-    DEBUG_ASSERT(row < max_no_rows);
+    assert(row < max_no_rows);
     return t + row * total_width;
   }
   unsigned char *GetAggregationRow(int64_t row) override {
-    DEBUG_ASSERT(row < max_no_rows);
+    assert(row < max_no_rows);
     return t_aggr + row * total_width;
   }
 

--- a/storage/tianmu/core/value_or_null.h
+++ b/storage/tianmu/core/value_or_null.h
@@ -30,7 +30,7 @@ class ValueOrNull final {
 
  public:
   ValueOrNull() : x(common::NULL_VALUE_64), null(true) {}
-  explicit ValueOrNull(int64_t x) : x(x), null(false) { DEBUG_ASSERT(x != common::NULL_VALUE_64); }
+  explicit ValueOrNull(int64_t x) : x(x), null(false) { assert(x != common::NULL_VALUE_64); }
   ValueOrNull(types::TianmuNum const &tianmu_n);
   ValueOrNull(types::TianmuDateTime const &tianmu_dt);
   ValueOrNull(types::BString const &tianmu_s);

--- a/storage/tianmu/core/value_set.cpp
+++ b/storage/tianmu/core/value_set.cpp
@@ -196,8 +196,8 @@ bool ValueSet::isContains(const types::TianmuDataType &v, DTCollation coll) {
 }
 
 bool ValueSet::Contains(int64_t v) {
-  DEBUG_ASSERT(prepared);
-  DEBUG_ASSERT(v != common::NULL_VALUE_64);
+  assert(prepared);
+  assert(v != common::NULL_VALUE_64);
 
   if (use_easy_table) {
     for (int i = 0; i < no_obj; i++)
@@ -216,7 +216,7 @@ bool ValueSet::Contains(int64_t v) {
 }
 
 bool ValueSet::Contains(types::BString &v) {
-  DEBUG_ASSERT(prepared);  // it implies a trivial collation
+  assert(prepared);  // it implies a trivial collation
 
   if (v.IsNull())
     return false;
@@ -524,7 +524,7 @@ void ValueSet::Prepare(common::ColumnType at, int scale, DTCollation coll) {
           for (const auto &it : values) {
             types::BString *v = static_cast<types::BString *>(it);
             int64_t vcode = easy_text->Encode(*v);
-            DEBUG_ASSERT(vcode != common::NULL_VALUE_64);  // should not occur, as we put this
+            assert(vcode != common::NULL_VALUE_64);  // should not occur, as we put this
                                                            // value in the previous loop
             easy_hash->Insert(vcode);
           }

--- a/storage/tianmu/core/value_set.cpp
+++ b/storage/tianmu/core/value_set.cpp
@@ -525,7 +525,7 @@ void ValueSet::Prepare(common::ColumnType at, int scale, DTCollation coll) {
             types::BString *v = static_cast<types::BString *>(it);
             int64_t vcode = easy_text->Encode(*v);
             assert(vcode != common::NULL_VALUE_64);  // should not occur, as we put this
-                                                           // value in the previous loop
+                                                     // value in the previous loop
             easy_hash->Insert(vcode);
           }
         } else {

--- a/storage/tianmu/data/pack_orderer.cpp
+++ b/storage/tianmu/data/pack_orderer.cpp
@@ -72,7 +72,7 @@ PackOrderer::PackOrderer(vcolumn::VirtualColumn *vc, common::RoughSetValue *r_fi
 }
 
 bool PackOrderer::Init(vcolumn::VirtualColumn *vc, OrderType order, common::RoughSetValue *r_filter) {
-  DEBUG_ASSERT(vc->GetDim() != -1);  // works only for vcolumns based on a single table
+  assert(vc->GetDim() != -1);  // works only for vcolumns based on a single table
 
   if (Initialized())
     return false;
@@ -290,7 +290,7 @@ void PackOrderer::NextPack() {
 }
 
 PackOrderer &PackOrderer::operator++() {
-  DEBUG_ASSERT(Initialized());
+  assert(Initialized());
   if (n_cols_ == 1) {
     NextPack();
   } else {
@@ -324,9 +324,9 @@ void PackOrderer::RewindCol() {
 }
 
 void PackOrderer::RewindToMatch(vcolumn::VirtualColumn *vc, MIIterator &mit) {
-  DEBUG_ASSERT(vc->GetDim() != -1);
-  DEBUG_ASSERT(order_type_[cur_vc_] == OrderType::kRangeSimilarity);
-  DEBUG_ASSERT(n_cols_ == 1);  // not implemented otherwise
+  assert(vc->GetDim() != -1);
+  assert(order_type_[cur_vc_] == OrderType::kRangeSimilarity);
+  assert(n_cols_ == 1);  // not implemented otherwise
 
   if (min_max_type_[cur_vc_] == MinMaxType::kMMTFixed) {
     int64_t mid = common::MINUS_INF_64;

--- a/storage/tianmu/data/pack_str.cpp
+++ b/storage/tianmu/data/pack_str.cpp
@@ -485,7 +485,7 @@ std::pair<PackStr::UniquePtr, size_t> PackStr::Compress() {
 }
 
 void PackStr::CompressTrie() {
-  DEBUG_ASSERT(pack_str_state_ == PackStrtate::kPackArray);
+  assert(pack_str_state_ == PackStrtate::kPackArray);
   marisa::Keyset keyset;
   std::size_t sum_len = 0;
   for (uint row = 0; row < dpn_->numOfRecords; row++) {
@@ -514,7 +514,7 @@ void PackStr::CompressTrie() {
       ids[row] = 0xffff;
     } else {
       auto id = keyset[idx].id();
-      DEBUG_ASSERT(id < (dpn_->numOfRecords - dpn_->numOfNulls));
+      assert(id < (dpn_->numOfRecords - dpn_->numOfNulls));
       ids[row] = id;
       idx++;
     }
@@ -753,7 +753,7 @@ types::BString PackStr::GetStringValueTrie(int locationInPack) const {
 types::BString PackStr::GetValueBinary(int locationInPack) const {
   if (IsNull(locationInPack))
     return types::BString();
-  DEBUG_ASSERT(locationInPack <= (int)dpn_->numOfRecords);
+  assert(locationInPack <= (int)dpn_->numOfRecords);
   // if (pack_str_state_ == PackStrtate::kPackTrie)
   // return GetStringValueTrie(locationInPack);
   size_t str_size;

--- a/storage/tianmu/executor/filter.cpp
+++ b/storage/tianmu/executor/filter.cpp
@@ -713,8 +713,8 @@ void Filter::SwapPack(Filter &f2, int pack) {
   if (block_status[pack] == FB_MIXED) {
     // save block
     assert(shallow || (blocks[pack] && (blocks[pack]->Owner() == block_filter)));  // block_filter->this//shallow
-                                                                                         // copy can have the original
-                                                                                         // filter as the block owner
+                                                                                   // copy can have the original
+                                                                                   // filter as the block owner
 
     b.CopyFrom(*(blocks[pack]), block_filter);  // block_filter->this
   }

--- a/storage/tianmu/executor/filter.cpp
+++ b/storage/tianmu/executor/filter.cpp
@@ -37,7 +37,7 @@ Filter::Filter(int64_t no_obj, uint32_t power, bool all_ones, bool shallow)
       delayed_stats_set(-1),
       no_power(power) {
   MEASURE_FET("Filter::Filter(int, bool, bool)");
-  DEBUG_ASSERT(no_obj >= 0);
+  assert(no_obj >= 0);
   pack_def = 1 << no_power;
   if (no_obj > common::MAX_ROW_NUMBER)
     throw common::OutOfMemoryException("Too many tuples.    (48)");
@@ -65,7 +65,7 @@ Filter::Filter(Filter *f, int64_t no_obj, uint32_t power, bool all_ones, bool sh
       delayed_stats_set(-1),
       no_power(power) {
   MEASURE_FET("Filter::Filter(int, bool, bool)");
-  DEBUG_ASSERT(no_obj >= 0);
+  assert(no_obj >= 0);
   pack_def = 1 << no_power;
   if (no_obj > common::MAX_ROW_NUMBER)
     throw common::OutOfMemoryException("Too many tuples.    (48)");
@@ -185,8 +185,8 @@ std::unique_ptr<Filter> Filter::Clone() const {
 }
 
 void Filter::SetDelayed(size_t b, int pos) {
-  DEBUG_ASSERT(b < no_blocks);
-  DEBUG_ASSERT(delayed_block == -1);  // no mixing!
+  assert(b < no_blocks);
+  assert(delayed_block == -1);  // no mixing!
   if (block_status[b] == FB_MIXED) {
     Set(b, pos);
     return;
@@ -241,7 +241,7 @@ void Filter::Set() {
 
 void Filter::SetBlock(size_t b) {
   MEASURE_FET("Filter::SetBlock(int)");
-  DEBUG_ASSERT(b < no_blocks);
+  assert(b < no_blocks);
   block_status[b] = FB_FULL;  // set the filter to all full
   block_last_one[b] = (b == no_blocks - 1 ? no_of_bits_in_last_block - 1 : pack_def - 1);
   if (blocks[b])
@@ -249,7 +249,7 @@ void Filter::SetBlock(size_t b) {
 }
 
 void Filter::Set(size_t b, int n) {
-  DEBUG_ASSERT(b < no_blocks);
+  assert(b < no_blocks);
   bool make_mixed = false;
   block_changed[b] = true;
   if (block_status[b] == FB_FULL) {
@@ -290,7 +290,7 @@ void Filter::SetBetween(int64_t n1, int64_t n2) {
 
 void Filter::SetBetween(size_t b1, int n1, size_t b2, int n2) {
   MEASURE_FET("Filter::SetBetween(...)");
-  DEBUG_ASSERT(b2 < no_blocks);
+  assert(b2 < no_blocks);
   if (b1 == b2) {
     if (block_status[b1] == FB_FULL && n1 <= int(block_last_one[b1]) + 1) {
       block_last_one[b1] = std::max(block_last_one[b1], ushort(n2));
@@ -344,7 +344,7 @@ void Filter::Reset() {
 
 void Filter::ResetBlock(size_t b) {
   MEASURE_FET("Filter::ResetBlock(int)");
-  DEBUG_ASSERT(b < no_blocks);
+  assert(b < no_blocks);
   block_status[b] = FB_EMPTY;
   if (blocks[b])
     DeleteBlock(b);
@@ -358,7 +358,7 @@ void Filter::ResetBetween(int64_t n1, int64_t n2) {
 }
 
 void Filter::ResetBetween(size_t b1, int n1, size_t b2, int n2) {
-  DEBUG_ASSERT(b2 <= no_blocks);
+  assert(b2 <= no_blocks);
   if (b1 == b2) {
     if (block_status[b1] == FB_FULL) {
       // if full block
@@ -427,7 +427,7 @@ void Filter::Reset(Filter &f2) {
 }
 
 bool Filter::Get(size_t b, int n) {
-  DEBUG_ASSERT(b < no_blocks);
+  assert(b < no_blocks);
   if (block_status[b] == FB_EMPTY)
     return false;
   if (block_status[b] == FB_FULL)
@@ -443,14 +443,14 @@ bool Filter::IsEmpty() {
 }
 
 bool Filter::IsEmpty(size_t b) const {
-  DEBUG_ASSERT(b < no_blocks);
+  assert(b < no_blocks);
   return (block_status[b] == FB_EMPTY);
 }
 
 bool Filter::IsEmptyBetween(int64_t n1,
                             int64_t n2)  // true if there are only 0 between n1 and n2, inclusively
 {
-  DEBUG_ASSERT((n1 >= 0) && (n1 <= n2));
+  assert((n1 >= 0) && (n1 <= n2));
   if (n1 == n2)
     return !Get(n1);
   size_t b1 = int(n1 >> no_power);
@@ -493,7 +493,7 @@ bool Filter::IsEmptyBetween(int64_t n1,
 bool Filter::IsFullBetween(int64_t n1,
                            int64_t n2)  // true if there are only 1 between n1 and n2, inclusively
 {
-  DEBUG_ASSERT((n1 >= 0) && (n1 <= n2));
+  assert((n1 >= 0) && (n1 <= n2));
   if (n1 == n2)
     return Get(n1);
   size_t b1 = int(n1 >> no_power);
@@ -540,8 +540,8 @@ bool Filter::IsFull() const {
 }
 
 void Filter::CopyBlock(Filter &f, size_t block) {
-  DEBUG_ASSERT(block < no_blocks);
-  DEBUG_ASSERT(!f.shallow || bit_block_pool == f.bit_block_pool);
+  assert(block < no_blocks);
+  assert(!f.shallow || bit_block_pool == f.bit_block_pool);
 
   block_status[block] = f.block_status[block];
   block_last_one[block] = f.block_last_one[block];
@@ -567,7 +567,7 @@ void Filter::CopyBlock(Filter &f, size_t block) {
       DeleteBlock(block);
   }
 
-  DEBUG_ASSERT(!blocks[block] || blocks[block]->Owner() == block_filter);  // block_filter->this
+  assert(!blocks[block] || blocks[block]->Owner() == block_filter);  // block_filter->this
 }
 
 void Filter::DeleteBlock(int pack) {
@@ -712,14 +712,14 @@ void Filter::SwapPack(Filter &f2, int pack) {
 
   if (block_status[pack] == FB_MIXED) {
     // save block
-    DEBUG_ASSERT(shallow || (blocks[pack] && (blocks[pack]->Owner() == block_filter)));  // block_filter->this//shallow
+    assert(shallow || (blocks[pack] && (blocks[pack]->Owner() == block_filter)));  // block_filter->this//shallow
                                                                                          // copy can have the original
                                                                                          // filter as the block owner
 
     b.CopyFrom(*(blocks[pack]), block_filter);  // block_filter->this
   }
   if (f2.block_status[pack] == FB_MIXED) {
-    DEBUG_ASSERT(f2.blocks[pack] && f2.blocks[pack]->Owner() == &f2);
+    assert(f2.blocks[pack] && f2.blocks[pack]->Owner() == &f2);
     if (!blocks[pack]) {
       blocks[pack] = block_allocator->Alloc();
       new (blocks[pack]) Block(*(f2.blocks[pack]), block_filter);  // block_filter->this
@@ -744,9 +744,9 @@ void Filter::SwapPack(Filter &f2, int pack) {
   std::swap(block_last_one[pack], f2.block_last_one[pack]);
   std::swap(block_changed[pack], f2.block_changed[pack]);
   if (block_status[pack] == FB_MIXED)
-    DEBUG_ASSERT(blocks[pack]->Owner() == block_filter);  // block_filter->this
+    assert(blocks[pack]->Owner() == block_filter);  // block_filter->this
   if (f2.block_status[pack] == FB_MIXED)
-    DEBUG_ASSERT(f2.blocks[pack]->Owner() == &f2);
+    assert(f2.blocks[pack]->Owner() == &f2);
 }
 
 int64_t Filter::NumOfOnes() const {
@@ -787,7 +787,7 @@ uint Filter::NumOfOnesUncommited(int b) {
 
 int64_t Filter::NumOfOnesBetween(int64_t n1, int64_t n2)  // no of 1 between n1 and n2, inclusively
 {
-  DEBUG_ASSERT((n1 >= 0) && (n1 <= n2));
+  assert((n1 >= 0) && (n1 <= n2));
   if (n1 == n2)
     return (Get(n1) ? 1 : 0);
   size_t b1 = int(n1 >> no_power);

--- a/storage/tianmu/executor/filter.h
+++ b/storage/tianmu/executor/filter.h
@@ -124,7 +124,7 @@ class Filter final : public mm::TraceableObject {
                       int64_t n2);  // true if there are only 0 between n1 and n2, inclusively
   bool IsFull() const;
   bool IsFull(unsigned int b) const {  // block b
-    DEBUG_ASSERT(b < no_blocks);
+    assert(b < no_blocks);
     return (block_status[b] == FB_FULL &&
             block_last_one[b] == (b == no_blocks - 1 ? no_of_bits_in_last_block - 1 : (pack_def - 1)));
   }
@@ -162,16 +162,16 @@ class Filter final : public mm::TraceableObject {
   class Block;
   class BlockAllocator;
   Block *GetBlock(size_t b) const {
-    DEBUG_ASSERT(b < no_blocks);
+    assert(b < no_blocks);
     return blocks[b];
   };
   uchar GetBlockStatus(size_t i) {
-    DEBUG_ASSERT(i < no_blocks);
+    assert(i < no_blocks);
     return block_status[i];
   };
   uint32_t GetPower() { return no_power; };
   bool GetBlockChangeStatus(uint32_t n) const {
-    DEBUG_ASSERT(n < no_blocks);
+    assert(n < no_blocks);
     return block_changed[n];
   }
   static const uchar FB_FULL = 0;   // block status: full
@@ -190,8 +190,8 @@ class Filter final : public mm::TraceableObject {
   void SetBetween(size_t b1, int n1, size_t b2, int n2);  // set 1 between...
   // Delayed operations on filter
   void ResetDelayed(unsigned int b, int pos) {
-    DEBUG_ASSERT(b < no_blocks);
-    DEBUG_ASSERT(delayed_block_set == -1);  // no mixing!
+    assert(b < no_blocks);
+    assert(delayed_block_set == -1);  // no mixing!
     if (block_status[b] == FB_FULL) {
       if (static_cast<size_t>(delayed_block) != b) {
         Commit();
@@ -254,7 +254,7 @@ class Filter final : public mm::TraceableObject {
     bool Set(int n);                                // the object = 1
     bool Set(int n1, int n2);                       // set 1 between..., true => block is full
     bool Reset(int n) {
-      DEBUG_ASSERT(n < no_obj);
+      assert(n < no_obj);
       uint mask = lshift1[n & 31];
       uint &cur_bl = block_table[n >> 5];
       if (cur_bl & mask) {  // if this operation change value
@@ -339,13 +339,13 @@ class FilterOnesIterator {
                           // end. Return false if we just restarted the pack
   bool IsValid() { return valid; }
   int64_t operator*() const {
-    DEBUG_ASSERT(valid);
+    assert(valid);
     return cur_position;
   }
 
   FilterOnesIterator &operator++() {
-    DEBUG_ASSERT(valid);  // cannot iterate invalid iterator
-    DEBUG_ASSERT(packs_to_go == -1 || packs_to_go > packs_done);
+    assert(valid);  // cannot iterate invalid iterator
+    assert(packs_to_go == -1 || packs_to_go > packs_done);
 
     if (IsEndOfBlock()) {
       if (!IteratorBpp()) {
@@ -390,12 +390,12 @@ class FilterOnesIterator {
   int GetPackCount() const { return f->no_blocks; }
   bool InsideOnePack() { return inside_one_pack; }
   int GetCurrPack() {
-    DEBUG_ASSERT(valid);
+    assert(valid);
     return iterator_b;
   }
 
   int GetCurrInPack() {
-    DEBUG_ASSERT(valid);
+    assert(valid);
     return iterator_n;
   }
 

--- a/storage/tianmu/executor/filter_block.cpp
+++ b/storage/tianmu/executor/filter_block.cpp
@@ -25,7 +25,7 @@ namespace core {
 
 Filter::Block::Block(Filter *owner, int _no_obj, bool all_full) {
   MEASURE_FET("Filter::Block::Block()");
-  DEBUG_ASSERT(_no_obj > 0 && _no_obj <= (1 << owner->GetPower()));
+  assert(_no_obj > 0 && _no_obj <= (1 << owner->GetPower()));
 
   this->owner = owner;
   no_obj = _no_obj;
@@ -72,7 +72,7 @@ void Filter::Block::CopyFrom(Block const &block, Filter *owner) {
 }
 
 Filter::Block *Filter::Block::MoveFromShallowCopy(Filter *new_owner) {
-  DEBUG_ASSERT(owner->GetBitBlockPool() == new_owner->GetBitBlockPool());
+  assert(owner->GetBitBlockPool() == new_owner->GetBitBlockPool());
   owner = new_owner;
   return this;
 }
@@ -114,7 +114,7 @@ void Filter::Block::Reset() {
 }
 
 bool Filter::Block::Reset(int n1, int n2) {
-  DEBUG_ASSERT(n1 <= n2 && n2 < no_obj);
+  assert(n1 <= n2 && n2 < no_obj);
   int bl1 = n1 / 32;
   int bl2 = n2 / 32;
   int off1 = (n1 & 31);

--- a/storage/tianmu/executor/filter_iterators.cpp
+++ b/storage/tianmu/executor/filter_iterators.cpp
@@ -98,7 +98,7 @@ void FilterOnesIterator::RewindToRow(const int64_t row)  // note: if row not exi
     valid = false;
   else
     valid = true;
-  DEBUG_ASSERT(pack < f->no_blocks);
+  assert(pack < f->no_blocks);
 
   iterator_b = prev_iterator_b = pack;
   iterator_n = int(row & (pack_def - 1));
@@ -128,7 +128,7 @@ void FilterOnesIterator::RewindToRow(const int64_t row)  // note: if row not exi
 
 bool FilterOnesIterator::RewindToPack(size_t pack) {
   // if SetNoPacksToGo() has been used, then RewindToPack can be done only to
-  // the previous pack DEBUG_ASSERT(packs_to_go == -1 || pack == prev_iterator_b
+  // the previous pack assert(packs_to_go == -1 || pack == prev_iterator_b
   // || pack == iterator_b);
   if (pack >= f->no_blocks)
     valid = false;
@@ -147,7 +147,7 @@ bool FilterOnesIterator::RewindToPack(size_t pack) {
   uchar stat = f->block_status[iterator_b];
   cur_block_full = (stat == f->FB_FULL);
   cur_block_empty = (stat == f->FB_EMPTY);
-  //	DEBUG_ASSERT(buffer.Empty());			// random order - forget
+  //	assert(buffer.Empty());			// random order - forget
   // history, WARNING: may lead to omitting
   // packs!
   buffer.Reset();
@@ -176,7 +176,7 @@ int64_t FilterOnesIterator::GetPackSizeLeft()  // how many 1-s in the current bl
     return 0;
   if (cur_block_full)
     return int64_t(f->block_last_one[iterator_b]) + 1 - iterator_n;
-  DEBUG_ASSERT(f->block_status[iterator_b] != f->FB_EMPTY);
+  assert(f->block_status[iterator_b] != f->FB_EMPTY);
   return ones_left_in_block;
 }
 
@@ -268,7 +268,7 @@ bool FilterOnesIterator::NextInsidePack()  // return false if we just restarted
 bool FilterOnesIterator::FindOneInsidePack() {
   bool found = false;
   // inter-block iteration
-  DEBUG_ASSERT(f->block_status[iterator_b] == f->FB_MIXED);  // IteratorBpp() omits empty blocks
+  assert(f->block_status[iterator_b] == f->FB_MIXED);  // IteratorBpp() omits empty blocks
   Filter::Block *cur_block = f->blocks[iterator_b];
   int cb_no_obj = cur_block->no_obj;
   if (iterator_b == static_cast<unsigned int>(prev_block)) {
@@ -282,7 +282,7 @@ bool FilterOnesIterator::FindOneInsidePack() {
     prev_block = iterator_b;
     ones_left_in_block = cur_block->no_set_bits;
   }
-  DEBUG_ASSERT(iterator_n < cb_no_obj || ones_left_in_block == 0);
+  assert(iterator_n < cb_no_obj || ones_left_in_block == 0);
   if (iterator_n < cb_no_obj) {
     // else leave "found == false", which will iterate to the next block
     if (lastn + 1 == iterator_n) {

--- a/storage/tianmu/executor/join_thread_table.cpp
+++ b/storage/tianmu/executor/join_thread_table.cpp
@@ -126,7 +126,7 @@ class JoinThreadTableManagerImpl : public JoinThreadTableManager {
   JoinThreadTableManagerImpl(uint32_t pack_power, size_t table_count, const HashTable::CreateParams &create_params,
                              std::vector<ColumnBinEncoder> &&column_encoder, bool watch_traversed = false,
                              bool ignore_conflicts = false) {
-    DEBUG_ASSERT(table_count >= 1u);
+    assert(table_count >= 1u);
     tables_.reserve(table_count);
     HashTable::CreateParams slice_create_params(create_params);
     slice_create_params.max_table_size /= table_count;
@@ -153,7 +153,7 @@ class JoinThreadTableManagerShared : public JoinThreadTableManager {
   JoinThreadTableManagerShared(uint32_t pack_power, size_t table_count, const HashTable::CreateParams &create_params,
                                std::vector<ColumnBinEncoder> &&column_encoder, bool watch_traversed = false,
                                bool ignore_conflicts = false) {
-    DEBUG_ASSERT(table_count >= 1u);
+    assert(table_count >= 1u);
 
     hash_table_ = std::make_shared<HashTable>(create_params);
     if (watch_traversed)

--- a/storage/tianmu/handler/ha_tianmu.cpp
+++ b/storage/tianmu/handler/ha_tianmu.cpp
@@ -2395,7 +2395,7 @@ int tianmu_throw_error_func([[maybe_unused]] MYSQL_THD thd, [[maybe_unused]] str
   int buffer_length = 512;
   char buff[512] = {0};
 
-  DEBUG_ASSERT(value->value_type(value) == MYSQL_VALUE_TYPE_STRING);
+  assert(value->value_type(value) == MYSQL_VALUE_TYPE_STRING);
 
   my_message(static_cast<int>(common::ErrorCode::UNKNOWN_ERROR), value->val_str(value, buff, &buffer_length), MYF(0));
   return -1;

--- a/storage/tianmu/index/index_table.cpp
+++ b/storage/tianmu/index/index_table.cpp
@@ -26,7 +26,7 @@ namespace core {
 IndexTable::IndexTable(int64_t _size, int64_t _orig_size, [[maybe_unused]] int mem_modifier)
     : system::CacheableItem("JW", "INT"), m_conn(current_txn_) {
   // Note: buffer size should be 2^n
-  DEBUG_ASSERT(_orig_size >= 0);
+  assert(_orig_size >= 0);
   orig_size = _orig_size;
   bytes_per_value = ((orig_size + 1) > 0xFFFF ? ((orig_size + 1) > 0xFFFFFFFF ? 8 : 4) : 2);
 
@@ -103,7 +103,7 @@ IndexTable::~IndexTable() {
 }
 
 void IndexTable::LoadBlock(int b) {
-  DEBUG_ASSERT(IsLocked());
+  assert(IsLocked());
   if (buf == nullptr) {  // possible after block caching on disk
     buf = (unsigned char *)alloc(buffer_size_in_bytes, mm::BLOCK_TYPE::BLOCK_TEMPORARY, true);
     if (!buf) {
@@ -112,7 +112,7 @@ void IndexTable::LoadBlock(int b) {
     }
   } else if (block_changed)
     CI_Put(cur_block, buf);
-  DEBUG_ASSERT(buf != nullptr);
+  assert(buf != nullptr);
   CI_Get(b, buf);
   if (m_conn->Killed())  // from time to time...
     throw common::KilledException();
@@ -122,7 +122,7 @@ void IndexTable::LoadBlock(int b) {
 }
 
 void IndexTable::ExpandTo(uint64_t new_size) {
-  DEBUG_ASSERT(IsLocked());
+  assert(IsLocked());
   if (new_size <= (uint64_t)size)
     return;
   if (size * bytes_per_value == buffer_size_in_bytes) {  // the whole table was in one buffer

--- a/storage/tianmu/index/index_table.h
+++ b/storage/tianmu/index/index_table.h
@@ -37,8 +37,8 @@ class IndexTable : private system::CacheableItem, public mm::TraceableObject {
   ~IndexTable();
 
   inline void Set64(uint64_t n, uint64_t val) {
-    DEBUG_ASSERT(IsLocked());
-    DEBUG_ASSERT(n < size);
+    assert(IsLocked());
+    assert(n < size);
     int b = int(n >> block_shift);
     if (b != cur_block)
       LoadBlock(b);
@@ -54,8 +54,8 @@ class IndexTable : private system::CacheableItem, public mm::TraceableObject {
                    uint32_t power);  // add all positions where filter is one
 
   inline uint64_t Get64(uint64_t n) {
-    DEBUG_ASSERT(IsLocked());
-    DEBUG_ASSERT(n < size);
+    assert(IsLocked());
+    assert(n < size);
     int b = int(n >> block_shift);
     if (b != cur_block)
       LoadBlock(b);
@@ -71,7 +71,7 @@ class IndexTable : private system::CacheableItem, public mm::TraceableObject {
   }
 
   inline uint64_t Get64InsideBlock(uint64_t n) {  // faster version (no block checking)
-    DEBUG_ASSERT(int(n >> block_shift) == cur_block);
+    assert(int(n >> block_shift) == cur_block);
     uint64_t ndx = n & block_mask;
     uint64_t res;
     if (bytes_per_value == 4)
@@ -90,8 +90,8 @@ class IndexTable : private system::CacheableItem, public mm::TraceableObject {
 
   // use only on newly added data, assumption: block_changed == true
   inline void Swap(uint64_t n1, uint64_t n2) {
-    DEBUG_ASSERT(IsLocked());
-    DEBUG_ASSERT(block_changed);  // use only on newly added data
+    assert(IsLocked());
+    assert(block_changed);  // use only on newly added data
     uint64_t ndx1 = n1 & block_mask;
     uint64_t ndx2 = n2 & block_mask;
     if (bytes_per_value == 4)

--- a/storage/tianmu/index/kv_store.cpp
+++ b/storage/tianmu/index/kv_store.cpp
@@ -148,7 +148,7 @@ void KVStore::AsyncDropData() {
       rocksdb::Range range = rocksdb::Range({reinterpret_cast<const char *>(buf_begin), INDEX_NUMBER_SIZE},
                                             {reinterpret_cast<const char *>(buf_end), INDEX_NUMBER_SIZE});
       rocksdb::ColumnFamilyHandle *cfh = cf_manager_.get_cf_by_id(id.cf_id);
-      DEBUG_ASSERT(cfh);
+      assert(cfh);
       // delete files by range, [start_index, end_index]
       // for more info: http://rocksdb.org/blog/2018/11/21/delete-range.html
       rocksdb::Status status = rocksdb::DeleteFilesInRange(txn_db_->GetBaseDB(), cfh, &range.start, &range.limit);

--- a/storage/tianmu/index/mi_new_contents.cpp
+++ b/storage/tianmu/index/mi_new_contents.cpp
@@ -238,9 +238,9 @@ void MINewContents::Commit([[maybe_unused]] int64_t joined_tuples)  // commit ch
 
 void MINewContents::DisableOptimized() {
   MEASURE_FET("MINewContents::DisableOptimized(...)");
-  DEBUG_ASSERT(optimized_dim_stay != -1);
+  assert(optimized_dim_stay != -1);
   if (!forget_now[optimized_dim_stay]) {
-    DEBUG_ASSERT(t_new[optimized_dim_stay] == nullptr);
+    assert(t_new[optimized_dim_stay] == nullptr);
     t_new[optimized_dim_stay] = t_opt;
     t_opt = nullptr;
     f_opt->Commit();

--- a/storage/tianmu/index/mi_rough_sorter.cpp
+++ b/storage/tianmu/index/mi_rough_sorter.cpp
@@ -56,7 +56,7 @@ MINewContentsRSorter::~MINewContentsRSorter() {
 }
 
 void MINewContentsRSorter::AddColumn(IndexTable *t, int dim) {
-  DEBUG_ASSERT(t == nullptr || tall[dim] == nullptr);  // else already added - something is wrong!
+  assert(t == nullptr || tall[dim] == nullptr);  // else already added - something is wrong!
   tall[dim] = t;
   tcheck[dim] = false;
   if (t) {

--- a/storage/tianmu/index/multi_index.cpp
+++ b/storage/tianmu/index/multi_index.cpp
@@ -110,7 +110,7 @@ void MultiIndex::Clear() {
       dim_groups[i] = nullptr;
     }
   } catch (...) {
-    DEBUG_ASSERT(!"exception from destructor");
+    assert(!"exception from destructor");
   }
   delete[] dim_size;
   delete[] group_for_dim;

--- a/storage/tianmu/index/rsi_histogram.cpp
+++ b/storage/tianmu/index/rsi_histogram.cpp
@@ -107,7 +107,7 @@ common::RoughSetValue RSIndex_Hist::IsValue(int64_t min_v, int64_t max_v, int pa
     double dmax_v = *(double *)(&max_v);
     double dpack_min = *(double *)(&pack_min);
     double dpack_max = *(double *)(&pack_max);
-    DEBUG_ASSERT(dmin_v <= dmax_v);
+    assert(dmin_v <= dmax_v);
     if (dmax_v < dpack_min || dmin_v > dpack_max)
       return common::RoughSetValue::RS_NONE;
     if (dmax_v >= dpack_max && dmin_v <= dpack_min)
@@ -120,7 +120,7 @@ common::RoughSetValue RSIndex_Hist::IsValue(int64_t min_v, int64_t max_v, int pa
     min_bit = int((dmin_v - dpack_min) / interval_len);
     max_bit = int((dmax_v - dpack_min) / interval_len);
   } else {
-    DEBUG_ASSERT(min_v <= max_v);
+    assert(min_v <= max_v);
     if (max_v < pack_min || min_v > pack_max)
       return common::RoughSetValue::RS_NONE;
     if (max_v >= pack_max && min_v <= pack_min)
@@ -138,7 +138,7 @@ common::RoughSetValue RSIndex_Hist::IsValue(int64_t min_v, int64_t max_v, int pa
       max_bit = int((max_v - pack_min - 1) / interval_len);
     }
   }
-  DEBUG_ASSERT(min_bit >= 0);
+  assert(min_bit >= 0);
   if (max_bit >= RSI_HIST_BITS)
     return common::RoughSetValue::RS_SOME;  // it may happen for extremely large numbers (
                                             // >2^52 )

--- a/storage/tianmu/loader/parsing_strategy.cpp
+++ b/storage/tianmu/loader/parsing_strategy.cpp
@@ -435,7 +435,7 @@ ParsingStrategy::ParseResult ParsingStrategy::GetOneRow(const char *const buf, s
 
       str = new (thd_->mem_root) String(MAX_FIELD_WIDTH);
       String *res = field->val_str(str);
-      DEBUG_ASSERT(res);
+      assert(res);
       vec_field_Str_list_.push_back(str);
       vec_field_num_to_index_.push_back(0);
       map_field_name_to_index_[field_name] = i;
@@ -555,13 +555,13 @@ ParsingStrategy::ParseResult ParsingStrategy::GetOneRow(const char *const buf, s
   // step3,field in the set clause
   while ((fld = f++)) {
     Item_field *const field = fld->field_for_view_update();
-    DEBUG_ASSERT(field != NULL);
+    assert(field != NULL);
     Field *const rfield = field->field;
 
     Item *const value = v++;
 
     if (value->save_in_field(rfield, false) < 0) {
-      DEBUG_ASSERT(0);
+      assert(0);
     }
 
     rfield->check_constraints(ER_BAD_NULL_ERROR);

--- a/storage/tianmu/loader/value_cache.h
+++ b/storage/tianmu/loader/value_cache.h
@@ -45,7 +45,7 @@ class ValueCache final {
     if (expected_null_)
       null_cnt_++;
     size_ += expected_size_;
-    DEBUG_ASSERT(size_ <= capacity_);
+    assert(size_ <= capacity_);
     expected_size_ = 0;
     expected_null_ = false;
     if (expected_delete_) {
@@ -71,19 +71,19 @@ class ValueCache final {
   }
 
   void SetNull(size_t ono, bool null) {
-    DEBUG_ASSERT(ono < values_.size());
+    assert(ono < values_.size());
     nulls_[ono] = null;
     if (null)
       null_cnt_++;
   }
 
   void SetDelete(size_t ono) {
-    DEBUG_ASSERT(ono < values_.size());
+    assert(ono < values_.size());
     deletes_.emplace(ono, true);
   }
 
   void ExpectedSize(size_t expectedSize) {
-    DEBUG_ASSERT((size_ + expectedSize) <= capacity_);
+    assert((size_ + expectedSize) <= capacity_);
     expected_size_ = expectedSize;
   }
 
@@ -98,18 +98,18 @@ class ValueCache final {
 
   size_t SumarizedSize() const { return size_; }
   size_t Size(size_t ono) const {
-    DEBUG_ASSERT(ono < values_.size());
+    assert(ono < values_.size());
     auto end(ono < (values_.size() - 1) ? values_[ono + 1] : size_);
     return (end - values_[ono]);
   }
 
   char *GetDataBytesPointer(size_t ono) {
-    DEBUG_ASSERT(ono < values_.size());
+    assert(ono < values_.size());
     return (static_cast<char *>(data_) + values_[ono]);
   }
 
   char const *GetDataBytesPointer(size_t ono) const {
-    DEBUG_ASSERT(ono < values_.size());
+    assert(ono < values_.size());
     return (static_cast<char *>(data_) + values_[ono]);
   }
 

--- a/storage/tianmu/mm/memory_handling_policy.cpp
+++ b/storage/tianmu/mm/memory_handling_policy.cpp
@@ -432,7 +432,7 @@ class SimpleHist {
   const char *label;
 
   inline void update_bin(int bin, uint64_t value) {
-    DEBUG_ASSERT(bin < bins);
+    assert(bin < bins);
     bin_count[bin]++;
     bin_total[bin] += value;
   }

--- a/storage/tianmu/mm/traceable_object.cpp
+++ b/storage/tianmu/mm/traceable_object.cpp
@@ -128,7 +128,7 @@ TraceableObject::TraceableObject(const TraceableObject &to)
 
 TraceableObject::~TraceableObject() {
   // Instance()->AssertNoLeak(this);
-  DEBUG_ASSERT(m_sizeAllocated == 0 /*, "TraceableObject size accounting"*/);
+  assert(m_sizeAllocated == 0 /*, "TraceableObject size accounting"*/);
   if (IsTracked())
     StopAccessTracking();
 }
@@ -188,7 +188,7 @@ void TraceableObject::Unlock() {
   m_lock_count--;
   if (m_lock_count < 0) {
     TIANMU_LOG(LogCtl_Level::ERROR, "Internal error: An object unlocked too many times in memory manager.");
-    DEBUG_ASSERT(!"Internal error: An object unlocked too many times in memory manager.");
+    assert(!"Internal error: An object unlocked too many times in memory manager.");
     m_lock_count = 0;
   }
   if (!IsLocked() && TraceableType() == TO_TYPE::TO_PACK) {
@@ -250,7 +250,7 @@ void TraceableObject::deinitialize(bool detect_leaks) {
 int64_t TraceableObject::MemScale2BufSizeLarge(int ms)
 
 {
-  DEBUG_ASSERT(ms > 2);
+  assert(ms > 2);
   size_t max_total_size = (ms - 2) * 512_MB;
   int sc16 = ms - 5;
   // additionally add progressively more mem for each additional 16GB of free

--- a/storage/tianmu/optimizer/aggregation_algorithm.cpp
+++ b/storage/tianmu/optimizer/aggregation_algorithm.cpp
@@ -570,7 +570,7 @@ AggregaGroupingResult AggregationAlgorithm::AggregatePackrow(GroupByWrapper &gbw
 
   gbw.ResetPackrow();
   int64_t rows_in_pack = gbw.TuplesLeftBetween(cur_tuple, cur_tuple + packrow_length - 1);
-  DEBUG_ASSERT(rows_in_pack > 0);
+  assert(rows_in_pack > 0);
 
   skip_packrow = AggregateRough(gbw, *mit, packrow_done, part_omitted, aggregations_not_changeable, stop_all,
                                 uniform_pos, rows_in_pack, factor);
@@ -813,7 +813,7 @@ bool AggregationAlgorithm::AggregateRough(GroupByWrapper &gbw, MIIterator &mit, 
       return true;  // no space to add uniform values in this pass, omit it for
                     // now
   }
-  DEBUG_ASSERT(!packrow_done);
+  assert(!packrow_done);
 
   // the next step: check if anything may be changed (when no new groups can be
   // added))

--- a/storage/tianmu/optimizer/aggregator.h
+++ b/storage/tianmu/optimizer/aggregator.h
@@ -61,9 +61,7 @@ class TIANMUAggregator {
    * This version is used only for COUNT(*), when no value is needed
    * May be left unimplemented if not applicable for a given aggregator.
    */
-  virtual void PutAggregatedValue([[maybe_unused]] unsigned char *buf, [[maybe_unused]] int64_t factor) {
-    assert(0);
-  }
+  virtual void PutAggregatedValue([[maybe_unused]] unsigned char *buf, [[maybe_unused]] int64_t factor) { assert(0); }
   /*!
    * \brief Add the current value to counter pointed by the pointer.
    * A version for all numerical values.

--- a/storage/tianmu/optimizer/aggregator.h
+++ b/storage/tianmu/optimizer/aggregator.h
@@ -62,7 +62,7 @@ class TIANMUAggregator {
    * May be left unimplemented if not applicable for a given aggregator.
    */
   virtual void PutAggregatedValue([[maybe_unused]] unsigned char *buf, [[maybe_unused]] int64_t factor) {
-    DEBUG_ASSERT(0);
+    assert(0);
   }
   /*!
    * \brief Add the current value to counter pointed by the pointer.
@@ -71,7 +71,7 @@ class TIANMUAggregator {
    */
   virtual void PutAggregatedValue([[maybe_unused]] unsigned char *buf, [[maybe_unused]] int64_t v,
                                   [[maybe_unused]] int64_t factor) {
-    DEBUG_ASSERT(0);
+    assert(0);
   }
   /*!
    * \brief Add the current value to counter pointed by the pointer.
@@ -80,7 +80,7 @@ class TIANMUAggregator {
    */
   virtual void PutAggregatedValue([[maybe_unused]] unsigned char *buf, [[maybe_unused]] const types::BString &v,
                                   [[maybe_unused]] int64_t factor) {
-    DEBUG_ASSERT(0);
+    assert(0);
   }
   /*!
    * \brief Add the counters value represented in src_buf into buf.
@@ -93,7 +93,7 @@ class TIANMUAggregator {
    * May be left unimplemented if no numerical value is returned.
    */
   virtual int64_t GetValue64([[maybe_unused]] unsigned char *buf) {
-    DEBUG_ASSERT(0);
+    assert(0);
     return common::NULL_VALUE_64;
   }
   /*!
@@ -101,7 +101,7 @@ class TIANMUAggregator {
    * May be left unimplemented if no text value is returned.
    */
   virtual types::BString GetValueT([[maybe_unused]] unsigned char *buf) {
-    DEBUG_ASSERT(0);
+    assert(0);
     return types::BString();
   }
   /*!
@@ -109,7 +109,7 @@ class TIANMUAggregator {
    * May be left unimplemented if no floating point value is returned.
    */
   virtual double GetValueD([[maybe_unused]] unsigned char *buf) {
-    DEBUG_ASSERT(0);
+    assert(0);
     return NULL_VALUE_D;
   }
 
@@ -161,19 +161,19 @@ class TIANMUAggregator {
   virtual bool PackAggregationDistinctIrrelevant() { return false; }
   /*!  Set a parameter for the whole packrow aggregation.
    */
-  virtual void SetAggregatePackNoObj([[maybe_unused]] int64_t par1) { DEBUG_ASSERT(0); }
+  virtual void SetAggregatePackNoObj([[maybe_unused]] int64_t par1) { assert(0); }
   /*!  Set a parameter for the whole packrow aggregation.
    */
-  virtual void SetAggregatePackNotNulls([[maybe_unused]] int64_t par1) { DEBUG_ASSERT(0); }
+  virtual void SetAggregatePackNotNulls([[maybe_unused]] int64_t par1) { assert(0); }
   /*!  Set a parameter for the whole packrow aggregation.
    */
-  virtual void SetAggregatePackSum([[maybe_unused]] int64_t par1, [[maybe_unused]] int64_t factor) { DEBUG_ASSERT(0); }
+  virtual void SetAggregatePackSum([[maybe_unused]] int64_t par1, [[maybe_unused]] int64_t factor) { assert(0); }
   /*!  Set a parameter for the whole packrow aggregation.
    */
-  virtual void SetAggregatePackMin([[maybe_unused]] int64_t par1) { DEBUG_ASSERT(0); }
+  virtual void SetAggregatePackMin([[maybe_unused]] int64_t par1) { assert(0); }
   /*!  Set a parameter for the whole packrow aggregation.
    */
-  virtual void SetAggregatePackMax([[maybe_unused]] int64_t par1) { DEBUG_ASSERT(0); }
+  virtual void SetAggregatePackMax([[maybe_unused]] int64_t par1) { assert(0); }
   /*!  Aggregate the whole packrow basing on parameters set previously.
    *  Implementation depends on the actual aggregator.
    *  \return True, if the packrow was successfully aggregated.
@@ -271,7 +271,7 @@ class AggregatorCount64 : public TIANMUAggregator {
     return (cur_min_counter == 1);  // minimal value, we will not find anything better
   }
   bool PackCannotChangeAggregation() override {
-    DEBUG_ASSERT(stats_updated);
+    assert(stats_updated);
     return (cur_min_counter == max_counter);
   }
 
@@ -339,7 +339,7 @@ class AggregatorCount32 : public TIANMUAggregator {
     return (cur_min_counter == 1);  // minimal value, we will not find anything better
   }
   bool PackCannotChangeAggregation() override {
-    DEBUG_ASSERT(stats_updated);
+    assert(stats_updated);
     return (cur_min_counter == max_counter);
   }
 

--- a/storage/tianmu/optimizer/aggregator_basic.cpp
+++ b/storage/tianmu/optimizer/aggregator_basic.cpp
@@ -61,7 +61,7 @@ void AggregatorSum64::SetAggregatePackSum(int64_t par1, int64_t factor) {
 }
 
 bool AggregatorSum64::AggregatePack(unsigned char *buf) {
-  DEBUG_ASSERT(pack_sum != common::NULL_VALUE_64);
+  assert(pack_sum != common::NULL_VALUE_64);
   PutAggregatedValue(buf, pack_sum, 1);
   return true;
 }
@@ -245,13 +245,13 @@ void AggregatorMin64::Merge(unsigned char *buf, unsigned char *src_buf) {
 }
 
 bool AggregatorMin64::AggregatePack(unsigned char *buf) {
-  DEBUG_ASSERT(pack_min != common::NULL_VALUE_64);
+  assert(pack_min != common::NULL_VALUE_64);
   PutAggregatedValue(buf, pack_min, 1);
   return true;
 }
 
 bool AggregatorMinD::AggregatePack(unsigned char *buf) {
-  DEBUG_ASSERT(pack_min != common::NULL_VALUE_64);
+  assert(pack_min != common::NULL_VALUE_64);
   int64_t pack_min_64 = *(int64_t *)&pack_min;  // pack_min is double, so it needs conversion into
                                                 // int64_t-encoded-double
   PutAggregatedValue(buf, pack_min_64, 1);
@@ -259,13 +259,13 @@ bool AggregatorMinD::AggregatePack(unsigned char *buf) {
 }
 
 bool AggregatorMax64::AggregatePack(unsigned char *buf) {
-  DEBUG_ASSERT(pack_max != common::NULL_VALUE_64);
+  assert(pack_max != common::NULL_VALUE_64);
   PutAggregatedValue(buf, pack_max, 1);
   return true;
 }
 
 bool AggregatorMaxD::AggregatePack(unsigned char *buf) {
-  DEBUG_ASSERT(pack_max != NULL_VALUE_D);
+  assert(pack_max != NULL_VALUE_D);
   int64_t pack_max_64 = *(int64_t *)&pack_max;  // pack_max is double, so it needs conversion into
                                                 // int64_t-encoded-double
   PutAggregatedValue(buf, pack_max_64, 1);
@@ -289,7 +289,7 @@ void AggregatorMinD::Merge(unsigned char *buf, unsigned char *src_buf) {
 }
 
 void AggregatorMinT::PutAggregatedValue(unsigned char *buf, const types::BString &v, [[maybe_unused]] int64_t factor) {
-  DEBUG_ASSERT((uint)val_len >= v.len_);
+  assert((uint)val_len >= v.len_);
   if (*((unsigned short *)buf) == 0 && buf[2] == 0) {  // still null
     stats_updated = false;
     std::memset(buf + 2, 0, val_len);
@@ -344,7 +344,7 @@ AggregatorMinT_UTF::AggregatorMinT_UTF(int max_len, DTCollation coll) : Aggregat
 
 void AggregatorMinT_UTF::PutAggregatedValue(unsigned char *buf, const types::BString &v,
                                             [[maybe_unused]] int64_t factor) {
-  DEBUG_ASSERT((uint)val_len >= v.len_);
+  assert((uint)val_len >= v.len_);
   if (*((unsigned short *)buf) == 0 && buf[2] == 0) {  // still null
     stats_updated = false;
     std::memset(buf + 2, 0, val_len);
@@ -441,7 +441,7 @@ AggregatorMaxT_UTF::AggregatorMaxT_UTF(int max_len, DTCollation coll) : Aggregat
 
 void AggregatorMaxT::PutAggregatedValue(unsigned char *buf, const types::BString &v, [[maybe_unused]] int64_t factor) {
   stats_updated = false;
-  DEBUG_ASSERT((uint)val_len >= v.len_);
+  assert((uint)val_len >= v.len_);
   if (*((unsigned short *)buf) == 0 && buf[2] == 0) {  // still null
     std::memset(buf + 2, 0, val_len);
     *((unsigned short *)buf) = v.len_;
@@ -493,7 +493,7 @@ types::BString AggregatorMaxT::GetValueT(unsigned char *buf) {
 void AggregatorMaxT_UTF::PutAggregatedValue(unsigned char *buf, const types::BString &v,
                                             [[maybe_unused]] int64_t factor) {
   stats_updated = false;
-  DEBUG_ASSERT((uint)val_len >= v.len_);
+  assert((uint)val_len >= v.len_);
   if (*((unsigned short *)buf) == 0 && buf[2] == 0) {  // still null
     std::memset(buf + 2, 0, val_len);
     *((unsigned short *)buf) = v.len_;
@@ -537,7 +537,7 @@ int64_t AggregatorList32::GetValue64(unsigned char *buf) {
 }
 
 void AggregatorListT::PutAggregatedValue(unsigned char *buf, const types::BString &v, [[maybe_unused]] int64_t factor) {
-  DEBUG_ASSERT((uint)val_len >= v.len_);
+  assert((uint)val_len >= v.len_);
   if (*(reinterpret_cast<unsigned short *>(buf)) == 0 && buf[AggregatedValue_LEN_SIZE] == 0) {  // still null
     stats_updated = false;
     *(reinterpret_cast<unsigned short *>(buf)) = v.len_;

--- a/storage/tianmu/optimizer/aggregator_basic.h
+++ b/storage/tianmu/optimizer/aggregator_basic.h
@@ -82,7 +82,7 @@ class AggregatorSum64 : public TIANMUAggregator {
     return null_group_found;  // if found, do not search any more
   }
   bool PackCannotChangeAggregation() override {
-    DEBUG_ASSERT(stats_updated);
+    assert(stats_updated);
     return !null_group_found && pack_min == 0 && pack_max == 0;  // uniform 0 pack - no change for sum
   }
 
@@ -307,7 +307,7 @@ class AggregatorMin32 : public AggregatorMin {
     return false;
   }
   bool PackCannotChangeAggregation() override {
-    DEBUG_ASSERT(stats_updated);
+    assert(stats_updated);
     return !null_group_found && pack_min != common::NULL_VALUE_64 && pack_min >= (int64_t)stat_max;
   }
 
@@ -362,7 +362,7 @@ class AggregatorMin64 : public AggregatorMin {
     return false;
   }
   bool PackCannotChangeAggregation() override {
-    DEBUG_ASSERT(stats_updated);
+    assert(stats_updated);
     return !null_group_found && pack_min != common::NULL_VALUE_64 && pack_min >= stat_max;
   }
 
@@ -420,7 +420,7 @@ class AggregatorMinD : public AggregatorMin {
     return false;
   }
   bool PackCannotChangeAggregation() override {
-    DEBUG_ASSERT(stats_updated);
+    assert(stats_updated);
     return !null_group_found && !IsDoubleNull(pack_min) && !IsDoubleNull(stat_max) && pack_min >= stat_max;
   }
 
@@ -536,7 +536,7 @@ class AggregatorMax32 : public AggregatorMax {
     return false;
   }
   bool PackCannotChangeAggregation() override {
-    DEBUG_ASSERT(stats_updated);
+    assert(stats_updated);
     return !null_group_found && pack_max != common::NULL_VALUE_64 && pack_max <= (int64_t)stat_min;
   }
 
@@ -592,7 +592,7 @@ class AggregatorMax64 : public AggregatorMax {
     return false;
   }
   bool PackCannotChangeAggregation() override {
-    DEBUG_ASSERT(stats_updated);
+    assert(stats_updated);
     return !null_group_found && pack_max != common::NULL_VALUE_64 && pack_max <= stat_min;
   }
 
@@ -650,7 +650,7 @@ class AggregatorMaxD : public AggregatorMax {
     return false;
   }
   bool PackCannotChangeAggregation() override {
-    DEBUG_ASSERT(stats_updated);
+    assert(stats_updated);
     return !null_group_found && !IsDoubleNull(pack_max) && !IsDoubleNull(stat_min) && pack_max <= stat_min;
   }
 

--- a/storage/tianmu/optimizer/compile/compilation_tools.h
+++ b/storage/tianmu/optimizer/compile/compilation_tools.h
@@ -23,7 +23,7 @@
 namespace Tianmu {
 namespace core {
 #define ASSERT_MYSQL_STRING(x)                           \
-  DEBUG_ASSERT(!x.str[x.length] &&                       \
+  assert(!x.str[x.length] &&                       \
                "Verification that LEX_STRING ends with " \
                "nil")
 

--- a/storage/tianmu/optimizer/compile/compilation_tools.h
+++ b/storage/tianmu/optimizer/compile/compilation_tools.h
@@ -22,10 +22,10 @@
 
 namespace Tianmu {
 namespace core {
-#define ASSERT_MYSQL_STRING(x)                           \
+#define ASSERT_MYSQL_STRING(x)                     \
   assert(!x.str[x.length] &&                       \
-               "Verification that LEX_STRING ends with " \
-               "nil")
+         "Verification that LEX_STRING ends with " \
+         "nil")
 
 #define EMPTY_TABLE_CONST_INDICATOR "%%TMP_TABLE%%"
 

--- a/storage/tianmu/optimizer/compile/compiled_query.cpp
+++ b/storage/tianmu/optimizer/compile/compiled_query.cpp
@@ -443,7 +443,7 @@ void CompiledQuery::TmpTable(TabID &t_out, const TabID &t1, bool for_subq_in_whe
     s.n1 = 1;
   else
     s.n1 = 0;
-  DEBUG_ASSERT(t1.n < 0 && NumOfTabs() > 0);
+  assert(t1.n < 0 && NumOfTabs() > 0);
   s.type = StepType::TMP_TABLE;
   s.t1 = t_out = NextTabID();  // was s.t2!!!
   s.tables1.push_back(t1);
@@ -605,7 +605,7 @@ void CompiledQuery::ApplyConds(const TabID &t1) {
 
 void CompiledQuery::AddColumn(AttrID &a_out, const TabID &t1, CQTerm e1, common::ColOperation op, char const alias[],
                               bool distinct, SI *si) {
-  DEBUG_ASSERT(t1.n < 0 && NumOfTabs() > 0);
+  assert(t1.n < 0 && NumOfTabs() > 0);
   CompiledQuery::CQStep s;
   s.type = StepType::ADD_COLUMN;
   s.a1 = a_out = NextAttrID(t1);
@@ -627,7 +627,7 @@ void CompiledQuery::AddColumn(AttrID &a_out, const TabID &t1, CQTerm e1, common:
 }
 
 void CompiledQuery::CreateVirtualColumn(AttrID &a_out, const TabID &t1, MysqlExpression *expr, const TabID &src_tab) {
-  DEBUG_ASSERT(t1.n < 0 && NumOfTabs() > 0);
+  assert(t1.n < 0 && NumOfTabs() > 0);
   CompiledQuery::CQStep s;
   s.type = StepType::CREATE_VC;
   s.a1 = a_out = NextVCID(t1);
@@ -638,7 +638,7 @@ void CompiledQuery::CreateVirtualColumn(AttrID &a_out, const TabID &t1, MysqlExp
 }
 
 void CompiledQuery::CreateVirtualColumn(AttrID &a_out, const TabID &t1, const TabID &subquery, bool on_result) {
-  DEBUG_ASSERT(t1.n < 0 && NumOfTabs() > 0);
+  assert(t1.n < 0 && NumOfTabs() > 0);
   CompiledQuery::CQStep s;
   s.type = StepType::CREATE_VC;
   s.a1 = a_out = NextVCID(t1);
@@ -649,7 +649,7 @@ void CompiledQuery::CreateVirtualColumn(AttrID &a_out, const TabID &t1, const Ta
 }
 
 void CompiledQuery::CreateVirtualColumn(AttrID &a_out, const TabID &t1, std::vector<int> &vcs, const AttrID &vc_id) {
-  DEBUG_ASSERT(t1.n < 0 && NumOfTabs() > 0);
+  assert(t1.n < 0 && NumOfTabs() > 0);
   CompiledQuery::CQStep s;
   s.type = StepType::CREATE_VC;
   s.a1 = a_out = NextVCID(t1);
@@ -661,7 +661,7 @@ void CompiledQuery::CreateVirtualColumn(AttrID &a_out, const TabID &t1, std::vec
 
 void CompiledQuery::CreateVirtualColumn(int &a_out, const TabID &t1, const TabID &table_alias,
                                         const AttrID &col_number) {
-  DEBUG_ASSERT(t1.n < 0 && NumOfTabs() > 0);
+  assert(t1.n < 0 && NumOfTabs() > 0);
   CompiledQuery::CQStep s;
   s.type = StepType::CREATE_VC;
   s.a1 = NextVCID(t1);
@@ -831,7 +831,7 @@ bool CompiledQuery::ExistsInTempTable(const TabID &tab_id, const TabID &tmp_tabl
 }
 
 TabID CompiledQuery::FindSourceOfParameter(const TabID &tab_id, const TabID &tmp_table, bool &is_group_by) {
-  DEBUG_ASSERT(tmp_table.n < 0);
+  assert(tmp_table.n < 0);
   is_group_by = false;
   for (int x = tmp_table.n + 1; x < 0; x++) {
     if (IsTempTable(TabID(x)) && ExistsInTempTable(tab_id, TabID(x))) {
@@ -840,7 +840,7 @@ TabID CompiledQuery::FindSourceOfParameter(const TabID &tab_id, const TabID &tmp
       return TabID(x);
     }
   }
-  DEBUG_ASSERT(!"Invalid parameter");
+  assert(!"Invalid parameter");
   return TabID(0);
 }
 
@@ -853,7 +853,7 @@ bool CompiledQuery::IsTempTable(const TabID &t) {
 }
 
 int CompiledQuery::FindRootTempTable(int tab_id) {
-  DEBUG_ASSERT(tab_id < 0);
+  assert(tab_id < 0);
   for (int x = tab_id + 1; x < 0; x++) {
     if (IsTempTable(TabID(x)) && ExistsInTempTable(TabID(tab_id), TabID(x)))
       return FindRootTempTable(x);
@@ -889,7 +889,7 @@ std::pair<int64_t, int64_t> CompiledQuery::GetGlobalLimit() {
       break;
     }
   }
-  DEBUG_ASSERT(i < NumOfSteps());
+  assert(i < NumOfSteps());
   TabID res = Step(i).t1;
   if (i > 0 && Step(i - 1).type == CompiledQuery::StepType::T_MODE && Step(i - 1).t1 == res) {
     return std::pair<int64_t, int64_t>(Step(i - 1).n1, Step(i - 1).n2);

--- a/storage/tianmu/optimizer/compile/descriptor.cpp
+++ b/storage/tianmu/optimizer/compile/descriptor.cpp
@@ -345,8 +345,7 @@ void Descriptor::SwitchSides()  // change "a<b" into "b>a" etc; throw error if
                                 // not possible (e.g. between)
 {
   assert(op == common::Operator::O_EQ || op == common::Operator::O_NOT_EQ || op == common::Operator::O_LESS ||
-         op == common::Operator::O_MORE || op == common::Operator::O_LESS_EQ ||
-         op == common::Operator::O_MORE_EQ);
+         op == common::Operator::O_MORE || op == common::Operator::O_LESS_EQ || op == common::Operator::O_MORE_EQ);
   SwitchOperator(op);
   CQTerm p = attr;
   attr = val1;
@@ -2185,7 +2184,7 @@ common::RoughSetValue DescTreeNode::EvaluateRoughlyPack(const MIIterator &mit) {
 }
 
 bool DescTreeNode::CheckCondition(MIIterator &mit) {
-  if (left) {             // i.e., not a leaf
+  if (left) {       // i.e., not a leaf
     assert(right);  // if left is not empty so should be right
     if (desc.lop == common::LogicalOperator::O_AND) {
       if (!left->CheckCondition(mit))
@@ -2253,7 +2252,7 @@ void DescTreeNode::EvaluatePack(MIUpdatingIterator &mit) {
   }
 
   // optimized case
-  if (left) {             // i.e., not a leaf
+  if (left) {       // i.e., not a leaf
     assert(right);  // if left is not empty so should be right
     if (desc.lop == common::LogicalOperator::O_AND) {
       if (left->desc.rv == common::RoughSetValue::RS_NONE || right->desc.rv == common::RoughSetValue::RS_NONE) {
@@ -2740,7 +2739,7 @@ void DescTreeNode::MEvaluatePack(MIUpdatingIterator &mit, int taskid) {
   }
 
   // optimized case
-  if (left) {             // i.e., not a leaf
+  if (left) {       // i.e., not a leaf
     assert(right);  // if left is not empty so should be right
     if (desc.lop == common::LogicalOperator::O_AND) {
       if (left->desc.rvs[taskid] == common::RoughSetValue::RS_NONE ||

--- a/storage/tianmu/optimizer/compile/descriptor.cpp
+++ b/storage/tianmu/optimizer/compile/descriptor.cpp
@@ -84,7 +84,7 @@ Descriptor::Descriptor(TempTable *t, int no_dims)  // no_dims is a destination n
       desc_t(DescriptorJoinType::DT_NOT_KNOWN_YET),
       collation(DTCollation()),
       null_after_simplify(false) {
-  DEBUG_ASSERT(table);
+  assert(table);
 }
 
 Descriptor::~Descriptor() { delete tree; }
@@ -344,9 +344,9 @@ void SwitchOperator(common::Operator &op) {
 void Descriptor::SwitchSides()  // change "a<b" into "b>a" etc; throw error if
                                 // not possible (e.g. between)
 {
-  DEBUG_ASSERT(op == common::Operator::O_EQ || op == common::Operator::O_NOT_EQ || op == common::Operator::O_LESS ||
-               op == common::Operator::O_MORE || op == common::Operator::O_LESS_EQ ||
-               op == common::Operator::O_MORE_EQ);
+  assert(op == common::Operator::O_EQ || op == common::Operator::O_NOT_EQ || op == common::Operator::O_LESS ||
+         op == common::Operator::O_MORE || op == common::Operator::O_LESS_EQ ||
+         op == common::Operator::O_MORE_EQ);
   SwitchOperator(op);
   CQTerm p = attr;
   attr = val1;
@@ -375,7 +375,7 @@ bool Descriptor::IsType_Subquery() {
 
 bool Descriptor::IsType_JoinSimple() const  // true if more than one table involved
 {
-  DEBUG_ASSERT(desc_t != DescriptorJoinType::DT_NOT_KNOWN_YET);
+  assert(desc_t != DescriptorJoinType::DT_NOT_KNOWN_YET);
   return desc_t == DescriptorJoinType::DT_SIMPLE_JOIN;
 }
 
@@ -435,7 +435,7 @@ void Descriptor::CalculateJoinType() {
 
 bool Descriptor::IsType_JoinComplex() const {
   // Make sure to use CalculateJoinType() before
-  DEBUG_ASSERT(desc_t != DescriptorJoinType::DT_NOT_KNOWN_YET);
+  assert(desc_t != DescriptorJoinType::DT_NOT_KNOWN_YET);
   return desc_t == DescriptorJoinType::DT_COMPLEX_JOIN;
 }
 
@@ -537,7 +537,7 @@ void Descriptor::Simplify(bool in_having) {
       break;
     case common::Operator::O_BETWEEN:
     case common::Operator::O_NOT_BETWEEN: {
-      DEBUG_ASSERT(sharp == false);
+      assert(sharp == false);
       if (acc->IsNull(mit)) {
         null_after_simplify = true;
         res = false;
@@ -977,7 +977,7 @@ bool Descriptor::CheckCondition_UTF(const MIIterator &mit) {
 
   // Assumption: LockSourcePack externally done.
   if (op == common::Operator::O_EQ) {  // fast track for the most common operator
-    DEBUG_ASSERT(attr.vc && val1.vc && types::RequiresUTFConversions(collation));
+    assert(attr.vc && val1.vc && types::RequiresUTFConversions(collation));
     if (attr.vc->IsNull(mit) || val1.vc->IsNull(mit))
       return false;
     types::BString s1, s2;
@@ -991,7 +991,7 @@ bool Descriptor::CheckCondition_UTF(const MIIterator &mit) {
     if (!attr.vc->IsNull(mit))
       return false;
   } else if (op == common::Operator::O_EXISTS || op == common::Operator::O_NOT_EXISTS) {
-    DEBUG_ASSERT(dynamic_cast<vcolumn::SubSelectColumn *>(attr.vc));
+    assert(dynamic_cast<vcolumn::SubSelectColumn *>(attr.vc));
     vcolumn::SubSelectColumn *sub = static_cast<vcolumn::SubSelectColumn *>(attr.vc);
     bool is_nonempty = sub->CheckExists(mit);
     if ((op == common::Operator::O_EXISTS && !is_nonempty) || (op == common::Operator::O_NOT_EXISTS && is_nonempty))
@@ -1022,7 +1022,7 @@ bool Descriptor::CheckCondition_UTF(const MIIterator &mit) {
         return false;
     }
   } else if (IsSetOperator(op)) {
-    DEBUG_ASSERT(attr.vc && dynamic_cast<vcolumn::MultiValColumn *>(val1.vc));
+    assert(attr.vc && dynamic_cast<vcolumn::MultiValColumn *>(val1.vc));
     return CheckSetCondition_UTF(mit, op);
   } else if (op == common::Operator::O_LIKE || op == common::Operator::O_NOT_LIKE) {
     if (attr.vc->IsNull(mit) || val1.vc->IsNull(mit))
@@ -1038,10 +1038,10 @@ bool Descriptor::CheckCondition_UTF(const MIIterator &mit) {
     else
       return !result;
   } else if (IsType_OrTree()) {
-    DEBUG_ASSERT(tree);
+    assert(tree);
     return tree->root->CheckCondition((MIIterator &)mit);
   } else {  // all other logical operators: >, >=, <, <=
-    DEBUG_ASSERT(attr.vc && val1.vc);
+    assert(attr.vc && val1.vc);
     if (attr.vc->IsNull(mit) || val1.vc->IsNull(mit))
       return false;
     types::BString s1, s2;
@@ -1064,7 +1064,7 @@ bool Descriptor::CheckCondition(const MIIterator &mit) {
 
   // Assumption: LockSourcePacks externally done.
   if (op == common::Operator::O_EQ) {  // fast track for the most common operator
-    DEBUG_ASSERT(attr.vc && val1.vc);
+    assert(attr.vc && val1.vc);
     // nulls checked in operator ==
     if (!(attr.vc->GetValue(mit) == val1.vc->GetValue(mit)))
       return false;
@@ -1075,7 +1075,7 @@ bool Descriptor::CheckCondition(const MIIterator &mit) {
     if (!attr.vc->IsNull(mit))
       return false;
   } else if (op == common::Operator::O_EXISTS || op == common::Operator::O_NOT_EXISTS) {
-    DEBUG_ASSERT(dynamic_cast<vcolumn::SubSelectColumn *>(attr.vc));
+    assert(dynamic_cast<vcolumn::SubSelectColumn *>(attr.vc));
     vcolumn::SubSelectColumn *sub = static_cast<vcolumn::SubSelectColumn *>(attr.vc);
     bool is_nonempty = sub->CheckExists(mit);
     if ((op == common::Operator::O_EXISTS && !is_nonempty) || (op == common::Operator::O_NOT_EXISTS && is_nonempty))
@@ -1123,13 +1123,13 @@ bool Descriptor::CheckCondition(const MIIterator &mit) {
         return false;
     }
   } else if (IsSetOperator(op)) {
-    DEBUG_ASSERT(attr.vc && dynamic_cast<vcolumn::MultiValColumn *>(val1.vc));
+    assert(attr.vc && dynamic_cast<vcolumn::MultiValColumn *>(val1.vc));
     return CheckSetCondition(mit, op);
   } else if (IsType_OrTree()) {
-    DEBUG_ASSERT(tree);
+    assert(tree);
     return tree->root->CheckCondition((MIIterator &)mit);
   } else {  // all other logical operators: >, >=, <, <=
-    DEBUG_ASSERT(attr.vc && val1.vc);
+    assert(attr.vc && val1.vc);
     if (attr.vc->IsNull(mit) || val1.vc->IsNull(mit))
       return false;
     if (!types::TianmuValueObject::compare(attr.vc->GetValue(mit), val1.vc->GetValue(mit), op, like_esc))
@@ -1147,7 +1147,7 @@ bool Descriptor::IsNull(const MIIterator &mit) {
 
   // Assumption: LockSourcePacks externally done.
   if (op == common::Operator::O_EQ) {
-    DEBUG_ASSERT(attr.vc && val1.vc);
+    assert(attr.vc && val1.vc);
     if (attr.vc->IsNull(mit) || val1.vc->IsNull(mit))
       return true;
   } else if (op == common::Operator::O_NOT_NULL || op == common::Operator::O_IS_NULL) {
@@ -1192,13 +1192,13 @@ bool Descriptor::IsNull(const MIIterator &mit) {
     if (common::Tribool::And(val1_res, val2_res) == common::TRIBOOL_UNKNOWN)
       return true;
   } else if (IsSetOperator(op)) {
-    DEBUG_ASSERT(attr.vc && dynamic_cast<vcolumn::MultiValColumn *>(val1.vc));
+    assert(attr.vc && dynamic_cast<vcolumn::MultiValColumn *>(val1.vc));
     return IsNull_Set(mit, op);
   } else if (IsType_OrTree()) {
-    DEBUG_ASSERT(tree);
+    assert(tree);
     return tree->root->CheckCondition((MIIterator &)mit);
   } else {  // all other logical operators: >, >=, <, <=
-    DEBUG_ASSERT(attr.vc && val1.vc);
+    assert(attr.vc && val1.vc);
     if (attr.vc->IsNull(mit) || val1.vc->IsNull(mit))
       return true;
   }
@@ -1222,7 +1222,7 @@ common::Tribool Descriptor::RoughCheckSubselectCondition(MIIterator &mit, SubSel
     return common::TRIBOOL_UNKNOWN;
 
   if (op == common::Operator::O_EXISTS || op == common::Operator::O_NOT_EXISTS) {
-    DEBUG_ASSERT(dynamic_cast<vcolumn::SubSelectColumn *>(attr.vc));
+    assert(dynamic_cast<vcolumn::SubSelectColumn *>(attr.vc));
     vcolumn::SubSelectColumn *sub = static_cast<vcolumn::SubSelectColumn *>(attr.vc);
     common::Tribool is_empty = sub->RoughIsEmpty(mit, sot);
     if ((op == common::Operator::O_EXISTS && is_empty == true) ||
@@ -1233,7 +1233,7 @@ common::Tribool Descriptor::RoughCheckSubselectCondition(MIIterator &mit, SubSel
       return true;
     return common::TRIBOOL_UNKNOWN;
   } else if (IsSetOperator(op)) {
-    DEBUG_ASSERT(attr.vc && dynamic_cast<vcolumn::MultiValColumn *>(val1.vc));
+    assert(attr.vc && dynamic_cast<vcolumn::MultiValColumn *>(val1.vc));
     return RoughCheckSetSubSelectCondition(mit, op, sot);
   }
 
@@ -1260,7 +1260,7 @@ common::Tribool Descriptor::RoughCheckSubselectCondition(MIIterator &mit, SubSel
   if (val1.vc->IsSubSelect() && attr.vc->IsSubSelect())
     return common::TRIBOOL_UNKNOWN;  // trivial, can be implemented better
 
-  DEBUG_ASSERT(dynamic_cast<vcolumn::SubSelectColumn *>(attr.vc) || dynamic_cast<vcolumn::SubSelectColumn *>(val1.vc));
+  assert(dynamic_cast<vcolumn::SubSelectColumn *>(attr.vc) || dynamic_cast<vcolumn::SubSelectColumn *>(val1.vc));
   vcolumn::SubSelectColumn *sub;
   vcolumn::VirtualColumn *val;
   if (attr.vc->IsSubSelect()) {
@@ -1283,7 +1283,7 @@ common::Tribool Descriptor::RoughCheckSubselectCondition(MIIterator &mit, SubSel
     rv_max.reset(new types::TianmuNum(rv.GetMax(), sub->Type().GetScale(), sub->Type().IsFloat(), sub->TypeName()));
   }
   types::TianmuValueObject v = val->GetValue(mit);
-  DEBUG_ASSERT(attr.vc);
+  assert(attr.vc);
   // NULLs are checked within operators
   if (op == common::Operator::O_EQ) {
     if (v < *rv_min || v > *rv_max)
@@ -1320,7 +1320,7 @@ common::Tribool Descriptor::RoughCheckSubselectCondition(MIIterator &mit, SubSel
 }
 
 bool Descriptor::CheckSetCondition_UTF(const MIIterator &mit, common::Operator op) {
-  DEBUG_ASSERT(IsSetOperator(op));
+  assert(IsSetOperator(op));
   bool result = true;
   vcolumn::MultiValColumn *mvc = static_cast<vcolumn::MultiValColumn *>(val1.vc);
   types::BString s1;
@@ -1411,11 +1411,11 @@ bool Descriptor::CheckSetCondition_UTF(const MIIterator &mit, common::Operator o
 
 bool Descriptor::CheckSetCondition(const MIIterator &mit, common::Operator op) {
   MEASURE_FET("Descriptor::CheckSetCondition(...)");
-  DEBUG_ASSERT(IsSetOperator(op));
+  assert(IsSetOperator(op));
   bool result = true;
   vcolumn::MultiValColumn *mvc = static_cast<vcolumn::MultiValColumn *>(val1.vc);
   if (encoded) {
-    DEBUG_ASSERT(op == common::Operator::O_IN || op == common::Operator::O_NOT_IN);
+    assert(op == common::Operator::O_IN || op == common::Operator::O_NOT_IN);
     if (attr.vc->IsNull(mit)) {
       if (op == common::Operator::O_IN)
         return false;
@@ -1512,7 +1512,7 @@ bool Descriptor::CheckSetCondition(const MIIterator &mit, common::Operator op) {
         result = false;
       break;
     default:
-      DEBUG_ASSERT(0 && "unexpected operator");
+      assert(0 && "unexpected operator");
       break;
   }
   return result;
@@ -1520,10 +1520,10 @@ bool Descriptor::CheckSetCondition(const MIIterator &mit, common::Operator op) {
 
 bool Descriptor::IsNull_Set(const MIIterator &mit, common::Operator op) {
   MEASURE_FET("Descriptor::CheckSetCondition(...)");
-  DEBUG_ASSERT(IsSetOperator(op));
+  assert(IsSetOperator(op));
   vcolumn::MultiValColumn *mvc = static_cast<vcolumn::MultiValColumn *>(val1.vc);
   if (encoded) {
-    DEBUG_ASSERT(op == common::Operator::O_IN || op == common::Operator::O_NOT_IN);
+    assert(op == common::Operator::O_IN || op == common::Operator::O_NOT_IN);
     if (attr.vc->IsNull(mit))
       return true;
     common::Tribool res;
@@ -1577,7 +1577,7 @@ bool Descriptor::IsNull_Set(const MIIterator &mit, common::Operator op) {
         return true;
       break;
     default:
-      DEBUG_ASSERT(0 && "unexpected operator");
+      assert(0 && "unexpected operator");
       break;
   }
   return false;
@@ -1586,8 +1586,8 @@ bool Descriptor::IsNull_Set(const MIIterator &mit, common::Operator op) {
 common::Tribool Descriptor::RoughCheckSetSubSelectCondition(const MIIterator &mit, common::Operator op,
                                                             SubSelectOptimizationType sot) {
   MEASURE_FET("Descriptor::RoughCheckSetSubselectCondition(...)");
-  DEBUG_ASSERT(IsSetOperator(op));
-  DEBUG_ASSERT(val1.vc->IsSubSelect());
+  assert(IsSetOperator(op));
+  assert(val1.vc->IsSubSelect());
   vcolumn::SubSelectColumn *sub = static_cast<vcolumn::SubSelectColumn *>(val1.vc);
   if (sub->IsMaterialized())
     return common::TRIBOOL_UNKNOWN;
@@ -1681,7 +1681,7 @@ common::Tribool Descriptor::RoughCheckSetSubSelectCondition(const MIIterator &mi
         return false;
       break;
     default:
-      DEBUG_ASSERT("unexpected operator");
+      assert("unexpected operator");
       break;
   }
   return common::TRIBOOL_UNKNOWN;
@@ -1837,7 +1837,7 @@ void Descriptor::ClearRoughValues() {
 }
 
 void Descriptor::RoughAccumulate(MIIterator &mit) {
-  DEBUG_ASSERT(IsType_OrTree());
+  assert(IsType_OrTree());
   tree->RoughAccumulate(mit);
 }
 
@@ -2186,7 +2186,7 @@ common::RoughSetValue DescTreeNode::EvaluateRoughlyPack(const MIIterator &mit) {
 
 bool DescTreeNode::CheckCondition(MIIterator &mit) {
   if (left) {             // i.e., not a leaf
-    DEBUG_ASSERT(right);  // if left is not empty so should be right
+    assert(right);  // if left is not empty so should be right
     if (desc.lop == common::LogicalOperator::O_AND) {
       if (!left->CheckCondition(mit))
         return false;
@@ -2215,7 +2215,7 @@ bool DescTreeNode::CheckCondition(MIIterator &mit) {
 bool DescTreeNode::IsNull(MIIterator &mit)
 {
     if (left) {         // i.e., not a leaf
-        DEBUG_ASSERT(right);  // if left is not empty so should be right
+        assert(right);  // if left is not empty so should be right
         bool left_res = left->CheckCondition(mit);
         bool right_res = right->CheckCondition(mit);
         if (desc.lop == common::LogicalOperator::O_AND) {
@@ -2254,7 +2254,7 @@ void DescTreeNode::EvaluatePack(MIUpdatingIterator &mit) {
 
   // optimized case
   if (left) {             // i.e., not a leaf
-    DEBUG_ASSERT(right);  // if left is not empty so should be right
+    assert(right);  // if left is not empty so should be right
     if (desc.lop == common::LogicalOperator::O_AND) {
       if (left->desc.rv == common::RoughSetValue::RS_NONE || right->desc.rv == common::RoughSetValue::RS_NONE) {
         mit.ResetCurrentPack();
@@ -2392,7 +2392,7 @@ void DescTreeNode::CollectDescriptor(std::vector<std::pair<int, Descriptor>> &de
     left->CollectDescriptor(desc_counts);
     right->CollectDescriptor(desc_counts);
   } else {
-    DEBUG_ASSERT(!left && !right);
+    assert(!left && !right);
     IncreaseDescriptorCount(desc_counts);
   }
 }
@@ -2404,7 +2404,7 @@ bool DescTreeNode::CanBeExtracted(Descriptor &searched_desc) {
         return true;
       return right->CanBeExtracted(searched_desc);
     } else {
-      DEBUG_ASSERT(desc.lop == common::LogicalOperator::O_OR);
+      assert(desc.lop == common::LogicalOperator::O_OR);
       return (left->CanBeExtracted(searched_desc) && right->CanBeExtracted(searched_desc));
     }
   } else {
@@ -2421,7 +2421,7 @@ bool DescTreeNode::CanBeExtracted(Descriptor &searched_desc) {
 //				return true;
 //			return right->IsWidestRange(searched_desc);
 //		} else {
-//			DEBUG_ASSERT(desc.lop == common::LogicalOperator::O_OR);
+//			assert(desc.lop == common::LogicalOperator::O_OR);
 //			return (left->IsWidestRange(searched_desc) &&
 // right->IsWidestRange(searched_desc));
 //		}
@@ -2432,10 +2432,10 @@ bool DescTreeNode::CanBeExtracted(Descriptor &searched_desc) {
 
 void DescTreeNode::ExtractDescriptor(Descriptor &searched_desc, DescTreeNode *&root) {
   if (left && left->left) {
-    DEBUG_ASSERT(left->right);
+    assert(left->right);
     left->ExtractDescriptor(searched_desc, root);
   } else {
-    DEBUG_ASSERT(left && right);
+    assert(left && right);
     if (/*(desc.lop == common::LogicalOperator::O_AND && left->desc <= searched_desc) ||
                     (desc.lop == common::LogicalOperator::O_OR && */
         left->desc == searched_desc /*)*/) {
@@ -2459,10 +2459,10 @@ void DescTreeNode::ExtractDescriptor(Descriptor &searched_desc, DescTreeNode *&r
   }
 
   if (right && right->left) {
-    DEBUG_ASSERT(right->right);
+    assert(right->right);
     right->ExtractDescriptor(searched_desc, root);
   } else {
-    DEBUG_ASSERT(left && right);
+    assert(left && right);
     if (/*(desc.lop == common::LogicalOperator::O_AND && right->desc <= searched_desc) ||
                     (desc.lop == common::LogicalOperator::O_OR &&*/
         right->desc == searched_desc /*)*/) {
@@ -2555,7 +2555,7 @@ void DescTreeNode::MakeSingleColsPrivate(std::vector<vcolumn::VirtualColumn *> &
       for (; i < virt_cols.size(); i++)
         if (virt_cols[i] == desc.attr.vc)
           break;
-      DEBUG_ASSERT(i < virt_cols.size());
+      assert(i < virt_cols.size());
       desc.attr.vc = CreateVCCopy(desc.attr.vc);
       desc.attr.is_vc_owner = true;
       virt_cols[i] = desc.attr.vc;
@@ -2565,7 +2565,7 @@ void DescTreeNode::MakeSingleColsPrivate(std::vector<vcolumn::VirtualColumn *> &
       for (; i < virt_cols.size(); i++)
         if (virt_cols[i] == desc.val1.vc)
           break;
-      DEBUG_ASSERT(i < virt_cols.size());
+      assert(i < virt_cols.size());
       desc.val1.vc = CreateVCCopy(desc.val1.vc);
       desc.val1.is_vc_owner = true;
       virt_cols[i] = desc.val1.vc;
@@ -2575,7 +2575,7 @@ void DescTreeNode::MakeSingleColsPrivate(std::vector<vcolumn::VirtualColumn *> &
       for (; i < virt_cols.size(); i++)
         if (virt_cols[i] == desc.val2.vc)
           break;
-      DEBUG_ASSERT(i < virt_cols.size());
+      assert(i < virt_cols.size());
       desc.val2.vc = CreateVCCopy(desc.val2.vc);
       desc.val2.is_vc_owner = true;
       virt_cols[i] = desc.val2.vc;
@@ -2741,7 +2741,7 @@ void DescTreeNode::MEvaluatePack(MIUpdatingIterator &mit, int taskid) {
 
   // optimized case
   if (left) {             // i.e., not a leaf
-    DEBUG_ASSERT(right);  // if left is not empty so should be right
+    assert(right);  // if left is not empty so should be right
     if (desc.lop == common::LogicalOperator::O_AND) {
       if (left->desc.rvs[taskid] == common::RoughSetValue::RS_NONE ||
           right->desc.rvs[taskid] == common::RoughSetValue::RS_NONE) {

--- a/storage/tianmu/optimizer/condition.cpp
+++ b/storage/tianmu/optimizer/condition.cpp
@@ -36,7 +36,7 @@ void Condition::Simplify() {
   int size = int(descriptors.size());
   for (int i = 0; i < size; i++) {
     if (descriptors[i].op == common::Operator::O_OR_TREE) {
-      DEBUG_ASSERT(descriptors[i].tree);
+      assert(descriptors[i].tree);
       Descriptor desc;
       do {
         if ((descriptors[i].op != common::Operator::O_OR_TREE))
@@ -54,7 +54,7 @@ void Condition::Simplify() {
 }
 
 void Condition::MakeSingleColsPrivate(std::vector<vcolumn::VirtualColumn *> &virt_cols) {
-  DEBUG_ASSERT(descriptors.size() == 1);
+  assert(descriptors.size() == 1);
   descriptors[0].tree->MakeSingleColsPrivate(virt_cols);
 }
 

--- a/storage/tianmu/optimizer/condition_encoder.cpp
+++ b/storage/tianmu/optimizer/condition_encoder.cpp
@@ -84,7 +84,7 @@ bool ConditionEncoder::IsTransformationNeeded() {
 void ConditionEncoder::DescriptorTransformation() {
   MEASURE_FET("ConditionEncoder::DescriptorTransformation(...)");
   if (desc->op == common::Operator::O_IN || desc->op == common::Operator::O_NOT_IN) {
-    DEBUG_ASSERT(dynamic_cast<vcolumn::MultiValColumn *>(desc->val1.vc));
+    assert(dynamic_cast<vcolumn::MultiValColumn *>(desc->val1.vc));
     return;
   }
   if (desc->op == common::Operator::O_EQ_ANY)
@@ -210,7 +210,7 @@ void ConditionEncoder::TransformWithRespectToNulls() {
 void ConditionEncoder::PrepareValueSet(vcolumn::MultiValColumn &mvc) { mvc.SetExpectedType(attr->Type()); }
 
 void ConditionEncoder::EncodeConditionOnStringColumn() {
-  DEBUG_ASSERT(ATI::IsStringType(AttrTypeName()));
+  assert(ATI::IsStringType(AttrTypeName()));
 
   TextTransformation();
   if (!IsTransformationNeeded())
@@ -421,7 +421,7 @@ void ConditionEncoder::TransformLIKEsPattern() {
 
 void ConditionEncoder::TransformLIKEsIntoINsOnLookup() {
   MEASURE_FET("ConditionEncoder::TransformLIKEsIntoINsOnLookup(...)");
-  DEBUG_ASSERT(attr->Type().Lookup());
+  assert(attr->Type().Lookup());
 
   if (desc->op == common::Operator::O_LIKE)
     desc->op = common::Operator::O_IN;
@@ -568,7 +568,7 @@ void ConditionEncoder::TransformIntoINsOnLookup() {
 
 void ConditionEncoder::TextTransformation() {
   MEASURE_FET("ConditionEncoder::TextTransformation(...)");
-  DEBUG_ASSERT(ATI::IsStringType(AttrTypeName()));
+  assert(ATI::IsStringType(AttrTypeName()));
 
   if (desc->attr.vc) {
     vcolumn::ExpressionColumn *vcec = dynamic_cast<vcolumn::ExpressionColumn *>(desc->attr.vc);
@@ -589,7 +589,7 @@ void ConditionEncoder::TextTransformation() {
 
 void ConditionEncoder::TransformINs() {
   MEASURE_FET("ConditionEncoder::TransformINs(...)");
-  DEBUG_ASSERT(dynamic_cast<vcolumn::MultiValColumn *>(desc->val1.vc));
+  assert(dynamic_cast<vcolumn::MultiValColumn *>(desc->val1.vc));
 
   static MIIterator mit(nullptr, pack_power);
 

--- a/storage/tianmu/optimizer/group_distinct_cache.cpp
+++ b/storage/tianmu/optimizer/group_distinct_cache.cpp
@@ -42,7 +42,7 @@ GroupDistinctCache::~GroupDistinctCache() {
 }
 
 void GroupDistinctCache::Initialize() {
-  DEBUG_ASSERT(no_obj > 0 && width > 0);
+  assert(no_obj > 0 && width > 0);
   upper_byte_limit = tianmu_sysvar_distcache_size * 1_MB;  // Default 64 MB - max size of buffer
   buf_size = no_obj;
   if (no_obj > 32_GB)
@@ -128,7 +128,7 @@ bool GroupDistinctCache::NextWrite()  // go to the next position, return false
 }
 
 void GroupDistinctCache::MarkCurrentAsPreserved() {
-  DEBUG_ASSERT(cur_obj >= cur_write_obj);
+  assert(cur_obj >= cur_write_obj);
   if (t_write == nullptr) {
     t_write = (unsigned char *)alloc(upper_byte_limit,
                                      mm::BLOCK_TYPE::BLOCK_TEMPORARY);  // switch writing to the new buffer

--- a/storage/tianmu/optimizer/group_distinct_table.cpp
+++ b/storage/tianmu/optimizer/group_distinct_table.cpp
@@ -54,7 +54,7 @@ GroupDistinctTable::~GroupDistinctTable() {
 
 void GroupDistinctTable::InitializeVC(int64_t max_no_groups, vcolumn::VirtualColumn *vc, int64_t max_no_rows,
                                       int64_t max_bytes, bool decodable) {
-  DEBUG_ASSERT(!initialized);
+  assert(!initialized);
   if (max_bytes > 0)
     max_total_size = max_bytes;
   if (max_bytes > static_cast<int64_t>(2_GB))  // possible for large aggregation settings, but
@@ -98,7 +98,7 @@ void GroupDistinctTable::InitializeVC(int64_t max_no_groups, vcolumn::VirtualCol
 
 void GroupDistinctTable::InitializeB(int max_len, int64_t max_no_rows)  // char* initialization
 {
-  DEBUG_ASSERT(!initialized);
+  assert(!initialized);
   input_length = max_len;
   group_bytes = 1;
   if (max_len > HASH_FUNCTION_BYTE_SIZE) {
@@ -150,7 +150,7 @@ void GroupDistinctTable::InitializeBuffers(int64_t max_no_rows)  // max_no_rows 
 
 int64_t GroupDistinctTable::BytesTaken()  // actual size of structures
 {
-  DEBUG_ASSERT(initialized);
+  assert(initialized);
   if (filter_implementation)
     return f->NumOfObj() / 8;
   return total_width * no_rows;
@@ -207,7 +207,7 @@ GDTResult GroupDistinctTable::Add(int64_t group, int64_t val)  // numeric values
 
 GDTResult GroupDistinctTable::Add(unsigned char *v)  // arbitrary vector of bytes
 {
-  DEBUG_ASSERT(!filter_implementation);
+  assert(!filter_implementation);
   input_buffer[0] = 1;
   if (use_CRC) {
     std::memset(input_buffer + group_bytes, 0, HASH_FUNCTION_BYTE_SIZE);
@@ -219,7 +219,7 @@ GDTResult GroupDistinctTable::Add(unsigned char *v)  // arbitrary vector of byte
 
 GDTResult GroupDistinctTable::AddFromCache(unsigned char *input_vector)  // input vector from cache
 {
-  DEBUG_ASSERT(!filter_implementation);
+  assert(!filter_implementation);
   std::memcpy(input_buffer, input_vector, total_width);
   return FindCurrentRow();
 }
@@ -262,7 +262,7 @@ GDTResult GroupDistinctTable::FindCurrentRowByVMTable() {
 
 GDTResult GroupDistinctTable::FindCurrentRow(bool find_only)  // find / insert the current buffer
 {
-  DEBUG_ASSERT(!filter_implementation);
+  assert(!filter_implementation);
   unsigned int crc_code = HashValue(input_buffer, total_width);
   int64_t row = crc_code % no_rows;
   int64_t step = 3 + crc_code % 8;

--- a/storage/tianmu/optimizer/group_table.cpp
+++ b/storage/tianmu/optimizer/group_table.cpp
@@ -52,7 +52,7 @@ GroupTable::~GroupTable() {
 }
 
 GroupTable::GroupTable(const GroupTable &sec) : mm::TraceableObject(sec) {
-  DEBUG_ASSERT(sec.initialized);  // can only copy initialized GroupTables!
+  assert(sec.initialized);  // can only copy initialized GroupTables!
   // Some fields are omitted (empty vectors), as they are used only for
   // Initialize()
   initialized = true;
@@ -380,7 +380,7 @@ void GroupTable::Initialize(int64_t max_no_groups, bool parallel_allowed) {
   for (int i = no_grouping_attr; i < no_attr; i++)
     if (distinct[i]) {
       desc = aggregated_desc[i - no_grouping_attr];
-      DEBUG_ASSERT(distinct_size > 0);
+      assert(distinct_size > 0);
       gdistinct[i] = std::make_shared<GroupDistinctTable>(p_power);
       gdistinct[i]->InitializeVC(vm_tab->RowNumberScope(), vc[i], desc.max_no_values,
                                  distinct_size / no_columns_with_distinct,
@@ -440,7 +440,7 @@ bool GroupTable::FindCurrentRow(int64_t &row)  // a position in the current Grou
 int GroupTable::MemoryBlocksLeft() { return vm_tab->MemoryBlocksLeft(); }
 
 void GroupTable::Merge(GroupTable &sec, Transaction *m_conn) {
-  DEBUG_ASSERT(total_width == sec.total_width);
+  assert(total_width == sec.total_width);
   sec.vm_tab->Rewind(true);
   int64_t sec_row;
   int64_t row;
@@ -453,7 +453,7 @@ void GroupTable::Merge(GroupTable &sec, Transaction *m_conn) {
       std::memcpy(input_buffer.data(), sec.vm_tab->GetGroupingRow(sec_row), grouping_and_UTF_width);
     FindCurrentRow(row);  // find the value on another position or add as a new one
     if (row != common::NULL_VALUE_64) {
-      DEBUG_ASSERT(row != common::NULL_VALUE_64);
+      assert(row != common::NULL_VALUE_64);
       unsigned char *p1 = vm_tab->GetAggregationRow(row);
       unsigned char *p2 = sec.vm_tab->GetAggregationRow(sec_row);
       for (int col = no_grouping_attr; col < no_attr; col++) {
@@ -545,7 +545,7 @@ bool GroupTable::PutAggregatedValue(int col, int64_t row,
 GDTResult GroupTable::FindDistinctValue(int col, int64_t row,
                                         int64_t v)  // for all numerical values
 {
-  DEBUG_ASSERT(gdistinct[col]);
+  assert(gdistinct[col]);
   if (v == common::NULL_VALUE_64)  // works also for double
     return GDTResult::GDT_EXISTS;  // null omitted
   return gdistinct[col]->Find(row, v);
@@ -554,7 +554,7 @@ GDTResult GroupTable::FindDistinctValue(int col, int64_t row,
 GDTResult GroupTable::AddDistinctValue(int col, int64_t row,
                                        int64_t v)  // for all numerical values
 {
-  DEBUG_ASSERT(gdistinct[col]);
+  assert(gdistinct[col]);
   if (v == common::NULL_VALUE_64)  // works also for double
     return GDTResult::GDT_EXISTS;  // null omitted
   return gdistinct[col]->Add(row, v);
@@ -563,7 +563,7 @@ GDTResult GroupTable::AddDistinctValue(int col, int64_t row,
 bool GroupTable::PutAggregatedValue(int col, int64_t row, MIIterator &mit, int64_t factor, bool as_string) {
   if (distinct[col]) {
     // Repetition? Return without action.
-    DEBUG_ASSERT(gdistinct[col]);
+    assert(gdistinct[col]);
     if (vc[col]->IsNull(mit))
       return true;  // omit nulls
     GDTResult res = gdistinct[col]->Add(row, mit);
@@ -613,7 +613,7 @@ bool GroupTable::PutAggregatedNull(int col, int64_t row, bool as_string) {
 bool GroupTable::PutCachedValue(int col, GroupDistinctCache &cache,
                                 bool as_text)  // for all numerical values
 {
-  DEBUG_ASSERT(distinct[col]);
+  assert(distinct[col]);
   GDTResult res = gdistinct[col]->AddFromCache(cache.GetCurrentValue());
   if (res == GDTResult::GDT_EXISTS)
     return true;  // value found, do not aggregate it again

--- a/storage/tianmu/optimizer/groupby_wrapper.cpp
+++ b/storage/tianmu/optimizer/groupby_wrapper.cpp
@@ -107,7 +107,7 @@ GroupByWrapper::GroupByWrapper(const GroupByWrapper &sec)
 void GroupByWrapper::AddGroupingColumn(int attr_no, int orig_attr_no, TempTable::Attr &a) {
   virt_col[attr_no] = a.term.vc;
 
-  DEBUG_ASSERT(virt_col[attr_no]);
+  assert(virt_col[attr_no]);
 
   // Not used for grouping columns:
   is_lookup[attr_no] = false;
@@ -137,7 +137,7 @@ void GroupByWrapper::AddAggregatedColumn(int orig_attr_no, TempTable::Attr &a, i
 
   virt_col[attr_no] = a.term.vc;
 
-  DEBUG_ASSERT(virt_col[attr_no] || a.term.IsNull());  // the second possibility is count(*)
+  assert(virt_col[attr_no] || a.term.IsNull());  // the second possibility is count(*)
 
   is_lookup[attr_no] = false;
   dist_vals[attr_no] = max_no_vals;
@@ -434,7 +434,7 @@ bool GroupByWrapper::AttrMayBeUpdatedByPack(int i, MIIterator &mit)  // false, i
 bool GroupByWrapper::PackWillNotUpdateAggregation(int i, MIIterator &mit)  // false, if counters can be changed
 {
   // MEASURE_FET("GroupByWrapper::PackWillNotUpdateAggregation(...)");
-  DEBUG_ASSERT(input_mode[i] != GBInputMode::GBIMODE_NOT_SET);
+  assert(input_mode[i] != GBInputMode::GBIMODE_NOT_SET);
   if (((is_lookup[i] || input_mode[i] == GBInputMode::GBIMODE_AS_TEXT) &&
        (gt.AttrOper(i) == GT_Aggregation::GT_MIN || gt.AttrOper(i) == GT_Aggregation::GT_MAX)) ||
       virt_col[i] == nullptr)
@@ -467,7 +467,7 @@ bool GroupByWrapper::PackWillNotUpdateAggregation(int i, MIIterator &mit)  // fa
 bool GroupByWrapper::DataWillNotUpdateAggregation(int i)  // false, if counters can be changed
 {
   // Identical with PackWillNot...(), but calculated for global statistics
-  DEBUG_ASSERT(input_mode[i] != GBInputMode::GBIMODE_NOT_SET);
+  assert(input_mode[i] != GBInputMode::GBIMODE_NOT_SET);
   if (((is_lookup[i] || input_mode[i] == GBInputMode::GBIMODE_AS_TEXT) &&
        (gt.AttrOper(i) == GT_Aggregation::GT_MIN || gt.AttrOper(i) == GT_Aggregation::GT_MAX)) ||
       virt_col[i] == nullptr)
@@ -498,23 +498,23 @@ bool GroupByWrapper::DataWillNotUpdateAggregation(int i)  // false, if counters 
 }
 
 bool GroupByWrapper::PutAggregatedValueForCount(int gr_a, int64_t pos, int64_t factor) {
-  DEBUG_ASSERT(gt.AttrOper(gr_a) == GT_Aggregation::GT_COUNT || gt.AttrOper(gr_a) == GT_Aggregation::GT_COUNT_NOT_NULL);
+  assert(gt.AttrOper(gr_a) == GT_Aggregation::GT_COUNT || gt.AttrOper(gr_a) == GT_Aggregation::GT_COUNT_NOT_NULL);
   return gt.PutAggregatedValue(gr_a, pos, factor);
 }
 
 bool GroupByWrapper::PutAggregatedValueForMinMax(int gr_a, int64_t pos, int64_t factor) {
-  DEBUG_ASSERT(gt.AttrOper(gr_a) == GT_Aggregation::GT_MIN || gt.AttrOper(gr_a) == GT_Aggregation::GT_MAX);
+  assert(gt.AttrOper(gr_a) == GT_Aggregation::GT_MIN || gt.AttrOper(gr_a) == GT_Aggregation::GT_MAX);
   return gt.PutAggregatedValue(gr_a, pos, factor);
 }
 
 bool GroupByWrapper::PutAggregatedNull(int gr_a, int64_t pos) {
-  DEBUG_ASSERT(input_mode[gr_a] != GBInputMode::GBIMODE_NOT_SET);
+  assert(input_mode[gr_a] != GBInputMode::GBIMODE_NOT_SET);
   return gt.PutAggregatedNull(gr_a, pos, (input_mode[gr_a] == GBInputMode::GBIMODE_AS_TEXT));
   return false;
 }
 
 bool GroupByWrapper::PutAggregatedValue(int gr_a, int64_t pos, MIIterator &mit, int64_t factor) {
-  DEBUG_ASSERT(input_mode[gr_a] != GBInputMode::GBIMODE_NOT_SET);
+  assert(input_mode[gr_a] != GBInputMode::GBIMODE_NOT_SET);
   if (input_mode[gr_a] == GBInputMode::GBIMODE_NO_VALUE)
     return gt.PutAggregatedValue(gr_a, pos, factor);
   return gt.PutAggregatedValue(gr_a, pos, mit, factor, (input_mode[gr_a] == GBInputMode::GBIMODE_AS_TEXT));
@@ -575,7 +575,7 @@ void GroupByWrapper::ClearDistinctBuffers() {
 
 bool GroupByWrapper::PutCachedValue(int gr_a)  // current value from distinct cache
 {
-  DEBUG_ASSERT(input_mode[gr_a] != GBInputMode::GBIMODE_NOT_SET);
+  assert(input_mode[gr_a] != GBInputMode::GBIMODE_NOT_SET);
   bool added =
       gt.PutCachedValue(gr_a, distinct_watch.gd_cache[gr_a], (input_mode[gr_a] == GBInputMode::GBIMODE_AS_TEXT));
   if (!added)
@@ -654,7 +654,7 @@ void GroupByWrapper::InitTupleLeft(int64_t n) {
     delete tuple_left;
     tuple_left = nullptr;
   }
-  DEBUG_ASSERT(tuple_left == nullptr);
+  assert(tuple_left == nullptr);
   tuple_left = new Filter(n, p_power);
   tuple_left->Set();
 }
@@ -710,7 +710,7 @@ void DistinctWrapper::InitTuples(int64_t n_obj, const GroupTable &gt) {
       // for now - init cache with a number of objects decreased (will cache on
       // disk if more is needed)
       gd_cache[i].SetNumOfObj(n_obj);
-      DEBUG_ASSERT(f[i] == nullptr);
+      assert(f[i] == nullptr);
       f[i].reset(new Filter(n_obj, p_power));
       gd_cache[i].SetWidth(gt.GetCachedWidth(i));
     }

--- a/storage/tianmu/optimizer/groupby_wrapper.h
+++ b/storage/tianmu/optimizer/groupby_wrapper.h
@@ -176,7 +176,7 @@ class GroupByWrapper final {
   void OmitColumnForPackrow(int a) { pack_not_omitted[a] = false; }
   vcolumn::VirtualColumn *SourceColumn(int a) { return virt_col[a]; }
   vcolumn::VirtualColumn *GetColumn(int i) {
-    DEBUG_ASSERT(i < no_attr);
+    assert(i < no_attr);
     return virt_col[i];
   }
   bool JustDistinct() { return just_distinct; }

--- a/storage/tianmu/optimizer/iterators/mi_iterator.cpp
+++ b/storage/tianmu/optimizer/iterators/mi_iterator.cpp
@@ -133,7 +133,7 @@ MIIterator::MIIterator(const MIIterator &sec, bool lock)
   p_power = sec.p_power;
   if (sec.mind_created_locally) {
     mind = new MultiIndex(*sec.mind);
-    DEBUG_ASSERT(no_dims == 1);
+    assert(no_dims == 1);
     dg[0] = mind->dim_groups[0];  // assuming that the local minds are
                                   // one-dimensional
   }
@@ -168,7 +168,7 @@ MIIterator::MIIterator(const MIIterator &sec, bool lock)
 }
 
 void MIIterator::swap(MIIterator &i) {
-  DEBUG_ASSERT(po.size() == 0 && "not working due to pack orderer swap");
+  assert(po.size() == 0 && "not working due to pack orderer swap");
   std::swap(p_power, i.p_power);
   std::swap(mind, i.mind);
   std::swap(mind_created_locally, i.mind_created_locally);
@@ -221,7 +221,7 @@ void MIIterator::Init(bool lock) {
     if (po.size() > 0) {
       for (int i = 0; i < no_dims; i++)
         if (dim_group_used[mind->group_num_for_dim[i]] && mind->GetFilter(i) && po[i].Initialized()) {
-          DEBUG_ASSERT(mind->IsOrderable(i));
+          assert(mind->IsOrderable(i));
           it.push_back(mind->group_for_dim[i]->NewOrderedIterator(dimensions, &po[i], p_power));
           dg.push_back(mind->group_for_dim[i]);
           dim_group_used[mind->group_num_for_dim[i]] = false;
@@ -384,7 +384,7 @@ void MIIterator::NextPackrow() {
     valid = false;
   else
     InitNextPackrow();
-  DEBUG_ASSERT(one_filter_dim == -1 || cur_pos[one_filter_dim] >> p_power == cur_pack[one_filter_dim]);
+  assert(one_filter_dim == -1 || cur_pos[one_filter_dim] >> p_power == cur_pack[one_filter_dim]);
 }
 
 bool MIIterator::WholePack(int dim) const {
@@ -448,7 +448,7 @@ void MIDummyIterator::Combine(const MIIterator &sec)  // copy position from the 
 
 void MIDummyIterator::Set(int dim, int64_t val)  // set a position manually
 {
-  DEBUG_ASSERT(dim >= 0 && dim < no_dims);
+  assert(dim >= 0 && dim < no_dims);
   cur_pos[dim] = val;
   if (val == common::NULL_VALUE_64)
     cur_pack[dim] = -1;
@@ -458,7 +458,7 @@ void MIDummyIterator::Set(int dim, int64_t val)  // set a position manually
 
 void MIDummyIterator::SetPack(int dim, int p)  // set a position manually
 {
-  DEBUG_ASSERT(dim >= 0 && dim < no_dims);
+  assert(dim >= 0 && dim < no_dims);
   cur_pos[dim] = (int64_t(p) << p_power);
   cur_pack[dim] = p;
 }
@@ -519,7 +519,7 @@ int MIInpackIterator::GetNextPackrow([[maybe_unused]] int dim, [[maybe_unused]] 
 }
 
 void MIIterator::SetNoPacksToGo(int n) {
-  DEBUG_ASSERT(one_filter_it);
+  assert(one_filter_it);
   one_filter_it->SetNoPacksToGo(n);
 }
 
@@ -566,7 +566,7 @@ MIIterator::SliceCapability MIIterator::GetSliceCapability() const {
 }
 
 void MIIterator::RewindToRow(int64_t row) {
-  DEBUG_ASSERT(one_filter_it);
+  assert(one_filter_it);
   one_filter_it->RewindToRow(row);
   valid = one_filter_it->IsValid();
   if (valid) {

--- a/storage/tianmu/optimizer/iterators/mi_iterator.h
+++ b/storage/tianmu/optimizer/iterators/mi_iterator.h
@@ -85,7 +85,7 @@ class MIIterator {
    * at the end of MultiIndex (check IsValid() first).
    */
   const int64_t *operator*() const {
-    DEBUG_ASSERT(valid);
+    assert(valid);
     return cur_pos;
   }
 
@@ -98,7 +98,7 @@ class MIIterator {
    * IsValid() first).
    */
   int64_t operator[](int n) const {
-    DEBUG_ASSERT(valid && n >= 0 && n < no_dims);
+    assert(valid && n >= 0 && n < no_dims);
     return cur_pos[n];
   }
 
@@ -113,7 +113,7 @@ class MIIterator {
   virtual MIIterator &Increment() { return this->operator++(); }
   //! move to the next row position within an associated MultiIndex
   inline MIIterator &operator++() {
-    DEBUG_ASSERT(valid);
+    assert(valid);
     next_pack_started = false;
     if (one_filter_dim > -1) {  // Optimized (one-dimensional filter) part:
       ++(*one_filter_it);
@@ -135,7 +135,7 @@ class MIIterator {
           InitNextPackrow();
       }
     }
-    DEBUG_ASSERT(one_filter_dim == -1 || cur_pos[one_filter_dim] >> p_power == cur_pack[one_filter_dim]);
+    assert(one_filter_dim == -1 || cur_pos[one_filter_dim] >> p_power == cur_pack[one_filter_dim]);
     return *this;
   }
 
@@ -209,7 +209,7 @@ class MIIterator {
   virtual int GetNextPackrow(int dim, int ahead = 1) const;
 
   int GetCurInpack(int dim) const {
-    DEBUG_ASSERT(valid && dim >= 0 && dim < no_dims);
+    assert(valid && dim >= 0 && dim < no_dims);
     return int(cur_pos[dim] & ((1 << p_power) - 1));
   }
 
@@ -317,20 +317,20 @@ class MIDummyIterator : public MIIterator {
   int64_t GetPackSizeLeft() const override { return 1; }
   // These functions are illegal for MIDummyIterator
   MIIterator &Increment() override {
-    DEBUG_ASSERT(0);
+    assert(0);
     return *this;
   }
   MIIterator &operator++() {
-    DEBUG_ASSERT(0);
+    assert(0);
     return *this;
   }
   int64_t Factor() const {
-    DEBUG_ASSERT(0);
+    assert(0);
     return omitted_factor;
   }
-  void NextPackrow() override { DEBUG_ASSERT(0); }
+  void NextPackrow() override { assert(0); }
   bool DimUsed([[maybe_unused]] int dim) const override {
-    DEBUG_ASSERT(0);
+    assert(0);
     return true;
   }
 };
@@ -367,12 +367,12 @@ class MIInpackIterator : public MIIterator {
   // These functions have special meaning for MIInpackIterator:
   void NextPackrow() override { valid = false; }
   int GetNextPackrow(int dim, int ahead = 1) const override;
-  void Rewind() { DEBUG_ASSERT(0); }  // do not use
+  void Rewind() { assert(0); }  // do not use
   MIIterator &Increment() override { return this->operator++(); }
   // Special version of iterator (use Increment() if the iterator should be
   // virtual)
   inline MIIterator &operator++() {
-    DEBUG_ASSERT(valid);
+    assert(valid);
     next_pack_started = false;
     if (one_filter_dim > -1) {
       valid = one_filter_it->NextInsidePack();

--- a/storage/tianmu/optimizer/iterators/mi_step_iterator.cpp
+++ b/storage/tianmu/optimizer/iterators/mi_step_iterator.cpp
@@ -52,7 +52,7 @@ MIRowsStepIterator::MIRowsStepIterator(int64_t start, int step, int64_t origin_s
 MIIterator &MIRowsStepIterator::Increment() {
   MIIterator &iter = this->operator++();
   if (iter.IsValid()) {
-    DEBUG_ASSERT(GetOneFilterDim() > -1);
+    assert(GetOneFilterDim() > -1);
     int64_t cur_pos = iter[iter.GetOneFilterDim()];
     if (cur_pos >= rows_finish_) {
       valid = false;

--- a/storage/tianmu/optimizer/iterators/mi_updating_iterator.cpp
+++ b/storage/tianmu/optimizer/iterators/mi_updating_iterator.cpp
@@ -25,7 +25,7 @@ MIUpdatingIterator::MIUpdatingIterator(MultiIndex *_mind, DimensionVector &dimen
   mind->IteratorUnlock();  // unlock a base class lock
   bool success = mind->IteratorUpdatingLock();
   (void)success;          // FIXME: error handling
-  DEBUG_ASSERT(success);  // Multiindex was already locked for reading or updating!
+  assert(success);  // Multiindex was already locked for reading or updating!
   if (one_filter_dim > -1 && !(it[it_for_dim[one_filter_dim]]->InternallyUpdatable()))
     one_filter_dim = -1;
   if (one_filter_dim == -1) {
@@ -90,7 +90,7 @@ void MIUpdatingIterator::NextPackrow() {
 }
 
 int MIUpdatingIterator::NumOfOnesUncommited(uint pack) {
-  DEBUG_ASSERT(one_filter_it);
+  assert(one_filter_it);
   if (one_filter_dim > -1)
     return one_filter_it->NumOfOnesUncommited(pack);
   else
@@ -100,13 +100,13 @@ int MIUpdatingIterator::NumOfOnesUncommited(uint pack) {
 /*
 void MIUpdatingIterator::SetNoPacksToGo(int n)
 {
-    DEBUG_ASSERT(one_filter_it);
+    assert(one_filter_it);
     one_filter_it->SetNoPacksToGo(n);
 }
 */
 
 void MIUpdatingIterator::RewindToRow(const int64_t row) {
-  DEBUG_ASSERT(one_filter_it);
+  assert(one_filter_it);
   one_filter_it->RewindToRow(row);
   valid = one_filter_it->IsValid();
   if (valid) {
@@ -119,7 +119,7 @@ void MIUpdatingIterator::RewindToRow(const int64_t row) {
 bool MIUpdatingIterator::RewindToPack(const int pack) {
   // if SetNoPacksToGo() has been used, then RewindToPack can be done only to
   // the previous pack
-  DEBUG_ASSERT(one_filter_it);
+  assert(one_filter_it);
   Commit(false);
   bool res = one_filter_it->RewindToPack(pack);
   valid = one_filter_it->IsValid();
@@ -134,7 +134,7 @@ bool MIUpdatingIterator::RewindToPack(const int pack) {
 
 Filter *MIUpdatingIterator::NewPackFilter(int pack)  // create a new filter for the snapshot and initialize it
 {
-  DEBUG_ASSERT(one_filter_it);
+  assert(one_filter_it);
   Filter *f_old = mind->GetFilter(one_filter_dim);
   Filter *new_f = new Filter(f_old->NumOfObj(), pack_power);
   new_f->Or(*f_old, pack);
@@ -145,7 +145,7 @@ bool MIUpdatingIterator::SwapPackFilter(int pack, Filter *f)  // swap the conten
                                                               // pack; return false without swapping
                                                               // if the current pack is full
 {
-  DEBUG_ASSERT(one_filter_it);
+  assert(one_filter_it);
   Commit(false);
   Filter *f_old = mind->GetFilter(one_filter_dim);
   if (f_old->IsFull(pack))
@@ -156,7 +156,7 @@ bool MIUpdatingIterator::SwapPackFilter(int pack, Filter *f)  // swap the conten
 
 void MIUpdatingIterator::OrPackFilter(int pack, Filter *f)  // make OR
 {
-  DEBUG_ASSERT(one_filter_it);
+  assert(one_filter_it);
   Commit(false);
   Filter *f_old = mind->GetFilter(one_filter_dim);
   f_old->Or(*f, pack);

--- a/storage/tianmu/optimizer/iterators/mi_updating_iterator.cpp
+++ b/storage/tianmu/optimizer/iterators/mi_updating_iterator.cpp
@@ -24,7 +24,7 @@ MIUpdatingIterator::MIUpdatingIterator(MultiIndex *_mind, DimensionVector &dimen
   pack_power = mind->ValueOfPower();
   mind->IteratorUnlock();  // unlock a base class lock
   bool success = mind->IteratorUpdatingLock();
-  (void)success;          // FIXME: error handling
+  (void)success;    // FIXME: error handling
   assert(success);  // Multiindex was already locked for reading or updating!
   if (one_filter_dim > -1 && !(it[it_for_dim[one_filter_dim]]->InternallyUpdatable()))
     one_filter_dim = -1;

--- a/storage/tianmu/optimizer/joiner_hash.cpp
+++ b/storage/tianmu/optimizer/joiner_hash.cpp
@@ -566,7 +566,7 @@ void JoinerHash::InitOuter(Condition &cond) {
 int64_t JoinerHash::SubmitOuterMatched(MIIterator &mit, MINewContents &new_mind) {
   MEASURE_FET("JoinerHash::SubmitOuterMatched(...)");
   // mit - an iterator through the matched dimensions
-  DEBUG_ASSERT(outer_filter && watch_matched);
+  assert(outer_filter && watch_matched);
   if (tips.count_only)
     return outer_filter->NumOfOnes();
   mit.Rewind();
@@ -810,7 +810,7 @@ int64_t JoinerHash::NewMatchDim(MINewContents *new_mind1, MIUpdatingIterator *ta
 
 int64_t JoinerHash::SubmitOuterTraversed(MINewContents &new_mind) {
   MEASURE_FET("JoinerHash::SubmitOuterTraversed(...)");
-  DEBUG_ASSERT(outer_filter && watch_traversed);
+  assert(outer_filter && watch_traversed);
   if (tips.count_only)
     return outer_filter->NumOfOnes();
   int64_t outer_added = 0;

--- a/storage/tianmu/optimizer/joiner_hash_table.cpp
+++ b/storage/tianmu/optimizer/joiner_hash_table.cpp
@@ -161,7 +161,7 @@ int64_t JoinerHashTable::FindAndAddCurrentRow()  // a position in the current Jo
       if (std::memcmp(cur_t, input_buffer.get(), key_buf_width) == 0) {
         // i.e. identical row found
         int64_t last_multiplier = *multiplier;
-        DEBUG_ASSERT(last_multiplier > 0);
+        assert(last_multiplier > 0);
         (*multiplier)++;
         if (for_count_only)
           return row;
@@ -237,7 +237,7 @@ int64_t JoinerHashTable::GetNextRow() {
   if (current_row >= no_rows)
     current_row = current_row % no_rows;
   do {
-    DEBUG_ASSERT(*((int *)(t + current_row * total_width + mult_offset)) != 0);
+    assert(*((int *)(t + current_row * total_width + mult_offset)) != 0);
     if (std::memcmp(t + current_row * total_width, input_buffer.get(), key_buf_width) == 0) {
       // i.e. identical row found - keep the current_row
       return row_to_return;

--- a/storage/tianmu/optimizer/joiner_hash_table.h
+++ b/storage/tianmu/optimizer/joiner_hash_table.h
@@ -101,7 +101,7 @@ class JoinerHashTable : public mm::TraceableObject {
   // columns have common numbering, both key and tuple ones
   void PutTupleValue(int col, int64_t row,
                      int64_t v) {  // common::NULL_VALUE_64 stored as 0
-    DEBUG_ASSERT(col >= no_key_attr);
+    assert(col >= no_key_attr);
     if (size[col] == 4) {
       if (v == common::NULL_VALUE_64)
         *((int *)(t + row * total_width + column_offset[col])) = 0;
@@ -119,7 +119,7 @@ class JoinerHashTable : public mm::TraceableObject {
   int64_t NoRows() { return no_rows; }  // buffer size (max. number of rows)
   int64_t GetTupleValue(int col,
                         int64_t row) {  // columns have common numbering
-    DEBUG_ASSERT(col >= no_key_attr);
+    assert(col >= no_key_attr);
     if (size[col] == 4) {
       int v = *((int *)(t + row * total_width + column_offset[col]));
       if (v == 0)

--- a/storage/tianmu/optimizer/joiner_mapped.cpp
+++ b/storage/tianmu/optimizer/joiner_mapped.cpp
@@ -75,7 +75,7 @@ void JoinerMapped::ExecuteJoinConditions(Condition &cond) {
       matched_dims.Intersects(desc.right_dims))  // only traversed dimension may be outer
     return;
   int traversed_dim = traversed_dims.GetOneDim();
-  DEBUG_ASSERT(traversed_dim > -1);
+  assert(traversed_dim > -1);
 
   // Prepare mapping function
   auto map_function = GenerateFunction(vc1);

--- a/storage/tianmu/optimizer/joiner_sort.cpp
+++ b/storage/tianmu/optimizer/joiner_sort.cpp
@@ -411,7 +411,7 @@ void JoinerSortWrapper::SetDimensions(MultiIndex *mind, DimensionVector &dim_tr,
     outer_offset = traverse_bytes - key_bytes;
     traverse_bytes += 8;
   }
-  DEBUG_ASSERT(buf == nullptr);
+  assert(buf == nullptr);
   buf_bytes = std::max(traverse_bytes, match_bytes);
   buf = new unsigned char[buf_bytes];
 }
@@ -523,7 +523,7 @@ void JoinerSortWrapper::InitCache(int64_t no_of_rows) {
 bool JoinerSortWrapper::AddToCache(unsigned char *v)  // return false if there is no more space in
                                                       // cache (i.e. the next operation would fail)
 {
-  DEBUG_ASSERT(cur_cache_used < cache_size);
+  assert(cur_cache_used < cache_size);
   if (cache_bytes > 0)
     std::memcpy(cache + cur_cache_used * cache_bytes, v, cache_bytes);
   cur_cache_used++;
@@ -532,7 +532,7 @@ bool JoinerSortWrapper::AddToCache(unsigned char *v)  // return false if there i
 
 int64_t JoinerSortWrapper::DimValue(int d, int cache_position, unsigned char *matched_buffer) {
   int64_t dim_value = 0;
-  DEBUG_ASSERT(dim_size[d] > 0);
+  assert(dim_size[d] > 0);
   if (dim_traversed[d])
     std::memcpy(&dim_value, cache + cache_bytes * cache_position + dim_offset[d],
                 dim_size[d]);  // get it from cache

--- a/storage/tianmu/system/cacheable_item.cpp
+++ b/storage/tianmu/system/cacheable_item.cpp
@@ -25,8 +25,8 @@ namespace Tianmu {
 namespace system {
 CacheableItem::CacheableItem(char const *owner_name, char const *object_id, int default_block_size)
     : default_block_size_(default_block_size) {
-  DEBUG_ASSERT(owner_name != nullptr);
-  DEBUG_ASSERT(object_id != nullptr);
+  assert(owner_name != nullptr);
+  assert(object_id != nullptr);
 
   constexpr size_t kMinOwnerNameLen = 3;
   constexpr size_t kOwnerAndObjectLen = 6;
@@ -88,7 +88,7 @@ CacheableItem::CacheableItem(char const *owner_name, char const *object_id, int 
   std::snprintf(file_name_ + filename_offset, kSuffixLen + 1, "%s", ".tianmu_tmp");
   filename_offset += kSuffixLen;
 
-  DEBUG_ASSERT(file_name_[filename_offset] == 0);
+  assert(file_name_[filename_offset] == 0);
 }
 
 CacheableItem::~CacheableItem() {
@@ -138,7 +138,7 @@ void CacheableItem::CI_Put(int block, unsigned char *data, int size) {
         cur_file_handle_.OpenCreateEmpty(file_name_);
       else
         cur_file_handle_.OpenReadWrite(file_name_);
-      DEBUG_ASSERT(cur_file_handle_.IsOpen());
+      assert(cur_file_handle_.IsOpen());
       cur_file_number_ = file_number_[block];
       max_file_pos_ += size;
     }
@@ -149,7 +149,7 @@ void CacheableItem::CI_Put(int block, unsigned char *data, int size) {
       cur_file_handle_.Close();
       SetFilename(cur_file_number_);
       cur_file_handle_.OpenReadWrite(file_name_);
-      DEBUG_ASSERT(cur_file_handle_.IsOpen());
+      assert(cur_file_handle_.IsOpen());
     }
 
 #ifdef FUNCTIONS_EXECUTION_TIMES
@@ -179,7 +179,7 @@ int CacheableItem::CI_Get(int block, uchar *data, int size, int off) {
       cur_file_handle_.Close();
       SetFilename(cur_file_number_);
       cur_file_handle_.OpenReadWrite(file_name_);
-      DEBUG_ASSERT(cur_file_handle_.IsOpen());
+      assert(cur_file_handle_.IsOpen());
     }
 
     // load the block

--- a/storage/tianmu/system/file.cpp
+++ b/storage/tianmu/system/file.cpp
@@ -23,7 +23,7 @@ namespace Tianmu {
 namespace system {
 
 int TianmuFile::Open(std::string const &file, int flags, mode_t mode) {
-  DEBUG_ASSERT(file.length());
+  assert(file.length());
   name_ = file;
 
   fd_ = open(file.c_str(), flags, mode);
@@ -34,7 +34,7 @@ int TianmuFile::Open(std::string const &file, int flags, mode_t mode) {
 }
 
 size_t TianmuFile::Read(void *buf, size_t count) {
-  DEBUG_ASSERT(fd_ != -1);
+  assert(fd_ != -1);
   auto read_bytes = read(fd_, buf, count);
   if (read_bytes == -1)
     ThrowError(errno);
@@ -86,7 +86,7 @@ void TianmuFile::ReadExact(void *buf, size_t count) {
 }
 
 void TianmuFile::WriteExact(const void *buf, size_t count) {
-  DEBUG_ASSERT(fd_ != -1);
+  assert(fd_ != -1);
   size_t total_writen_bytes = 0;
   while (total_writen_bytes < count) {
     auto writen_bytes = write(fd_, ((char *)buf) + total_writen_bytes, count - total_writen_bytes);
@@ -98,7 +98,7 @@ void TianmuFile::WriteExact(const void *buf, size_t count) {
 
 off_t TianmuFile::Seek(off_t pos, int whence) {
   off_t new_pos = -1;
-  DEBUG_ASSERT(fd_ != -1);
+  assert(fd_ != -1);
 
   new_pos = lseek(fd_, pos, whence);
 
@@ -109,7 +109,7 @@ off_t TianmuFile::Seek(off_t pos, int whence) {
 
 off_t TianmuFile::Tell() {
   off_t pos;
-  DEBUG_ASSERT(fd_ != -1);
+  assert(fd_ != -1);
   pos = lseek(fd_, 0, SEEK_CUR);
   if (pos == (off_t)-1)
     ThrowError(errno);

--- a/storage/tianmu/system/file_system.cpp
+++ b/storage/tianmu/system/file_system.cpp
@@ -97,14 +97,14 @@ bool DoesFileExist(std::string const &file) {
 }
 
 void RenameFile(std::string const &OldPath, std::string const &NewPath) {
-  DEBUG_ASSERT(OldPath.length() && NewPath.length());
+  assert(OldPath.length() && NewPath.length());
   if (rename(OldPath.c_str(), NewPath.c_str())) {
     throw common::DatabaseException(std::strerror(errno));
   }
 };
 
 void RemoveFile(std::string const &path, int throwerror) {
-  DEBUG_ASSERT(path.length());
+  assert(path.length());
   if (remove(path.c_str())) {
     if (DoesFileExist(path) && throwerror) {
       throw common::DatabaseException(std::strerror(errno));

--- a/storage/tianmu/system/io_parameters.h
+++ b/storage/tianmu/system/io_parameters.h
@@ -73,7 +73,7 @@ class IOParameters {
         lock_option_ = value;
         break;
       default:
-        DEBUG_ASSERT(0 && "unexpected value");
+        assert(0 && "unexpected value");
         break;
     }
   }
@@ -91,7 +91,7 @@ class IOParameters {
         charsets_dir_ = value;
         break;
       default:
-        DEBUG_ASSERT(0 && "unexpected value");
+        assert(0 && "unexpected value");
         break;
     }
   }
@@ -108,7 +108,7 @@ class IOParameters {
         table_id_ = value;
         break;
       default:
-        DEBUG_ASSERT(0 && "unexpected value");
+        assert(0 && "unexpected value");
         break;
     }
   }

--- a/storage/tianmu/system/large_buffer.cpp
+++ b/storage/tianmu/system/large_buffer.cpp
@@ -116,7 +116,7 @@ void LargeBuffer::BufClose()  // close the buffer; warning: does not flush data
   buf_used_ = 0;
   if (buf_[size_ + 1] != D_OVERRUN_GUARDIAN) {
     TIANMU_LOG(LogCtl_Level::WARN, "buffer overrun detected in LargeBuffer::BufClose.");
-    DEBUG_ASSERT(0);
+    assert(0);
   }
 }
 
@@ -145,7 +145,7 @@ char *LargeBuffer::BufAppend(unsigned int len) {
 }
 
 char *LargeBuffer::SeekBack(uint len) {
-  DEBUG_ASSERT((uint)buf_used_ >= len);
+  assert((uint)buf_used_ >= len);
   buf_used_ -= len;
   return this->Buf(buf_used_);
 }

--- a/storage/tianmu/system/large_buffer.h
+++ b/storage/tianmu/system/large_buffer.h
@@ -47,7 +47,7 @@ class LargeBuffer final : public mm::TraceableObject {
   char *Buf(int n) {
     // Note: we allow n=buf_used, although it is out of declared limits.
     // Fortunately "buf" is one character longer.
-    DEBUG_ASSERT(n >= 0 && n <= buf_used_);
+    assert(n >= 0 && n <= buf_used_);
     return buf_ + n;
   }
 

--- a/storage/tianmu/system/txt_utils.cpp
+++ b/storage/tianmu/system/txt_utils.cpp
@@ -28,7 +28,7 @@ inline char Convert2Hex(int index) {
 };
 
 void Convert2Hex(const unsigned char *src, int src_size, char *dest, int dest_size, bool zero_term) {
-  DEBUG_ASSERT(dest_size > 1 && "At least 2 bytes needed for hexadecimal representation");
+  assert(dest_size > 1 && "At least 2 bytes needed for hexadecimal representation");
 
   dest_size = std::min(src_size * 2 + 1, dest_size);
   if (zero_term) {

--- a/storage/tianmu/types/bstring.cpp
+++ b/storage/tianmu/types/bstring.cpp
@@ -204,19 +204,19 @@ std::string BString::ToString() const {
 }
 
 char &BString::operator[](size_t pos) const {
-  DEBUG_ASSERT(pos < len_);  // Out of BString. Note: val_ is not ended by '\0'.
+  assert(pos < len_);  // Out of BString. Note: val_ is not ended by '\0'.
   return val_[this->pos_ + pos];
 }
 
 BString &BString::operator+=(ushort pos) {
-  DEBUG_ASSERT((int)len_ - pos >= 0);
+  assert((int)len_ - pos >= 0);
   this->pos_ = this->pos_ + (ushort)pos;
   this->len_ -= pos;
   return *this;
 }
 
 BString &BString::operator-=(ushort pos) {
-  DEBUG_ASSERT(pos <= this->pos_);
+  assert(pos <= this->pos_);
   this->pos_ = this->pos_ - (ushort)pos;
   this->len_ += pos;
   return *this;
@@ -352,7 +352,7 @@ bool BString::GreaterEqThanMinUTF(const void *txt_min, DTCollation col, bool use
         if (useful_len >= len_ || chars_included == min_charlen)
           break;
         next_char_len = col.collation->cset->mbcharlen(col.collation, (uchar)val_[useful_len + pos_]);
-        DEBUG_ASSERT("wide character unrecognized" && next_char_len > 0);
+        assert("wide character unrecognized" && next_char_len > 0);
         useful_len += next_char_len;
         chars_included++;
       }
@@ -391,7 +391,7 @@ bool BString::LessEqThanMaxUTF(const void *txt_max, DTCollation col, bool use_fu
         if (useful_len >= len_ || chars_included == max_charlen)
           break;
         next_char_len = col.collation->cset->mbcharlen(col.collation, (uchar)val_[useful_len + pos_]);
-        DEBUG_ASSERT("wide character unrecognized" && next_char_len > 0);
+        assert("wide character unrecognized" && next_char_len > 0);
         useful_len += next_char_len;
         chars_included++;
       }
@@ -506,7 +506,7 @@ size_t BString::RoundUpTo8Bytes(const DTCollation &dt) const {
         next_char_len = 1;
       }
 
-      DEBUG_ASSERT("wide character unrecognized" && next_char_len > 0);
+      assert("wide character unrecognized" && next_char_len > 0);
       if (useful_len + next_char_len > 8)
         break;
       useful_len += next_char_len;

--- a/storage/tianmu/types/data_type.cpp
+++ b/storage/tianmu/types/data_type.cpp
@@ -65,7 +65,7 @@ DataType::DataType(common::ColumnType atype, int prec, int scale, DTCollation co
       break;
 
     case common::ColumnType::NUM:
-      DEBUG_ASSERT((prec > 0) && (prec <= 19) && (fixscale >= 0));
+      assert((prec > 0) && (prec <= 19) && (fixscale >= 0));
       if (prec == 19)
         fixmax = common::PLUS_INF_64;
       else

--- a/storage/tianmu/types/text_stat.cpp
+++ b/storage/tianmu/types/text_stat.cpp
@@ -66,7 +66,7 @@ void TextStat::AddLen(int pos)  // value of len n puts 0 on position n (starting
 {
   if (static_cast<size_t>(pos) == TAB_SIZE_)
     return;
-  DEBUG_ASSERT(static_cast<size_t>(pos) < TAB_SIZE_);
+  assert(static_cast<size_t>(pos) < TAB_SIZE_);
   chars_found_[256 * pos] = 1;
   if (static_cast<size_t>(pos) > max_string_size_)
     max_string_size_ = pos;
@@ -207,7 +207,7 @@ BString TextStat::Decode(int64_t code) {
   int len = max_string_size_;
   char buf_val[TMP_BUFFER_SIZE_] = {0};
 
-  DEBUG_ASSERT(max_string_size_ < TMP_BUFFER_SIZE_);
+  assert(max_string_size_ < TMP_BUFFER_SIZE_);
   buf_val[max_string_size_] = 0;
   for (int i = max_string_size_ - 1; i >= 0; i--) {
     charcode = 0;

--- a/storage/tianmu/types/tianmu_data_types.cpp
+++ b/storage/tianmu/types/tianmu_data_types.cpp
@@ -37,7 +37,7 @@ bool TianmuDataType::AreComperable(const TianmuDataType &tianmu_dt1, const Tianm
 
 bool TianmuDataType::compare(const TianmuDataType &tianmu_dt1, const TianmuDataType &tianmu_dt2, common::Operator op,
                              char like_esc) {
-  // DEBUG_ASSERT(TianmuDataType::AreComperable(tianmu_dt1, tianmu_dt2));
+  // assert(TianmuDataType::AreComperable(tianmu_dt1, tianmu_dt2));
   if (op == common::Operator::O_LIKE || op == common::Operator::O_NOT_LIKE) {
     if (tianmu_dt1.IsNull() || tianmu_dt2.IsNull())
       return false;

--- a/storage/tianmu/types/tianmu_data_types.h
+++ b/storage/tianmu/types/tianmu_data_types.h
@@ -442,7 +442,7 @@ class TianmuValueObject {
   TianmuDataType *Get() const { return value_.get(); }
   TianmuDataType &operator*() const;
 
-  // TianmuDataType& operator*() const	{ DEBUG_ASSERT(value_.get()); return
+  // TianmuDataType& operator*() const	{ assert(value_.get()); return
   // *value_; }
 
   operator TianmuNum &() const;
@@ -564,7 +564,7 @@ static bool conv_required_table[] = {
 };
 
 static inline bool RequiresUTFConversions(const DTCollation &coll) {
-  DEBUG_ASSERT(coll.collation->number < 256);
+  assert(coll.collation->number < 256);
   return (conv_required_table[coll.collation->number]);
 }
 
@@ -593,7 +593,7 @@ inline DTCollation ResolveCollation(DTCollation first, DTCollation sec) {
       if (IsBin(sec))
         return sec;
     }
-    DEBUG_ASSERT(!"Error: Incompatible collations!");
+    assert(!"Error: Incompatible collations!");
   }
   return first;
 }
@@ -601,7 +601,7 @@ inline DTCollation ResolveCollation(DTCollation first, DTCollation sec) {
 static inline double PowOfTen(int exponent) { return std::pow((double)10, exponent); }
 
 static inline uint64_t Uint64PowOfTen(short exponent) {
-  DEBUG_ASSERT(exponent >= 0 && exponent < 20);
+  assert(exponent >= 0 && exponent < 20);
 
   static uint64_t v[] = {1ULL,
                          10ULL,
@@ -633,7 +633,7 @@ static inline uint64_t Uint64PowOfTen(short exponent) {
 static inline int64_t Int64PowOfTen(short exponent) { return int64_t(Uint64PowOfTen(exponent)); }
 
 static inline uint64_t Uint64PowOfTenMultiply5(short exponent) {
-  DEBUG_ASSERT(exponent >= 0 && exponent < 19);
+  assert(exponent >= 0 && exponent < 19);
 
   static uint64_t v[] = {5ULL,
                          50ULL,

--- a/storage/tianmu/types/tianmu_item_types.cpp
+++ b/storage/tianmu/types/tianmu_item_types.cpp
@@ -27,7 +27,7 @@ ItemSumInTianmuBase::ItemSumInTianmuBase() : Item_sum_num() {}
 ItemSumInTianmuBase::~ItemSumInTianmuBase() {}
 
 longlong ItemSumInTianmuBase::val_int() {
-  DEBUG_ASSERT(fixed == 1);
+  assert(fixed == 1);
   return (longlong)count_;
 }
 
@@ -47,7 +47,7 @@ ItemSumSumTianmuBase::ItemSumSumTianmuBase() : Item_sum_num() { sum_ = 0; }
 ItemSumSumTianmuBase::~ItemSumSumTianmuBase() {}
 
 double ItemSumSumTianmuBase::val_real() {
-  DEBUG_ASSERT(fixed == 1);
+  assert(fixed == 1);
   if (hybrid_type_ == DECIMAL_RESULT)
     my_decimal2double(E_DEC_FATAL_ERROR, decimal_buffs_, &sum_);
   return sum_;
@@ -66,7 +66,7 @@ String *ItemSumSumTianmuBase::val_str(String *str) {
 }
 
 longlong ItemSumSumTianmuBase::val_int() {
-  DEBUG_ASSERT(fixed == 1);
+  assert(fixed == 1);
   if (hybrid_type_ == DECIMAL_RESULT) {
     longlong result;
     my_decimal2int(E_DEC_FATAL_ERROR, decimal_buffs_, unsigned_flag, &result);
@@ -123,7 +123,7 @@ void ItemSumHybridTianmuBase::clear() {
 }
 
 double ItemSumHybridTianmuBase::val_real() {
-  DEBUG_ASSERT(fixed == 1);
+  assert(fixed == 1);
   if (null_value)
     return 0.0;
   switch (hybrid_type_) {
@@ -152,7 +152,7 @@ double ItemSumHybridTianmuBase::val_real() {
 }
 
 longlong ItemSumHybridTianmuBase::val_int() {
-  DEBUG_ASSERT(fixed == 1);
+  assert(fixed == 1);
   if (null_value)
     return 0;
   switch (hybrid_type_) {
@@ -169,7 +169,7 @@ longlong ItemSumHybridTianmuBase::val_int() {
 }
 
 my_decimal *ItemSumHybridTianmuBase::val_decimal(my_decimal *val) {
-  DEBUG_ASSERT(fixed == 1);
+  assert(fixed == 1);
   if (null_value)
     return 0;
   switch (hybrid_type_) {
@@ -195,7 +195,7 @@ my_decimal *ItemSumHybridTianmuBase::val_decimal(my_decimal *val) {
 }
 
 String *ItemSumHybridTianmuBase::val_str(String *str) {
-  DEBUG_ASSERT(fixed == 1);
+  assert(fixed == 1);
   if (null_value)
     return (String *)0;
   switch (hybrid_type_) {

--- a/storage/tianmu/types/tianmu_item_types.h
+++ b/storage/tianmu/types/tianmu_item_types.h
@@ -32,7 +32,7 @@ class ItemSumInTianmuBase : public Item_sum_num {
   longlong val_int() override;
 
   double val_real() override {
-    DEBUG_ASSERT(fixed == 1);
+    assert(fixed == 1);
     return (double)val_int();
   }
   String *val_str(String *str) override;

--- a/storage/tianmu/types/tianmu_num.cpp
+++ b/storage/tianmu/types/tianmu_num.cpp
@@ -346,7 +346,7 @@ bool TianmuNum::operator>=(const TianmuDataType &tianmu_dt) const {
 }
 
 TianmuNum &TianmuNum::operator-=(const TianmuNum &tianmu_n) {
-  DEBUG_ASSERT(!null_);
+  assert(!null_);
   if (tianmu_n.IsNull() || tianmu_n.IsNull())
     return *this;
   if (IsReal() || tianmu_n.IsReal()) {
@@ -370,7 +370,7 @@ TianmuNum &TianmuNum::operator-=(const TianmuNum &tianmu_n) {
 }
 
 TianmuNum &TianmuNum::operator+=(const TianmuNum &tianmu_n) {
-  DEBUG_ASSERT(!null_);
+  assert(!null_);
   if (tianmu_n.IsNull() || tianmu_n.IsNull())
     return *this;
   if (IsReal() || tianmu_n.IsReal()) {
@@ -394,7 +394,7 @@ TianmuNum &TianmuNum::operator+=(const TianmuNum &tianmu_n) {
 }
 
 TianmuNum &TianmuNum::operator*=(const TianmuNum &tianmu_n) {
-  DEBUG_ASSERT(!null_);
+  assert(!null_);
   if (tianmu_n.IsNull() || tianmu_n.IsNull())
     return *this;
   if (IsReal() || tianmu_n.IsReal()) {
@@ -431,7 +431,7 @@ void fcvt(char *buf, double val, int digits, int *dec, int *sign) {
 }
 
 TianmuNum &TianmuNum::operator/=(const TianmuNum &tianmu_n) {
-  DEBUG_ASSERT(!null_);
+  assert(!null_);
   if (tianmu_n.IsNull() || tianmu_n.IsNull())
     return *this;
   if (IsReal() || tianmu_n.IsReal()) {

--- a/storage/tianmu/types/value_parser4txt.cpp
+++ b/storage/tianmu/types/value_parser4txt.cpp
@@ -646,7 +646,7 @@ common::ErrorCode ValueParserForText::ParseBitAdapter(const BString &tianmu_s, i
   int len = tianmu_s.len_;
   // No matter null value or not, the value stored in char buffer at least one byte and up to 8 bytes.
   // calculated by len = (prec+7)/8
-  DEBUG_ASSERT(len >= 1 && len <= 8);
+  assert(len >= 1 && len <= 8);
 
   // The parse code may never go here, but we still check null value for integrity.
   if (tianmu_s.Equals("nullptr", 4)) {
@@ -1056,7 +1056,7 @@ common::ErrorCode ValueParserForText::ParseTime(const BString &tianmu_s, TianmuD
         else if (hour * sign > kTianmuTimeMax.Hour())
           rcv = TianmuDateTime(kTianmuTimeMax);
         else
-          DEBUG_ASSERT(0);  // hmmm... ????
+          assert(0);  // hmmm... ????
 
         return common::ErrorCode::OUT_OF_RANGE;
       }
@@ -1201,7 +1201,7 @@ common::ErrorCode ValueParserForText::ParseYear(const BString &tianmu_s, TianmuD
 
 common::ErrorCode ValueParserForText::ParseDateTime(const BString &tianmu_s, TianmuDateTime &rcv,
                                                     common::ColumnType at) {
-  DEBUG_ASSERT(core::ATI::IsDateTimeType(at));
+  assert(core::ATI::IsDateTimeType(at));
   switch (at) {
     case common::ColumnType::TIMESTAMP:
     case common::ColumnType::DATETIME:

--- a/storage/tianmu/util/bin_tools.cpp
+++ b/storage/tianmu/util/bin_tools.cpp
@@ -126,7 +126,7 @@ common::RoughSetValue And(common::RoughSetValue f, common::RoughSetValue s) {
 int64_t MonotonicDouble2Int64(int64_t d)  // encode double value (bitwise stored as int64_t) into
                                           // int64_t to prevent comparison directions
 {
-  DEBUG_ASSERT(!(std::isnan)(*(double *)&d));
+  assert(!(std::isnan)(*(double *)&d));
   if (*((double *)(&d)) < 0)
     return ~d;  // for negative - reverse all bits (including the sign 1)
   else

--- a/storage/tianmu/util/circ_buf.h
+++ b/storage/tianmu/util/circ_buf.h
@@ -32,14 +32,14 @@ class FixedSizeBuffer {
   }
 
   void Put(const T &v) {
-    DEBUG_ASSERT(elems_ < size_);
+    assert(elems_ < size_);
     iin_ = (iin_ + 1) % size_;
     buffer_[iin_] = v;
     ++elems_;
   }
 
   T &Get() {
-    DEBUG_ASSERT(elems_ > 0);
+    assert(elems_ > 0);
     T &v = buffer_[iout_];
     --elems_;
     iout_ = (iout_ + 1) % size_;
@@ -47,12 +47,12 @@ class FixedSizeBuffer {
   }
 
   T &GetLast() {
-    DEBUG_ASSERT(elems_ > 0);
+    assert(elems_ > 0);
     return buffer_[iin_];
   }
 
   T &Nth(int n) {
-    DEBUG_ASSERT(elems_ >= n - 1);
+    assert(elems_ >= n - 1);
     return buffer_[(iout_ + n) % size_];
   }
 

--- a/storage/tianmu/util/sorter3.cpp
+++ b/storage/tianmu/util/sorter3.cpp
@@ -36,7 +36,7 @@ Sorter3 *Sorter3::CreateSorter(int64_t size, uint key_bytes, uint total_bytes, i
 
   int64_t max_no_rows = max_mem_size / total_bytes;
   if (limit != -1 && limit < max_no_rows / 3 && limit < size / 3) {
-    DEBUG_ASSERT(limit >= 0);
+    assert(limit >= 0);
     return new SorterLimit((uint)limit, key_bytes, total_bytes);
   }
   if (max_no_rows > size) {        // matching the memory
@@ -86,7 +86,7 @@ SorterOnePass::~SorterOnePass() {
 }
 
 bool SorterOnePass::PutValue(unsigned char *b) {
-  DEBUG_ASSERT(buf_input_pos < buf_end);
+  assert(buf_input_pos < buf_end);
   already_sorted = false;
   std::memcpy(buf_input_pos, b, total_bytes);
   buf_input_pos += total_bytes;
@@ -97,7 +97,7 @@ bool SorterOnePass::PutValue(unsigned char *b) {
 
 bool SorterOnePass::PutValue(Sorter3 *s) {
   TIANMU_LOG(LogCtl_Level::WARN, "SorterOnePass PutValue merger, never verified.");
-  DEBUG_ASSERT(buf_input_pos < buf_end);
+  assert(buf_input_pos < buf_end);
   already_sorted = false;
   SorterOnePass *sp = (SorterOnePass *)s;
   int tmpobj = sp->GetObjNo();
@@ -348,7 +348,7 @@ SorterCounting::SorterCounting(uint _size, uint _key_bytes, uint _total_bytes)
     throw common::OutOfMemoryException();
   }
 
-  DEBUG_ASSERT(key_bytes <= 2);
+  assert(key_bytes <= 2);
   already_sorted = false;
   distrib_min = 65536;
   distrib_max = 0;
@@ -366,7 +366,7 @@ SorterCounting::~SorterCounting() {
 }
 
 bool SorterCounting::PutValue(unsigned char *b) {
-  DEBUG_ASSERT(buf_input_pos < buf_end);
+  assert(buf_input_pos < buf_end);
   std::memcpy(buf_input_pos, b, total_bytes);
   int pos = Position(b);
   if (pos > distrib_max)
@@ -395,7 +395,7 @@ unsigned char *SorterCounting::GetNextValue() {
 }
 
 void SorterCounting::CountingSort() {
-  DEBUG_ASSERT(distrib_min <= distrib_max);
+  assert(distrib_min <= distrib_max);
   int distrib_size = distrib_max - distrib_min + 1;
 
   std::vector<int> distrib(distrib_size);

--- a/storage/tianmu/util/sorter_wrapper.cpp
+++ b/storage/tianmu/util/sorter_wrapper.cpp
@@ -55,13 +55,13 @@ void SorterWrapper::InitOrderByVector(std::vector<int> &order_by) {
     if (ord < 0)
       ord = -ord;
     if (ord != 0) {
-      DEBUG_ASSERT(order_by[ord - 1] == -1);
+      assert(order_by[ord - 1] == -1);
       order_by[ord - 1] = i;
     }
   }
   for (uint i = 0; i < input_cols.size(); i++)  // check whether all sorting columns are really needed
     if (order_by[i] != -1) {
-      DEBUG_ASSERT(i == 0 || order_by[i - 1] != -1);  // assure continuity
+      assert(i == 0 || order_by[i - 1] != -1);  // assure continuity
       if (input_cols[order_by[i]].col->IsDistinct()) {
         // do not sort by any other column:
         for (uint j = i + 1; j < input_cols.size(); j++)

--- a/storage/tianmu/util/tools.h
+++ b/storage/tianmu/util/tools.h
@@ -117,11 +117,11 @@ class ObjectId : public U {
     return object_id_helper::range_eq<int const *>()(oid1._coord, oid1._coord + no_dims, oid2._coord);
   }
   int const &operator[](int const &idx_) const {
-    DEBUG_ASSERT(idx_ < no_dims);
+    assert(idx_ < no_dims);
     return _coord[idx_];
   }
   int &operator[](int const &idx_) {
-    DEBUG_ASSERT(idx_ < no_dims);
+    assert(idx_ < no_dims);
     return _coord[idx_];
   }
   size_t operator()(ObjectId const &oid) const { return oid.hash(); }

--- a/storage/tianmu/vc/column_bin_encoder.cpp
+++ b/storage/tianmu/vc/column_bin_encoder.cpp
@@ -139,7 +139,7 @@ bool ColumnBinEncoder::PrepareEncoder(vcolumn::VirtualColumn *_vc, vcolumn::Virt
                                                                   // (above)
     my_encoder.reset(new ColumnBinEncoder::EncoderInt(vc, decodable, nulls_possible, descending));
   } else {
-    DEBUG_ASSERT(!"wrong combination of encoded columns");  // Other types not
+    assert(!"wrong combination of encoded columns");  // Other types not
                                                             // implemented yet
     my_encoder.reset(new ColumnBinEncoder::EncoderText(vc, decodable, nulls_possible, descending));
   }
@@ -238,7 +238,7 @@ types::BString ColumnBinEncoder::GetValueT(uchar *buf, const MIDummyIterator &mi
 
 void ColumnBinEncoder::UpdateStatistics(unsigned char *buf)  // get value from the buffer and update internal statistics
 {
-  DEBUG_ASSERT(!implicit);
+  assert(!implicit);
   my_encoder->UpdateStatistics(buf + val_offset);
 }
 
@@ -359,7 +359,7 @@ int64_t ColumnBinEncoder::EncoderInt::ValEncode(vcolumn::VirtualColumn *vc, MIIt
 }
 
 int64_t ColumnBinEncoder::EncoderInt::ValEncodeInt64(int64_t v, bool update_stats) {
-  DEBUG_ASSERT(null_status < 2);  // should be used only for small values, when
+  assert(null_status < 2);  // should be used only for small values, when
                                   // an additional byte is not needed
   if (v == common::NULL_VALUE_64) {
     if (descending)
@@ -388,7 +388,7 @@ void ColumnBinEncoder::EncoderInt::SetNull(uchar *buf, [[maybe_unused]] uchar *b
   // status=2, descend.|   1000    |   0xxx      |
   // ---------------------------------------------
 
-  DEBUG_ASSERT(null_status > 0);
+  assert(null_status > 0);
   std::memset(buf, 0,
               size);  // zero on the first and all other bytes (to be changed below)
   if (descending) {
@@ -817,7 +817,7 @@ void ColumnBinEncoder::EncoderDouble::SetNull(uchar *buf, [[maybe_unused]] uchar
   // status=2, ascend. |   00..00  |   1<64bit>  |
   // status=2, descend.|   10..00  |   0<64bit>  |
   // ---------------------------------------------
-  DEBUG_ASSERT(null_status == 2);
+  assert(null_status == 2);
   std::memset(buf, 0, 9);
   if (descending)
     *buf = '\1';
@@ -1073,12 +1073,12 @@ void ColumnBinEncoder::EncoderText_UTF::SetNull(uchar *buf, uchar *buf_sec) {
 }
 
 bool ColumnBinEncoder::EncoderText_UTF::IsNull([[maybe_unused]] uchar *buf, uchar *buf_sec) {
-  DEBUG_ASSERT(size_sec > 0);
+  assert(size_sec > 0);
   return (*(reinterpret_cast<uint32_t *>(buf_sec + size_sec - sizeof(uint32_t))) == 0);
 }
 
 types::BString ColumnBinEncoder::EncoderText_UTF::GetValueT(uchar *buf, uchar *buf_sec) {
-  DEBUG_ASSERT(size_sec > 0);
+  assert(size_sec > 0);
   if (null_status > 0 && IsNull(buf, buf_sec))
     return types::BString();
   uint32_t len = *(reinterpret_cast<uint32_t *>(buf_sec + size_sec - sizeof(uint32_t))) - 1;
@@ -1308,7 +1308,7 @@ ColumnBinEncoder::EncoderTextMD5::EncoderTextMD5(vcolumn::VirtualColumn *vc, boo
   size = HASH_FUNCTION_BYTE_SIZE;
   size_sec = 0;
   null_status = 1;  // ignored
-  DEBUG_ASSERT(!decodable);
+  assert(!decodable);
   std::memset(null_buf, 0, HASH_FUNCTION_BYTE_SIZE);
   std::memset(empty_buf, 0, HASH_FUNCTION_BYTE_SIZE);
   std::memcpy(null_buf, "-- null --",

--- a/storage/tianmu/vc/column_bin_encoder.cpp
+++ b/storage/tianmu/vc/column_bin_encoder.cpp
@@ -140,7 +140,7 @@ bool ColumnBinEncoder::PrepareEncoder(vcolumn::VirtualColumn *_vc, vcolumn::Virt
     my_encoder.reset(new ColumnBinEncoder::EncoderInt(vc, decodable, nulls_possible, descending));
   } else {
     assert(!"wrong combination of encoded columns");  // Other types not
-                                                            // implemented yet
+                                                      // implemented yet
     my_encoder.reset(new ColumnBinEncoder::EncoderText(vc, decodable, nulls_possible, descending));
   }
   if (_vc2 != nullptr) {  // multiple column encoding?
@@ -360,7 +360,7 @@ int64_t ColumnBinEncoder::EncoderInt::ValEncode(vcolumn::VirtualColumn *vc, MIIt
 
 int64_t ColumnBinEncoder::EncoderInt::ValEncodeInt64(int64_t v, bool update_stats) {
   assert(null_status < 2);  // should be used only for small values, when
-                                  // an additional byte is not needed
+                            // an additional byte is not needed
   if (v == common::NULL_VALUE_64) {
     if (descending)
       return max_code;

--- a/storage/tianmu/vc/column_bin_encoder.h
+++ b/storage/tianmu/vc/column_bin_encoder.h
@@ -191,15 +191,15 @@ class ColumnBinEncoder::ColumnValueEncoder {  // base class for detailed
 
   virtual int64_t ValEncode([[maybe_unused]] vcolumn::VirtualColumn *vc, [[maybe_unused]] MIIterator &mit,
                             [[maybe_unused]] bool update_stats = false) {
-    DEBUG_ASSERT(0);
+    assert(0);
     return 0;
   }
   virtual int64_t ValEncodeInt64([[maybe_unused]] int64_t v, [[maybe_unused]] bool update_stats) {
-    DEBUG_ASSERT(0);
+    assert(0);
     return 0;
   }  // used in special cases only
   virtual int64_t ValEncodeString([[maybe_unused]] types::BString &v, [[maybe_unused]] bool update_stats) {
-    DEBUG_ASSERT(0);
+    assert(0);
     return 0;
   }  // used in special cases only
 

--- a/storage/tianmu/vc/const_column.cpp
+++ b/storage/tianmu/vc/const_column.cpp
@@ -77,14 +77,14 @@ ConstColumn::ConstColumn(const types::TianmuValueObject &v, const core::ColumnTy
     else
       throw common::DataTypeConversionException(common::ErrorCode::DATACONVERSION);
   } else {
-    DEBUG_ASSERT(v.GetValueType() == types::ValueTypeEnum::DATE_TIME_TYPE);
+    assert(v.GetValueType() == types::ValueTypeEnum::DATE_TIME_TYPE);
     // TODO: if it is non-date-time a proper conversion should be done here
     value_or_null_ = core::ValueOrNull(static_cast<types::TianmuDateTime &>(v));
   }
 }
 
 double ConstColumn::GetValueDoubleImpl([[maybe_unused]] const core::MIIterator &mit) {
-  DEBUG_ASSERT(core::ATI::IsNumericType(TypeName()));
+  assert(core::ATI::IsNumericType(TypeName()));
   double val = 0;
   if (value_or_null_.IsNull())
     val = NULL_VALUE_D;
@@ -110,7 +110,7 @@ double ConstColumn::GetValueDoubleImpl([[maybe_unused]] const core::MIIterator &
     if (vs)
       val = std::stod(*vs);
   } else
-    DEBUG_ASSERT(0 && "conversion to double not implemented");
+    assert(0 && "conversion to double not implemented");
   return val;
 }
 
@@ -131,14 +131,14 @@ types::TianmuValueObject ConstColumn::GetValueImpl([[maybe_unused]] const core::
     return types::TianmuNum(value_or_null_.Get64(), 0, true, TypeName());
   if (lookup_to_num || TypeName() == common::ColumnType::NUM || TypeName() == common::ColumnType::BIT)
     return types::TianmuNum((int64_t)value_or_null_.Get64(), Type().GetScale());
-  DEBUG_ASSERT(!"Illegal execution path");
+  assert(!"Illegal execution path");
   return types::TianmuValueObject();
 }
 
 void ConstColumn::GetValueStringImpl(types::BString &s, const core::MIIterator &mit) { s = GetValue(mit).ToBString(); }
 
 int64_t ConstColumn::GetSumImpl(const core::MIIterator &mit, bool &nonnegative) {
-  DEBUG_ASSERT(!core::ATI::IsStringType(TypeName()));
+  assert(!core::ATI::IsStringType(TypeName()));
   nonnegative = true;
   if (value_or_null_.IsNull())
     return common::NULL_VALUE_64;  // note that this is a bit ambiguous: the
@@ -183,7 +183,7 @@ core::PackOntologicalStatus ConstColumn::GetPackOntologicalStatusImpl([[maybe_un
 
 void ConstColumn::EvaluatePackImpl([[maybe_unused]] core::MIUpdatingIterator &mit,
                                    [[maybe_unused]] core::Descriptor &desc) {
-  DEBUG_ASSERT(0);  // comparison of a const with a const should be simplified earlier
+  assert(0);  // comparison of a const with a const should be simplified earlier
 }
 
 char *ConstColumn::ToString(char p_buf[], size_t buf_ct) const {

--- a/storage/tianmu/vc/const_column.h
+++ b/storage/tianmu/vc/const_column.h
@@ -103,7 +103,7 @@ class ConstColumn : public VirtualColumn {
   // comparison of a const with a const should be simplified earlier
   virtual common::ErrorCode EvaluateOnIndexImpl([[maybe_unused]] core::MIUpdatingIterator &mit, core::Descriptor &,
                                                 [[maybe_unused]] int64_t limit) override {
-    DEBUG_ASSERT(0);
+    assert(0);
     return common::ErrorCode::FAILED;
   }
   core::ValueOrNull value_or_null_;

--- a/storage/tianmu/vc/const_expr_column.cpp
+++ b/storage/tianmu/vc/const_expr_column.cpp
@@ -36,7 +36,7 @@ void ConstExpressionColumn::RequestEval([[maybe_unused]] const core::MIIterator 
 }
 
 double ConstExpressionColumn::GetValueDoubleImpl([[maybe_unused]] const core::MIIterator &mit) {
-  DEBUG_ASSERT(core::ATI::IsNumericType(TypeName()));
+  assert(core::ATI::IsNumericType(TypeName()));
 
   double val = 0;
   if (last_val_->IsNull())
@@ -65,7 +65,7 @@ double ConstExpressionColumn::GetValueDoubleImpl([[maybe_unused]] const core::MI
     if (vs)
       val = std::stod(*vs);
   } else
-    DEBUG_ASSERT(0 && "conversion to double not implemented");
+    assert(0 && "conversion to double not implemented");
 
   return val;
 }
@@ -93,12 +93,12 @@ types::TianmuValueObject ConstExpressionColumn::GetValueImpl([[maybe_unused]] co
   if (lookup_to_num || TypeName() == common::ColumnType::NUM || TypeName() == common::ColumnType::BIT)
     return types::TianmuNum((int64_t)last_val_->Get64(), Type().GetScale());
 
-  DEBUG_ASSERT(!"Illegal execution path");
+  assert(!"Illegal execution path");
   return types::TianmuValueObject();
 }
 
 int64_t ConstExpressionColumn::GetSumImpl(const core::MIIterator &mit, bool &nonnegative) {
-  DEBUG_ASSERT(!core::ATI::IsStringType(TypeName()));
+  assert(!core::ATI::IsStringType(TypeName()));
 
   nonnegative = true;
   if (last_val_->IsNull())
@@ -147,7 +147,7 @@ core::PackOntologicalStatus ConstExpressionColumn::GetPackOntologicalStatusImpl(
 
 void ConstExpressionColumn::EvaluatePackImpl([[maybe_unused]] core::MIUpdatingIterator &mit,
                                              [[maybe_unused]] core::Descriptor &desc) {
-  DEBUG_ASSERT(0);  // comparison of a const with a const should be simplified earlier
+  assert(0);  // comparison of a const with a const should be simplified earlier
 }
 
 common::RoughSetValue ConstExpressionColumn::RoughCheckImpl([[maybe_unused]] const core::MIIterator &mit,

--- a/storage/tianmu/vc/const_expr_column.h
+++ b/storage/tianmu/vc/const_expr_column.h
@@ -62,7 +62,7 @@ class ConstExpressionColumn : public ExpressionColumn {
 
   ConstExpressionColumn(ConstExpressionColumn const &cc)
       : ExpressionColumn(nullptr, nullptr, common::NULL_VALUE_32, nullptr) {
-    DEBUG_ASSERT(params_.size() == 0 && "cannot copy expressions");
+    assert(params_.size() == 0 && "cannot copy expressions");
     last_val_ = cc.last_val_;
     ct = cc.ct;
     first_eval_ = cc.first_eval_;
@@ -140,7 +140,7 @@ class ConstExpressionColumn : public ExpressionColumn {
   // comparison of a const with a const should be simplified earlier
   virtual common::ErrorCode EvaluateOnIndexImpl([[maybe_unused]] core::MIUpdatingIterator &mit, core::Descriptor &,
                                                 [[maybe_unused]] int64_t limit) override {
-    DEBUG_ASSERT(0);
+    assert(0);
     return common::ErrorCode::FAILED;
   }
 };

--- a/storage/tianmu/vc/expr_column.cpp
+++ b/storage/tianmu/vc/expr_column.cpp
@@ -77,7 +77,7 @@ ExpressionColumn::ExpressionColumn(core::MysqlExpression *expr, core::TempTable 
     // if (status == VC_EXPR && var_map_.size() == 0 )
     //	status = VC_CONST;
   } else {
-    DEBUG_ASSERT(!"unexpected!!");
+    assert(!"unexpected!!");
   }
 }
 
@@ -105,7 +105,7 @@ bool ExpressionColumn::FeedArguments(const core::MIIterator &mit) {
     core::ValueOrNull v(it.just_a_table_ptr->GetComplexValue(mit[it.dim], it.col_ndx));
     v.MakeStringOwner();
     auto cache = var_buf_.find(it.var_id);
-    DEBUG_ASSERT(cache != var_buf_.end());
+    assert(cache != var_buf_.end());
     diff = diff || (v != cache->second.begin()->first);
     if (diff)
       for (auto &val_it : cache->second) *(val_it.second) = val_it.first = v;
@@ -179,7 +179,7 @@ double ExpressionColumn::GetValueDoubleImpl(const core::MIIterator &mit) {
     if (str)
       val = std::stod(*str);
   } else
-    DEBUG_ASSERT(0 && "conversion to double not implemented");
+    assert(0 && "conversion to double not implemented");
 
   return val;
 }
@@ -198,7 +198,7 @@ types::TianmuValueObject ExpressionColumn::GetValueImpl(const core::MIIterator &
     return types::TianmuNum(GetValueInt64(mit), 0, true, TypeName());
   if (lookup_to_num || TypeName() == common::ColumnType::NUM || TypeName() == common::ColumnType::BIT)
     return types::TianmuNum(GetValueInt64(mit), Type().GetScale());
-  DEBUG_ASSERT(!"Illegal execution path");
+  assert(!"Illegal execution path");
   return types::TianmuValueObject();
 }
 
@@ -254,7 +254,7 @@ core::PackOntologicalStatus ExpressionColumn::GetPackOntologicalStatusImpl(const
 
 void ExpressionColumn::EvaluatePackImpl([[maybe_unused]] core::MIUpdatingIterator &mit,
                                         [[maybe_unused]] core::Descriptor &d) {
-  DEBUG_ASSERT(!"Common path shall be used in case of ExpressionColumn.");
+  assert(!"Common path shall be used in case of ExpressionColumn.");
 }
 
 int64_t ExpressionColumn::RoughMinImpl() {

--- a/storage/tianmu/vc/in_set_column.cpp
+++ b/storage/tianmu/vc/in_set_column.cpp
@@ -87,13 +87,13 @@ void InSetColumn::RequestEval(const core::MIIterator &mit, const int tta) {
 
 types::BString InSetColumn::GetMinStringImpl([[maybe_unused]] const core::MIIterator &mit) {
   types::BString s;
-  DEBUG_ASSERT(!"To be implemented.");
+  assert(!"To be implemented.");
   return s;
 }
 
 types::BString InSetColumn::GetMaxStringImpl([[maybe_unused]] const core::MIIterator &mit) {
   types::BString s;
-  DEBUG_ASSERT(!"To be implemented.");
+  assert(!"To be implemented.");
   return s;
 }
 
@@ -103,14 +103,14 @@ size_t InSetColumn::MaxStringSizeImpl()  // maximal byte string length in column
 }
 
 core::PackOntologicalStatus InSetColumn::GetPackOntologicalStatusImpl([[maybe_unused]] const core::MIIterator &mit) {
-  DEBUG_ASSERT(!"To be implemented.");
+  assert(!"To be implemented.");
   return core::PackOntologicalStatus::NORMAL;
 }
 
 void InSetColumn::EvaluatePackImpl([[maybe_unused]] core::MIUpdatingIterator &mit,
                                    [[maybe_unused]] core::Descriptor &desc) {
-  DEBUG_ASSERT(!"To be implemented.");
-  DEBUG_ASSERT(0);  // comparison of a const with a const should be simplified earlier
+  assert(!"To be implemented.");
+  assert(0);  // comparison of a const with a const should be simplified earlier
 }
 
 bool InSetColumn::IsSetEncoded(common::ColumnType at, int scale) {
@@ -233,7 +233,7 @@ void InSetColumn::PrepareCache(const core::MIIterator &mit, const int64_t &at_le
 }
 
 int64_t InSetColumn::AtLeastNoDistinctValuesImpl(const core::MIIterator &mit, int64_t const at_least) {
-  DEBUG_ASSERT(at_least > 0);
+  assert(at_least > 0);
   if (!full_cache_ || !is_const_)
     PrepareCache(mit, at_least);
   return cache_.NoVals();

--- a/storage/tianmu/vc/in_set_column.h
+++ b/storage/tianmu/vc/in_set_column.h
@@ -64,16 +64,16 @@ class InSetColumn : public MultiValColumn {
       return std::unique_ptr<LazyValueInterface>(new LazyValueImpl(value));
     }
     types::BString DoGetString() const override {
-      DEBUG_ASSERT(dynamic_cast<types::BString const *>(value));
+      assert(dynamic_cast<types::BString const *>(value));
       return *static_cast<types::BString const *>(value);
     }
     types::TianmuNum DoGetRCNum() const override {
-      DEBUG_ASSERT(dynamic_cast<types::TianmuNum const *>(value));
+      assert(dynamic_cast<types::TianmuNum const *>(value));
       return *static_cast<types::TianmuNum const *>(value);
     }
     types::TianmuValueObject DoGetValue() const override { return *value; }
     int64_t DoGetInt64() const override {
-      DEBUG_ASSERT(dynamic_cast<types::TianmuNum const *>(value));
+      assert(dynamic_cast<types::TianmuNum const *>(value));
       return static_cast<types::TianmuNum const *>(value)->ValueInt();
     }
     bool DoIsNull() const override { return value->IsNull(); }
@@ -122,27 +122,27 @@ class InSetColumn : public MultiValColumn {
   bool IsEmptyImpl(const core::MIIterator &) override;
 
   bool IsNullsPossibleImpl([[maybe_unused]] bool val_nulls_possible) override {
-    DEBUG_ASSERT(!"To be implemented.");
+    assert(!"To be implemented.");
     return true;
   }
 
   int64_t GetMinInt64Impl([[maybe_unused]] const core::MIIterator &mit) override {
-    // DEBUG_ASSERT( !"To be implemented." );
+    // assert( !"To be implemented." );
     return common::MINUS_INF_64;
   }
 
   int64_t GetMaxInt64Impl([[maybe_unused]] const core::MIIterator &mit) override {
-    // DEBUG_ASSERT( !"To be implemented." );
+    // assert( !"To be implemented." );
     return common::PLUS_INF_64;
   }
 
   int64_t RoughMinImpl() override {
-    // DEBUG_ASSERT( !"To be implemented." );
+    // assert( !"To be implemented." );
     return common::MINUS_INF_64;
   }
 
   int64_t RoughMaxImpl() override {
-    // DEBUG_ASSERT( !"To be implemented." );
+    // assert( !"To be implemented." );
     return common::PLUS_INF_64;
   }
 
@@ -150,7 +150,7 @@ class InSetColumn : public MultiValColumn {
   types::BString GetMinStringImpl(const core::MIIterator &mit) override;
 
   bool IsDistinctImpl() override {
-    DEBUG_ASSERT(!"To be implemented.");
+    assert(!"To be implemented.");
     return (false);
   }
 

--- a/storage/tianmu/vc/multi_value_column.h
+++ b/storage/tianmu/vc/multi_value_column.h
@@ -117,7 +117,7 @@ class MultiValColumn : public VirtualColumn {
     LazyValue operator*() { return LazyValue(impl->GetValue()); }
     LazyValue operator->() { return LazyValue(impl->GetValue()); }
     bool operator!=(Iterator const &it) const {
-      DEBUG_ASSERT(owner == it.owner);
+      assert(owner == it.owner);
       return (impl->NotEq(it.impl.get()));
     }
 
@@ -163,12 +163,12 @@ class MultiValColumn : public VirtualColumn {
   inline types::TianmuValueObject GetSetMax(core::MIIterator const &mit) { return GetSetMaxImpl(mit); }
   inline void SetExpectedType(core::ColumnType const &ct) { SetExpectedTypeImpl(ct); }
   int64_t GetNotNullValueInt64([[maybe_unused]] const core::MIIterator &mit) override {
-    DEBUG_ASSERT(0);
+    assert(0);
     return 0;
   }
   void GetNotNullValueString([[maybe_unused]] types::BString &s,
                              [[maybe_unused]] const core::MIIterator &mit) override {
-    DEBUG_ASSERT(0);
+    assert(0);
     ;
   }
   inline bool CopyCond(core::MIIterator const &mit, types::CondArray &condition, DTCollation coll) {
@@ -191,23 +191,23 @@ class MultiValColumn : public VirtualColumn {
   virtual void SetExpectedTypeImpl(core::ColumnType const &) = 0;
 
   int64_t GetValueInt64Impl([[maybe_unused]] const core::MIIterator &mit) override {
-    DEBUG_ASSERT(!"Invalid call for this type of column.");
+    assert(!"Invalid call for this type of column.");
     return (0);
   }
   double GetValueDoubleImpl([[maybe_unused]] const core::MIIterator &mit) override {
-    DEBUG_ASSERT(!"Invalid call for this type of column.");
+    assert(!"Invalid call for this type of column.");
     return (0);
   }
   bool IsNullImpl([[maybe_unused]] const core::MIIterator &mit) override {
-    DEBUG_ASSERT(!"Invalid call for this type of column.");
+    assert(!"Invalid call for this type of column.");
     return (false);
   }
   void GetValueStringImpl([[maybe_unused]] types::BString &s, [[maybe_unused]] const core::MIIterator &mit) override {
-    DEBUG_ASSERT(!"Invalid call for this type of column.");
+    assert(!"Invalid call for this type of column.");
   }
   types::TianmuValueObject GetValueImpl([[maybe_unused]] const core::MIIterator &mit,
                                         [[maybe_unused]] bool lookup_to_num) override {
-    DEBUG_ASSERT(!"Invalid call for this type of column.");
+    assert(!"Invalid call for this type of column.");
     return (types::TianmuValueObject());
   }
   int64_t GetNumOfNullsImpl([[maybe_unused]] const core::MIIterator &mit,
@@ -219,7 +219,7 @@ class MultiValColumn : public VirtualColumn {
   }  // implement properly when DoRoughMin/Max are implemented non-trivially
 
   int64_t GetSumImpl([[maybe_unused]] const core::MIIterator &mit, [[maybe_unused]] bool &nonnegative) override {
-    DEBUG_ASSERT(!"Invalid call for this type of column.");
+    assert(!"Invalid call for this type of column.");
     nonnegative = false;
     return common::NULL_VALUE_64;
   }

--- a/storage/tianmu/vc/single_column.cpp
+++ b/storage/tianmu/vc/single_column.cpp
@@ -76,7 +76,7 @@ double SingleColumn::GetValueDoubleImpl(const core::MIIterator &mit) {
     vs[vrcbs.len_] = '\0';
     val = std::atof(vs.get());
   } else
-    DEBUG_ASSERT(0 && "conversion to double not implemented");
+    assert(0 && "conversion to double not implemented");
 
   return val;
 }
@@ -86,7 +86,7 @@ types::TianmuValueObject SingleColumn::GetValueImpl(const core::MIIterator &mit,
 }
 
 int64_t SingleColumn::GetSumImpl(const core::MIIterator &mit, bool &nonnegative) {
-  // DEBUG_ASSERT(!core::ATI::IsStringType(TypeName()));
+  // assert(!core::ATI::IsStringType(TypeName()));
   if (mit.WholePack(dim_) && mit.GetCurPackrow(dim_) >= 0)
     return col_->GetSum(mit.GetCurPackrow(dim_), nonnegative);
 
@@ -95,7 +95,7 @@ int64_t SingleColumn::GetSumImpl(const core::MIIterator &mit, bool &nonnegative)
 }
 
 int64_t SingleColumn::GetApproxSumImpl(const core::MIIterator &mit, bool &nonnegative) {
-  // DEBUG_ASSERT(!core::ATI::IsStringType(TypeName()));
+  // assert(!core::ATI::IsStringType(TypeName()));
   if (mit.GetCurPackrow(dim_) >= 0)
     return col_->GetSum(mit.GetCurPackrow(dim_), nonnegative);
 

--- a/storage/tianmu/vc/subselect_column.cpp
+++ b/storage/tianmu/vc/subselect_column.cpp
@@ -125,7 +125,7 @@ SubSelectColumn::~SubSelectColumn() {
 }
 
 void SubSelectColumn::SetBufs(core::MysqlExpression::var_buf_t *bufs) {
-  DEBUG_ASSERT(bufs);
+  assert(bufs);
   for (auto &it : tianmu_items_) {
     auto buf_set = bufs->find(it.first);
     if (buf_set != bufs->end()) {
@@ -141,13 +141,13 @@ void SubSelectColumn::SetBufs(core::MysqlExpression::var_buf_t *bufs) {
 
 types::BString SubSelectColumn::GetMinStringImpl([[maybe_unused]] const core::MIIterator &mit) {
   types::BString s;
-  DEBUG_ASSERT(!"To be implemented.");
+  assert(!"To be implemented.");
   return s;
 }
 
 types::BString SubSelectColumn::GetMaxStringImpl([[maybe_unused]] const core::MIIterator &mit) {
   types::BString s;
-  DEBUG_ASSERT(!"To be implemented.");
+  assert(!"To be implemented.");
   return s;
 }
 
@@ -163,8 +163,8 @@ core::PackOntologicalStatus SubSelectColumn::GetPackOntologicalStatusImpl([
 
 void SubSelectColumn::EvaluatePackImpl([[maybe_unused]] core::MIUpdatingIterator &mit,
                                        [[maybe_unused]] core::Descriptor &desc) {
-  DEBUG_ASSERT(!"To be implemented.");
-  DEBUG_ASSERT(0);
+  assert(!"To be implemented.");
+  assert(0);
 }
 
 common::Tribool SubSelectColumn::ContainsImpl(core::MIIterator const &mit, types::TianmuDataType const &v) {
@@ -314,7 +314,7 @@ int64_t SubSelectColumn::NumOfValuesImpl(core::MIIterator const &mit) {
 }
 
 int64_t SubSelectColumn::AtLeastNoDistinctValuesImpl(core::MIIterator const &mit, int64_t const at_least) {
-  DEBUG_ASSERT(at_least > 0);
+  assert(at_least > 0);
   PrepareSubqResult(mit, false);
   core::ValueSet vals(multi_index_->ValueOfPower());
   vals.Prepare(expected_type_.GetTypeName(), expected_type_.GetScale(), expected_type_.GetCollation());
@@ -583,7 +583,7 @@ bool SubSelectColumn::FeedArguments(const core::MIIterator &mit, bool for_rough)
         if (ldiff)
           param_cache_for_rough_[iter.var_id] = v;
       } else {
-        DEBUG_ASSERT(cache != var_buf_for_rough_.end());
+        assert(cache != var_buf_for_rough_.end());
         diff = diff || (v != cache->second.begin()->first);
         if (diff)
           for (auto &val_it : cache->second) *(val_it.second) = val_it.first = v;
@@ -602,7 +602,7 @@ bool SubSelectColumn::FeedArguments(const core::MIIterator &mit, bool for_rough)
         if (ldiff)
           param_cache_for_exact_[iter.var_id] = v;
       } else {
-        DEBUG_ASSERT(cache != var_buf_for_exact_.end());
+        assert(cache != var_buf_for_exact_.end());
         core::ValueOrNull v1 = *(cache->second.begin()->second);
         core::ValueOrNull v2 = (cache->second.begin()->first);
         diff = diff || (v != cache->second.begin()->first);
@@ -631,7 +631,7 @@ bool SubSelectColumn::MakeParallelReady() {
     return false;  // multipage Attrs - not thread safe
   // below assert doesn't take into account lazy field
   // NumOfMaterialized() tells how many rows in lazy mode are materialized
-  DEBUG_ASSERT(tmp_tab_subq_ptr_->NumOfObj() == tmp_tab_subq_ptr_->NumOfMaterialized());
+  assert(tmp_tab_subq_ptr_->NumOfObj() == tmp_tab_subq_ptr_->NumOfMaterialized());
   PrepareAndFillCache();
   return true;
 }

--- a/storage/tianmu/vc/subselect_column.h
+++ b/storage/tianmu/vc/subselect_column.h
@@ -164,26 +164,26 @@ class SubSelectColumn : public MultiValColumn {
 
   bool IsNullsPossibleImpl([[maybe_unused]] bool val_nulls_possible) override { return true; }
   int64_t GetMinInt64Impl([[maybe_unused]] const core::MIIterator &mit) override {
-    // DEBUG_ASSERT( !"To be implemented." );
+    // assert( !"To be implemented." );
     return common::MINUS_INF_64;
   }
   int64_t GetMaxInt64Impl([[maybe_unused]] const core::MIIterator &mit) override {
-    // DEBUG_ASSERT( !"To be implemented." );
+    // assert( !"To be implemented." );
     return common::PLUS_INF_64;
   }
   int64_t RoughMinImpl() override {
-    // DEBUG_ASSERT( !"To be implemented." );
+    // assert( !"To be implemented." );
     return common::MINUS_INF_64;
   }
   int64_t RoughMaxImpl() override {
-    // DEBUG_ASSERT( !"To be implemented." );
+    // assert( !"To be implemented." );
     return common::PLUS_INF_64;
   }
   types::BString GetMaxStringImpl(const core::MIIterator &mit) override;
   types::BString GetMinStringImpl(const core::MIIterator &mit) override;
 
   bool IsDistinctImpl() override {
-    // DEBUG_ASSERT( !"To be implemented." );
+    // assert( !"To be implemented." );
     return (false);
   }
 

--- a/storage/tianmu/vc/tianmu_attr.cpp
+++ b/storage/tianmu/vc/tianmu_attr.cpp
@@ -409,7 +409,7 @@ types::BString TianmuAttr::GetValueString(const int64_t obj) {
     auto const &dpn(get_dpn(pack));
     if (dpn.Trivial())  // no pack data
       return types::BString();
-    DEBUG_ASSERT(get_pack(pack)->IsLocked());
+    assert(get_pack(pack)->IsLocked());
     auto cur_pack = get_packS(pack);
 
     return cur_pack->GetValueBinary(offset);
@@ -438,7 +438,7 @@ void TianmuAttr::GetValueBin(int64_t obj, size_t &size, char *val_buf) {
     return;
   common::ColumnType a_type = TypeName();
   size = 0;
-  DEBUG_ASSERT(NumOfObj() >= static_cast<uint64_t>(obj));
+  assert(NumOfObj() >= static_cast<uint64_t>(obj));
   LoadPackInfo();
   int pack = row2pack(obj);
   int offset = row2offset(obj);
@@ -457,7 +457,7 @@ void TianmuAttr::GetValueBin(int64_t obj, size_t &size, char *val_buf) {
       if (dpn.Trivial())
         return;
       auto p = get_packS(pack);
-      DEBUG_ASSERT(p->IsLocked());
+      assert(p->IsLocked());
       types::BString v(p->GetValueBinary(offset));
       size = v.size();
       v.CopyTo(val_buf, size);
@@ -488,7 +488,7 @@ types::TianmuValueObject TianmuAttr::GetValue(int64_t obj, bool lookup_to_num) {
   if (obj == common::NULL_VALUE_64)
     return types::TianmuValueObject();
   common::ColumnType a_type = TypeName();
-  DEBUG_ASSERT(NumOfObj() >= static_cast<uint64_t>(obj));
+  assert(NumOfObj() >= static_cast<uint64_t>(obj));
   types::TianmuValueObject ret;
   if (!IsNull(obj)) {
     if (ATI::IsTxtType(a_type) && !lookup_to_num)
@@ -524,7 +524,7 @@ types::TianmuDataType &TianmuAttr::GetValueData(size_t obj, types::TianmuDataTyp
     value = ValuePrototype(lookup_to_num);
   else {
     common::ColumnType a_type = TypeName();
-    DEBUG_ASSERT(NumOfObj() >= static_cast<uint64_t>(obj));
+    assert(NumOfObj() >= static_cast<uint64_t>(obj));
     if (ATI::IsTxtType(a_type) && !lookup_to_num)
       ((types::BString &)value) = GetNotNullValueString(obj);
     else if (ATI::IsBinType(a_type)) {
@@ -615,7 +615,7 @@ types::BString TianmuAttr::GetMinString(int pack) {
 
 // size of original 0-level value (text/binary, not null-terminated)
 size_t TianmuAttr::GetLength(int64_t obj) {
-  DEBUG_ASSERT(NumOfObj() >= static_cast<uint64_t>(obj));
+  assert(NumOfObj() >= static_cast<uint64_t>(obj));
   LoadPackInfo();
   int pack = row2pack(obj);
   auto const &dpn(get_dpn(pack));
@@ -632,7 +632,7 @@ types::BString TianmuAttr::DecodeValue_S(int64_t code) {
     return types::BString();
   }
   if (Type().Lookup()) {
-    DEBUG_ASSERT(GetPackType() == common::PackType::INT);
+    assert(GetPackType() == common::PackType::INT);
     return m_dict->GetRealValue((int)code);
   }
   common::ColumnType a_type = TypeName();
@@ -673,7 +673,7 @@ int TianmuAttr::EncodeValue_T(const types::BString &tianmu_s, bool new_val, comm
     return common::NULL_VALUE_32;
 
   if (ATI::IsStringType(TypeName())) {
-    DEBUG_ASSERT(GetPackType() == common::PackType::INT);
+    assert(GetPackType() == common::PackType::INT);
     LoadPackInfo();
 
     int vs = m_dict->GetEncodedValue(tianmu_s.val_, tianmu_s.len_);
@@ -1187,7 +1187,7 @@ void TianmuAttr::UpdateBatchData(core::Transaction *tx,
 bool TianmuAttr::IsDelete(int64_t row) {
   if (row == common::NULL_VALUE_64)
     return true;
-  DEBUG_ASSERT(hdr.numOfRecords >= static_cast<uint64_t>(row));
+  assert(hdr.numOfRecords >= static_cast<uint64_t>(row));
   auto pack = row2pack(row);
   const auto &dpn = get_dpn(pack);
 

--- a/storage/tianmu/vc/tianmu_attr.h
+++ b/storage/tianmu/vc/tianmu_attr.h
@@ -107,20 +107,20 @@ class TianmuAttr final : public mm::TraceableObject, public PhysicalColumn, publ
       return types::TianmuNum::NullValue();
     if (ATI::IsStringType(TypeName()))
       return types::BString::NullValue();
-    DEBUG_ASSERT(ATI::IsDateTimeType(TypeName()));
+    assert(ATI::IsDateTimeType(TypeName()));
     return types::TianmuDateTime::NullValue();
   }
 
   int64_t GetValueInt64(int64_t obj) const override {
     if (obj == common::NULL_VALUE_64)
       return common::NULL_VALUE_64;
-    DEBUG_ASSERT(hdr.numOfRecords >= static_cast<uint64_t>(obj));
+    assert(hdr.numOfRecords >= static_cast<uint64_t>(obj));
     auto pack = row2pack(obj);
     const auto &dpn = get_dpn(pack);
     auto p = get_packN(pack);
     if (!dpn.Trivial()) {
-      DEBUG_ASSERT(pack_type == common::PackType::INT);
-      DEBUG_ASSERT(p->IsLocked());  // assuming it is already loaded and locked
+      assert(pack_type == common::PackType::INT);
+      assert(p->IsLocked());  // assuming it is already loaded and locked
       int inpack = row2offset(obj);
       if (p->IsNull(inpack))
         return common::NULL_VALUE_64;
@@ -143,7 +143,7 @@ class TianmuAttr final : public mm::TraceableObject, public PhysicalColumn, publ
     int pack = row2pack(obj);
     const auto &dpn = get_dpn(pack);
     if (!dpn.Trivial()) {
-      DEBUG_ASSERT(get_pack(pack)->IsLocked());
+      assert(get_pack(pack)->IsLocked());
 
       int64_t res = get_packN(pack)->GetValInt(row2offset(obj));  // 2-level encoding
       // Natural encoding
@@ -159,7 +159,7 @@ class TianmuAttr final : public mm::TraceableObject, public PhysicalColumn, publ
   bool IsNull(int64_t obj) const override {
     if (obj == common::NULL_VALUE_64)
       return true;
-    DEBUG_ASSERT(hdr.numOfRecords >= static_cast<uint64_t>(obj));
+    assert(hdr.numOfRecords >= static_cast<uint64_t>(obj));
     auto pack = row2pack(obj);
     const auto &dpn = get_dpn(pack);
 
@@ -167,7 +167,7 @@ class TianmuAttr final : public mm::TraceableObject, public PhysicalColumn, publ
       return false;
 
     if (!dpn.Trivial()) {
-      DEBUG_ASSERT(get_pack(pack)->IsLocked());  // assuming the pack is already loaded and locked
+      assert(get_pack(pack)->IsLocked());  // assuming the pack is already loaded and locked
       return get_pack(pack)->IsNull(row2offset(obj));
     }
 
@@ -175,7 +175,7 @@ class TianmuAttr final : public mm::TraceableObject, public PhysicalColumn, publ
       return true;
 
     if ((pack_type == common::PackType::STR) && !dpn.Trivial()) {
-      DEBUG_ASSERT(0);
+      assert(0);
       return true;
     }
     return true;

--- a/storage/tianmu/vc/tianmu_attr_exeq_rs.cpp
+++ b/storage/tianmu/vc/tianmu_attr_exeq_rs.cpp
@@ -85,7 +85,7 @@ common::RoughSetValue TianmuAttr::RoughCheck(int pack, Descriptor &d, bool addit
       return common::RoughSetValue::RS_SOME;
     } else if ((d.op == common::Operator::O_LIKE || d.op == common::Operator::O_NOT_LIKE) &&
                GetPackType() == common::PackType::STR) {
-      DEBUG_ASSERT(vc1->IsConst());
+      assert(vc1->IsConst());
       types::BString pat;
       vc1->GetValueString(pat, mit);
       common::RoughSetValue res = common::RoughSetValue::RS_SOME;
@@ -172,7 +172,7 @@ common::RoughSetValue TianmuAttr::RoughCheck(int pack, Descriptor &d, bool addit
       return res;
     } else if ((d.op == common::Operator::O_IN || d.op == common::Operator::O_NOT_IN) &&
                GetPackType() == common::PackType::STR) {
-      DEBUG_ASSERT(dynamic_cast<vcolumn::MultiValColumn *>(vc1));
+      assert(dynamic_cast<vcolumn::MultiValColumn *>(vc1));
       vcolumn::MultiValColumn *mvc(static_cast<vcolumn::MultiValColumn *>(vc1));
       uint pack_prefix = GetPrefixLength(pack);
       common::RoughSetValue res = common::RoughSetValue::RS_SOME;
@@ -224,7 +224,7 @@ common::RoughSetValue TianmuAttr::RoughCheck(int pack, Descriptor &d, bool addit
     } else if ((d.op == common::Operator::O_IN || d.op == common::Operator::O_NOT_IN) &&
                (GetPackType() == common::PackType::INT)) {
       if (vc1->IsConst()) {
-        DEBUG_ASSERT(dynamic_cast<vcolumn::MultiValColumn *>(vc1));
+        assert(dynamic_cast<vcolumn::MultiValColumn *>(vc1));
         vcolumn::MultiValColumn *mvc(static_cast<vcolumn::MultiValColumn *>(vc1));
         int64_t v1, v2;
         types::TianmuNum rcn_min = mvc->GetSetMin(mit);
@@ -296,7 +296,7 @@ common::RoughSetValue TianmuAttr::RoughCheck(int pack, Descriptor &d, bool addit
                                                           // common::PackType::INT calculated as
                                                           // IN or below
 
-      DEBUG_ASSERT(d.op == common::Operator::O_BETWEEN || d.op == common::Operator::O_NOT_BETWEEN);
+      assert(d.op == common::Operator::O_BETWEEN || d.op == common::Operator::O_NOT_BETWEEN);
       vcolumn::VirtualColumn *vc2 = d.val2.vc;
       common::RoughSetValue res = common::RoughSetValue::RS_SOME;
       uint pack_prefix = GetPrefixLength(pack);
@@ -361,7 +361,7 @@ common::RoughSetValue TianmuAttr::RoughCheck(int pack, Descriptor &d, bool addit
       }
       return res;
     } else if (GetPackType() == common::PackType::INT) {
-      DEBUG_ASSERT(d.op == common::Operator::O_BETWEEN || d.op == common::Operator::O_NOT_BETWEEN);
+      assert(d.op == common::Operator::O_BETWEEN || d.op == common::Operator::O_NOT_BETWEEN);
       // common::Operator::O_BETWEEN or common::Operator::O_NOT_BETWEEN
       int64_t v1 = d.val1.vc->GetValueInt64(mit);  // 1-level values; note that these
                                                    // values were already transformed in

--- a/storage/tianmu/vc/tianmu_attr_exqp.cpp
+++ b/storage/tianmu/vc/tianmu_attr_exqp.cpp
@@ -56,7 +56,7 @@ void TianmuAttr::EvaluatePack(MIUpdatingIterator &mit, int dim, Descriptor &d) {
       else
         EvaluatePack_AttrAttr(mit, dim, d);
     } else
-      DEBUG_ASSERT(0);  // case not implemented
+      assert(0);  // case not implemented
   } else if (GetPackType() == common::PackType::INT &&
              (d.op == common::Operator::O_BETWEEN || d.op == common::Operator::O_NOT_BETWEEN)) {
     if (!ATI::IsRealType(TypeName()))
@@ -86,7 +86,7 @@ void TianmuAttr::EvaluatePack(MIUpdatingIterator &mit, int dim, Descriptor &d) {
   else if (d.op == common::Operator::O_EQ_ALL)
     EvaluatePack_IsNoDelete(mit, dim);
   else
-    DEBUG_ASSERT(0);  // case not implemented!
+    assert(0);  // case not implemented!
 }
 
 // TODO: op (common::Operator::O_LIKE common::Operator::O_IN)
@@ -564,7 +564,7 @@ void TianmuAttr::EvaluatePack_InString(MIUpdatingIterator &mit, int dim, Descrip
     mit.NextPackrow();
     return;
   }
-  DEBUG_ASSERT(dynamic_cast<vcolumn::MultiValColumn *>(d.val1.vc) != nullptr);
+  assert(dynamic_cast<vcolumn::MultiValColumn *>(d.val1.vc) != nullptr);
   vcolumn::MultiValColumn *multival_column = static_cast<vcolumn::MultiValColumn *>(d.val1.vc);
   bool encoded_set = multival_column->IsSetEncoded(TypeName(), ct.GetScale());
   do {
@@ -606,7 +606,7 @@ void TianmuAttr::EvaluatePack_InString_UTF(MIUpdatingIterator &mit, int dim, Des
     return;
   }
 
-  DEBUG_ASSERT(dynamic_cast<vcolumn::MultiValColumn *>(d.val1.vc) != nullptr);
+  assert(dynamic_cast<vcolumn::MultiValColumn *>(d.val1.vc) != nullptr);
   vcolumn::MultiValColumn *multival_column = static_cast<vcolumn::MultiValColumn *>(d.val1.vc);
   DTCollation coll = d.GetCollation();
   int arraysize = d.val1.cond_value.size();
@@ -661,7 +661,7 @@ void TianmuAttr::EvaluatePack_InNum(MIUpdatingIterator &mit, int dim, Descriptor
   int64_t local_min = dpn.min_i;
   int64_t local_max = dpn.max_i;
 
-  DEBUG_ASSERT(dynamic_cast<vcolumn::MultiValColumn *>(d.val1.vc) != nullptr);
+  assert(dynamic_cast<vcolumn::MultiValColumn *>(d.val1.vc) != nullptr);
   vcolumn::MultiValColumn *multival_column = static_cast<vcolumn::MultiValColumn *>(d.val1.vc);
   bool lookup_to_num = ATI::IsStringType(TypeName());
   bool encoded_set = (lookup_to_num ? multival_column->IsSetEncoded(common::ColumnType::NUM, 0)
@@ -1095,7 +1095,7 @@ void TianmuAttr::EvaluatePack_AttrAttr(MIUpdatingIterator &mit, int dim, Descrip
           res = (v1 >= v2);
           break;
         default:
-          DEBUG_ASSERT(0);
+          assert(0);
       }
       if (!res)
         mit.ResetCurrent();
@@ -1159,7 +1159,7 @@ void TianmuAttr::EvaluatePack_AttrAttrReal(MIUpdatingIterator &mit, int dim, Des
           res = (v1 >= v2);
           break;
         default:
-          DEBUG_ASSERT(0);
+          assert(0);
       }
       if (!res)
         mit.ResetCurrent();

--- a/storage/tianmu/vc/tianmu_attr_typeinfo.cpp
+++ b/storage/tianmu/vc/tianmu_attr_typeinfo.cpp
@@ -33,7 +33,7 @@ const types::TianmuDataType &AttributeTypeInfo::ValuePrototype() const {
     return types::TianmuNum::NullValue();
   if (ATI::IsStringType(attrt_))
     return types::BString::NullValue();
-  DEBUG_ASSERT(ATI::IsDateTimeType(attrt_));
+  assert(ATI::IsDateTimeType(attrt_));
   return types::TianmuDateTime::NullValue();
 }
 }  // namespace core

--- a/storage/tianmu/vc/type_cast_column.cpp
+++ b/storage/tianmu/vc/type_cast_column.cpp
@@ -28,7 +28,7 @@ TypeCastColumn::TypeCastColumn(VirtualColumn *from, core::ColumnType const &targ
 }
 
 TypeCastColumn::TypeCastColumn(const TypeCastColumn &c) : VirtualColumn(c) {
-  DEBUG_ASSERT(CanCopy());
+  assert(CanCopy());
   vc_ = CreateVCCopy(c.vc_);
 }
 
@@ -608,7 +608,7 @@ types::TianmuValueObject DateTime2NumCastColumn::GetValueImpl(const core::MIIter
 
 TimeZoneConversionCastColumn::TimeZoneConversionCastColumn(VirtualColumn *from)
     : TypeCastColumn(from, core::ColumnType(common::ColumnType::DATETIME)) {
-  DEBUG_ASSERT(from->TypeName() == common::ColumnType::TIMESTAMP);
+  assert(from->TypeName() == common::ColumnType::TIMESTAMP);
   core::MIIterator mit(nullptr, PACK_INVALID);
   full_const_ = vc_->IsFullConst();
   if (full_const_) {

--- a/storage/tianmu/vc/virtual_column_base.cpp
+++ b/storage/tianmu/vc/virtual_column_base.cpp
@@ -131,7 +131,7 @@ void VirtualColumnBase::SetLocalMinMax(int64_t loc_min, int64_t loc_max) {
 
 int64_t VirtualColumnBase::RoughMax() {
   int64_t res = RoughMaxImpl();
-  DEBUG_ASSERT(res != common::NULL_VALUE_64);
+  assert(res != common::NULL_VALUE_64);
 
   if (Type().IsFloat()) {
     if (*(double *)&res > *(double *)&vc_max_val_ && vc_max_val_ != common::PLUS_INF_64 &&
@@ -145,7 +145,7 @@ int64_t VirtualColumnBase::RoughMax() {
 
 int64_t VirtualColumnBase::RoughMin() {
   int64_t res = RoughMinImpl();
-  DEBUG_ASSERT(res != common::NULL_VALUE_64);
+  assert(res != common::NULL_VALUE_64);
 
   if (Type().IsFloat()) {
     if (*(double *)&res < *(double *)&vc_min_val_ && vc_min_val_ != common::MINUS_INF_64 &&
@@ -190,7 +190,7 @@ int64_t VirtualColumnBase::GetApproxDistVals(bool incl_nulls, core::RoughMultiIn
 
 int64_t VirtualColumnBase::GetMaxInt64(const core::MIIterator &mit) {
   int64_t res = GetMaxInt64Impl(mit);
-  DEBUG_ASSERT(res != common::NULL_VALUE_64);
+  assert(res != common::NULL_VALUE_64);
   if (Type().IsFloat()) {
     if (*(double *)&res > *(double *)&vc_max_val_ && vc_max_val_ != common::PLUS_INF_64 &&
         vc_max_val_ != common::NULL_VALUE_64)
@@ -203,7 +203,7 @@ int64_t VirtualColumnBase::GetMaxInt64(const core::MIIterator &mit) {
 
 int64_t VirtualColumnBase::GetMinInt64(const core::MIIterator &mit) {
   int64_t res = GetMinInt64Impl(mit);
-  DEBUG_ASSERT(res != common::NULL_VALUE_64);
+  assert(res != common::NULL_VALUE_64);
   if (Type().IsFloat()) {
     if (*(double *)&res < *(double *)&vc_min_val_ && vc_min_val_ != common::MINUS_INF_64 &&
         vc_min_val_ != common::NULL_VALUE_64)

--- a/storage/tianmu/vc/virtual_column_base.h
+++ b/storage/tianmu/vc/virtual_column_base.h
@@ -286,11 +286,11 @@ class VirtualColumnBase : public core::Column {
    */
   inline size_t MaxStringSize() { return MaxStringSizeImpl(); }
   virtual types::BString DecodeValue_S([[maybe_unused]] int64_t code) {
-    DEBUG_ASSERT(0);
+    assert(0);
     return types::BString();
   }  // lookup (physical) only
   virtual int EncodeValue_S([[maybe_unused]] types::BString &v) {
-    DEBUG_ASSERT(0);
+    assert(0);
     return -1;
   }                                           // lookup (physical) only
   int64_t DecodeValueAsDouble(int64_t code);  // convert code to a double value
@@ -427,7 +427,7 @@ class VirtualColumnBase : public core::Column {
    *
    */
   virtual VirtualColumn *Copy() {
-    DEBUG_ASSERT(0 && "not implemented");
+    assert(0 && "not implemented");
     return nullptr;
   }
 


### PR DESCRIPTION
<!--

Thank you for contributing to StoneDB!

PR Title Format: <type>(<scope>): description to this pr (#issue_id)
e.g.
fix(util): fix sth..... (#1)

-->

## Summary about this PR
<!--

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".
e.g.:


-->

feat: remove DBUG_OFF flag and repalce DEBUG_ASSERT with assert in tianmu engine(#1551)

1.Remove the code segment in `common/assert.h`
```
#ifdef DBUG_OFF
#define DEBUG_ASSERT(condition) \
  do {                          \
  } while (false)
#else
#define DEBUG_ASSERT(...) assert(__VA_ARGS__)
#endif
```
2.Automatically  replace DBUG_ASSERT with assert in all files under tianmu directory.

3.Manually adjust indent in `core/query.cpp` and `optimizer/compile/descriptor.cpp`

[Edited]4.Automatically update fomat use clang-format after first check failed.
## Tests Check List
<!-- At least one of next options must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

## Changelog
<!-- At least one of next options must be included. -->

- [x] New Feature
- [ ] Bug Fix
- [ ] Performance Improvement
- [ ] Build/Testing/CI/CD
- [ ] Documentation
- [ ] Not for changelog (changelog entry is not required)

## Documentation
<!-- At least one of next options must be included. -->

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
