### PR TITLE
fix(tianmu): backport load dpn when table is empty #1684

### DIFF
--- a/mysql-test/suite/tianmu/r/issue964.result
+++ b/mysql-test/suite/tianmu/r/issue964.result
@@ -1,0 +1,29 @@
+DROP DATABASE IF EXISTS issue964_test;
+CREATE DATABASE issue964_test;
+use issue964_test;
+CREATE TABLE `t1` (
+`id` int DEFAULT NULL,
+`name` varchar(20) DEFAULT NULL,
+KEY `idx_n` (`name`)
+) DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin;
+CREATE TABLE `t2` (
+`id` int DEFAULT NULL,
+`name` varchar(20) DEFAULT NULL,
+KEY `idx_n` (`name`)
+)DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin;
+insert into t1 values(1,'abc');
+insert into t1 values(2,'def');
+SELECT
+t1.id,
+t1.name,
+t2.id,
+t2.name
+FROM
+t1
+LEFT JOIN t2 ON
+t1.name = t2.name
+WHERE
+t1.name IN ('abc');
+id	name	id	name
+1	abc	NULL	NULL
+DROP DATABASE issue964_test;

--- a/mysql-test/suite/tianmu/t/issue964.test
+++ b/mysql-test/suite/tianmu/t/issue964.test
@@ -1,0 +1,42 @@
+--source include/have_tianmu.inc
+--disable_warnings
+DROP DATABASE IF EXISTS issue964_test;
+--enable_warnings
+CREATE DATABASE issue964_test;
+use issue964_test;
+## DDL
+
+CREATE TABLE `t1` (
+  `id` int DEFAULT NULL,
+  `name` varchar(20) DEFAULT NULL,
+  KEY `idx_n` (`name`)
+) DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin;
+
+CREATE TABLE `t2` (
+  `id` int DEFAULT NULL,
+  `name` varchar(20) DEFAULT NULL,
+  KEY `idx_n` (`name`)
+)DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin;
+
+## insert data, only for table t1
+
+insert into t1 values(1,'abc');
+insert into t1 values(2,'def');
+
+## join return empty table t2
+
+SELECT
+	t1.id,
+	t1.name,
+	t2.id,
+	t2.name
+FROM
+	t1
+LEFT JOIN t2 ON
+	t1.name = t2.name
+WHERE
+	t1.name IN ('abc');
+
+## clear tables
+
+DROP DATABASE issue964_test;

--- a/storage/tianmu/core/rc_attr.cpp
+++ b/storage/tianmu/core/rc_attr.cpp
@@ -758,6 +758,8 @@ size_t RCAttr::GetPrefixLength(int pack) {
 }
 
 void RCAttr::LockPackForUse(common::PACK_INDEX pn) {
+  if (m_idx.empty())
+    return;
   auto dpn = &get_dpn(pn);
   if (dpn->IsLocal())
     dpn = m_share->get_dpn_ptr(dpn->base);
@@ -799,6 +801,8 @@ void RCAttr::LockPackForUse(common::PACK_INDEX pn) {
 }
 
 void RCAttr::UnlockPackFromUse(common::PACK_INDEX pn) {
+  if (m_idx.empty())
+    return;
   auto dpn = &get_dpn(pn);
   if (dpn->IsLocal())
     dpn = m_share->get_dpn_ptr(dpn->base);


### PR DESCRIPTION
<!--

Thank you for contributing to StoneDB!

PR Title Format: <type>(<scope>): description to this pr (#issue_id)
e.g.
fix(util): fix sth..... (#1)

-->

## Summary about this PR
<!--

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".
e.g.:
Issue: close #1

-->

Issue Number: close #1684 


## Tests Check List
<!-- At least one of next options must be included. -->

- [ ] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

## Changelog
<!-- At least one of next options must be included. -->

- [ ] New Feature
- [x] Bug Fix
- [ ] Performance Improvement
- [ ] Build/Testing/CI/CD
- [ ] Documentation
- [ ] Not for changelog (changelog entry is not required)

## Documentation
<!-- At least one of next options must be included. -->

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
