### PR TITLE
    fix(tinmu): fix tianmu crash when set varchar to num when order by

### DIFF
--- a/storage/tianmu/types/bstring.cpp
+++ b/storage/tianmu/types/bstring.cpp
@@ -72,7 +72,7 @@ BString::BString(const BString &tianmu_s)
 }
 
 BString::~BString() {
-  if (persistent_)
+  if (persistent_ && len_)
     delete[] val_;
 }
 


### PR DESCRIPTION
由于crash的问题过于严重，优先避免crash。
随后立即开始着手修复tianm查询树上对于给数字类型赋值字符串的在order by操作符上的问题

<!--

Thank you for contributing to StoneDB!
PR Title Format: <type>(<scope>): description to this pr (#issue_id)
e.g.
fix(util): fix sth..... (#1)

-->

## Summary about this PR
<!--

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".
e.g.:
Issue: close #1

-->

Issue Number: close #1792 


## Tests Check List
<!-- At least one of next options must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

## Changelog
<!-- At least one of next options must be included. -->

- [ ] New Feature
- [x] Bug Fix
- [ ] Performance Improvement
- [ ] Build/Testing/CI/CD
- [ ] Documentation
- [ ] Not for changelog (changelog entry is not required)

## Documentation
<!-- At least one of next options must be included. -->

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
