### PR TITLE
fix(tianmu): backport ALTER table xxx ADD numeric column return error(#1734)

### DIFF
--- a/mysql-test/suite/tianmu/r/alter_column.result
+++ b/mysql-test/suite/tianmu/r/alter_column.result
@@ -1,0 +1,26 @@
+DROP DATABASE IF EXISTS alter_column;
+CREATE DATABASE alter_column;
+USE alter_column;
+CREATE TABLE st1 (
+task_id INT NOT NULL,
+subject VARCHAR(45) NULL,
+start_date DATE NULL,
+end_date DATE NULL,
+description VARCHAR(200) NULL,
+PRIMARY KEY (task_id)
+);
+ALTER TABLE st1 ADD COLUMN test numeric(20,10);
+ERROR HY000: Unable to inplace alter table
+ALTER TABLE st1 ADD COLUMN test1 numeric(8,2);
+SHOW CREATE TABLE st1;
+Table	Create Table
+st1	CREATE TABLE `st1` (
+  `task_id` int NOT NULL,
+  `subject` varchar(45) DEFAULT NULL,
+  `start_date` date DEFAULT NULL,
+  `end_date` date DEFAULT NULL,
+  `description` varchar(200) DEFAULT NULL,
+  `test1` decimal(8,2) DEFAULT NULL,
+  PRIMARY KEY (`task_id`)
+) ENGINE=TIANMU DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci
+DROP DATABASE alter_column;

--- a/mysql-test/suite/tianmu/t/alter_column.test
+++ b/mysql-test/suite/tianmu/t/alter_column.test
@@ -1,0 +1,31 @@
+--source include/have_tianmu.inc
+
+--disable_warnings
+DROP DATABASE IF EXISTS alter_column;
+--enable_warnings
+
+CREATE DATABASE alter_column;
+USE alter_column;
+
+#################
+# ADD COLUMN BEFORE THE FIRST ADDING COLUMN IS WRONG
+#################
+
+CREATE TABLE st1 (
+    task_id INT NOT NULL,
+    subject VARCHAR(45) NULL,
+    start_date DATE NULL,
+    end_date DATE NULL,
+    description VARCHAR(200) NULL,
+    PRIMARY KEY (task_id)
+);
+
+--ERROR 6
+ALTER TABLE st1 ADD COLUMN test numeric(20,10);
+
+ALTER TABLE st1 ADD COLUMN test1 numeric(8,2);
+
+SHOW CREATE TABLE st1;
+
+# Clean UP
+DROP DATABASE alter_column;

--- a/storage/tianmu/core/rc_table.cpp
+++ b/storage/tianmu/core/rc_table.cpp
@@ -99,6 +99,9 @@ void RCTable::Alter(const std::string &table_path, std::vector<Field *> &new_col
   fs::path tmp_dir = table_path + ".tmp";
   fs::path tab_dir = table_path + common::TIANMU_EXT;
 
+  if (fs::exists(tmp_dir))
+    fs::remove_all(tmp_dir);
+
   fs::copy(tab_dir, tmp_dir, fs::copy_options::recursive | fs::copy_options::copy_symlinks);
 
   for (auto &p : fs::directory_iterator(tmp_dir / common::COLUMN_DIR)) fs::remove(p);

--- a/storage/tianmu/handler/ha_tianmu.cpp
+++ b/storage/tianmu/handler/ha_tianmu.cpp
@@ -1601,6 +1601,10 @@ bool ha_tianmu::inplace_alter_table(TABLE *altered_table [[maybe_unused]],
     TIANMU_LOG(LogCtl_Level::ERROR, "An unknown system exception error caught.");
   }
 
+  fs::path tmp_dir = table_name_ + ".tmp";
+  if (fs::exists(tmp_dir))
+    fs::remove_all(tmp_dir);
+
   my_message(static_cast<int>(common::ErrorCode::UNKNOWN_ERROR), "Unable to inplace alter table", MYF(0));
 
   DBUG_RETURN(true);


### PR DESCRIPTION
<!--

Thank you for contributing to StoneDB!

PR Title Format: <type>(<scope>): description to this pr (#issue_id)
e.g.
fix(util): fix sth..... (#1)

-->

## Summary about this PR
<!--

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".
e.g.:
Issue: close #1

-->

Issue Number: close #1734

1.Add test case: when alter table xxx add colmn operation is failed firstly, executing
alter table xxx add column by successful case again
2. Delete the temporary directory to solve the copy problem

## Tests Check List
<!-- At least one of next options must be included. -->

- [ ] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

## Changelog
<!-- At least one of next options must be included. -->

- [ ] New Feature
- [x] Bug Fix
- [ ] Performance Improvement
- [ ] Build/Testing/CI/CD
- [ ] Documentation
- [ ] Not for changelog (changelog entry is not required)

## Documentation
<!-- At least one of next options must be included. -->

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
