### PR TITLE
fix(tianmu): Fix up the unknown exception after instance killed randomly

### DIFF
--- a/storage/tianmu/vc/tianmu_attr.cpp
+++ b/storage/tianmu/vc/tianmu_attr.cpp
@@ -725,6 +725,7 @@ int64_t TianmuAttr::EncodeValue64(types::TianmuDataType *v, bool &rounded, commo
   rounded = false;
   if (tianmu_err_code)
     *tianmu_err_code = common::ErrorCode::SUCCESS;
+
   if (!v || v->IsNull())
     return common::NULL_VALUE_64;
 
@@ -733,6 +734,7 @@ int64_t TianmuAttr::EncodeValue64(types::TianmuDataType *v, bool &rounded, commo
   } else if (ATI::IsDateTimeType(TypeName()) || ATI::IsDateTimeNType(TypeName())) {
     return ((types::TianmuDateTime *)v)->GetInt64();
   }
+
   ASSERT(GetPackType() == common::PackType::INT, "Pack type must be numeric!");
 
   int64_t vv = ((types::TianmuNum *)v)->ValueInt();
@@ -745,6 +747,7 @@ int64_t TianmuAttr::EncodeValue64(types::TianmuDataType *v, bool &rounded, commo
     // for(int i=0;i<vp;i++) res*=10;
     return *(int64_t *)(&res);  // encode
   }
+
   if (((types::TianmuNum *)v)->IsReal()) {  // v is double
     double vd = *(double *)(&vv);
     vd *= types::Uint64PowOfTen(Type().GetScale());  // translate into int64_t of proper precision
@@ -754,10 +757,10 @@ int64_t TianmuAttr::EncodeValue64(types::TianmuDataType *v, bool &rounded, commo
       return common::MINUS_INF_64;
     int64_t res = int64_t(vd);
     if (fabs(vd - double(res)) > 0.01)
-      rounded = true;  // ignore errors which are 2 digits less than declared
-                       // precision
+      rounded = true;  // ignore errors which are 2 digits less than declared precision
     return res;
   }
+
   unsigned char dplaces = Type().GetScale();
   while (vp < dplaces) {
     if (vv < common::MINUS_INF_64 / 10)
@@ -767,9 +770,11 @@ int64_t TianmuAttr::EncodeValue64(types::TianmuDataType *v, bool &rounded, commo
     vv *= 10;
     vp++;
   }
+
   while (vp > dplaces) {
     if (vv % 10 != 0)
       rounded = true;
+
     vv /= 10;
     vp--;
   }
@@ -937,7 +942,8 @@ void TianmuAttr::LoadData(loader::ValueCache *nvs, Transaction *conn_info) {
   }
 
   DPN &dpn = get_dpn(pi);
-  if (current_txn_->LoadSource() == common::LoadSource::LS_File || dpn.numOfRecords == (1U << pss)) {
+  if (current_txn_->LoadSource() == common::LoadSource::LS_Direct ||
+      current_txn_->LoadSource() == common::LoadSource::LS_File || dpn.numOfRecords == (1U << pss)) {
     Pack *pack = get_pack(pi);
     if (!dpn.Trivial()) {
       pack->Save();


### PR DESCRIPTION
<!--

Thank you for contributing to StoneDB!

PR Title Format: <type>(<scope>): description to this pr (#issue_id)
e.g.
fix(util): fix sth..... (#1)

-->

## Summary about this PR
<!--

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".
e.g.:
Issue: close #1

-->
If the instance was killed by `kill -9 'pid'` randomly, the new inserted data will not be written into `DATA` file under the param of `tianmu_insert_delayed` was set to 0. Under this configuration, the data will write to memory not a `DATA` file. Therefore, when the instance was killed and restarted, the data will be lost, and the `DATA` can not be found, and an TianmuError exception will be thrown.

changed the writing behavior of instance from writting data into memory to writting data into `DATA` file immediately as that of `tianmu_insert_delayed=1`.
Issue Number: close #1621


## Tests Check List
<!-- At least one of next options must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

## Changelog
<!-- At least one of next options must be included. -->

- [ ] New Feature
- [ ] Bug Fix
- [ ] Performance Improvement
- [ ] Build/Testing/CI/CD
- [ ] Documentation
- [ ] Not for changelog (changelog entry is not required)

## Documentation
<!-- At least one of next options must be included. -->

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
