### PR TITLE
feature(tianmu): backport support replace into #1714

### DIFF
--- a/mysql-test/suite/tianmu/r/replace.result
+++ b/mysql-test/suite/tianmu/r/replace.result
@@ -1,0 +1,56 @@
+DROP DATABASE IF EXISTS test_replace_db;
+CREATE DATABASE test_replace_db;
+use test_replace_db;
+CREATE TABLE test1 (
+id INT NOT NULL AUTO_INCREMENT,
+data VARCHAR(64) DEFAULT NULL,
+ts TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+PRIMARY KEY (id)
+)  engine=tianmu;
+REPLACE INTO test1 VALUES (1, 'Old', '2014-08-20 18:47:00');
+REPLACE INTO test1 VALUES (1, 'New', '2014-08-20 18:47:42');
+SELECT * FROM test1;
+id	data	ts
+1	New	2014-08-20 18:47:42
+drop table test1;
+CREATE TABLE test2 (
+id INT NOT NULL AUTO_INCREMENT,
+data VARCHAR(64) DEFAULT NULL,
+ts TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+PRIMARY KEY (id, ts)
+)  engine=tianmu;
+REPLACE INTO test2 VALUES (1, 'Old', '2014-08-20 18:47:00');
+REPLACE INTO test2 VALUES (1, 'New', '2014-08-20 18:47:42');
+select * from test2;
+id	data	ts
+1	Old	2014-08-20 18:47:00
+1	New	2014-08-20 18:47:42
+drop table test2;
+CREATE TABLE test1 (
+id INT NOT NULL AUTO_INCREMENT,
+data VARCHAR(64) DEFAULT NULL,
+ts TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+PRIMARY KEY (id)
+)  engine=tianmu;
+insert into test1 values (1,'Old', '2014-08-20 18:47:00');
+insert into test1 values (2, 'Old', '2014-08-20 18:47:00');
+REPLACE INTO test1 VALUES (1, 'New', '2014-08-20 18:47:42');
+SELECT * FROM test1;
+id	data	ts
+1	New	2014-08-20 18:47:42
+2	Old	2014-08-20 18:47:00
+delete from test1 where id =1;
+SELECT * FROM test1;
+id	data	ts
+2	Old	2014-08-20 18:47:00
+REPLACE INTO test1 VALUES (1, 'NewNew', '2014-08-20 18:47:55');
+SELECT * FROM test1;
+id	data	ts
+2	Old	2014-08-20 18:47:00
+1	NewNew	2014-08-20 18:47:55
+REPLACE INTO test1 VALUES (1, 'NewNewNew', '2014-08-20 18:55:55');
+SELECT * FROM test1;
+id	data	ts
+2	Old	2014-08-20 18:47:00
+1	NewNewNew	2014-08-20 18:55:55
+drop database test_replace_db;

--- a/mysql-test/suite/tianmu/t/replace.test
+++ b/mysql-test/suite/tianmu/t/replace.test
@@ -1,0 +1,53 @@
+--source include/have_tianmu.inc
+
+#
+# Test REPLACE INTO with TIANMU
+#
+
+--disable_warnings
+DROP DATABASE IF EXISTS test_replace_db;
+--enable_warnings
+CREATE DATABASE test_replace_db;
+use test_replace_db;
+# test auto_increment and the primary key covers 1 columns
+CREATE TABLE test1 (
+  id INT NOT NULL AUTO_INCREMENT,
+  data VARCHAR(64) DEFAULT NULL,
+  ts TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  PRIMARY KEY (id)
+)  engine=tianmu;
+REPLACE INTO test1 VALUES (1, 'Old', '2014-08-20 18:47:00');
+REPLACE INTO test1 VALUES (1, 'New', '2014-08-20 18:47:42');
+SELECT * FROM test1;
+drop table test1;
+
+# the primary key now covers 2 columns
+CREATE TABLE test2 (
+  id INT NOT NULL AUTO_INCREMENT,
+  data VARCHAR(64) DEFAULT NULL,
+  ts TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  PRIMARY KEY (id, ts)
+)  engine=tianmu;
+REPLACE INTO test2 VALUES (1, 'Old', '2014-08-20 18:47:00');
+REPLACE INTO test2 VALUES (1, 'New', '2014-08-20 18:47:42');
+select * from test2;
+drop table test2;
+
+# test whether `delete` would impact the `replace into` action
+CREATE TABLE test1 (
+  id INT NOT NULL AUTO_INCREMENT,
+  data VARCHAR(64) DEFAULT NULL,
+  ts TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  PRIMARY KEY (id)
+)  engine=tianmu;
+insert into test1 values (1,'Old', '2014-08-20 18:47:00');
+insert into test1 values (2, 'Old', '2014-08-20 18:47:00');
+REPLACE INTO test1 VALUES (1, 'New', '2014-08-20 18:47:42');
+SELECT * FROM test1;
+delete from test1 where id =1;
+SELECT * FROM test1;
+REPLACE INTO test1 VALUES (1, 'NewNew', '2014-08-20 18:47:55');
+SELECT * FROM test1;
+REPLACE INTO test1 VALUES (1, 'NewNewNew', '2014-08-20 18:55:55');
+SELECT * FROM test1;
+drop database test_replace_db;

--- a/storage/tianmu/handler/ha_tianmu.cpp
+++ b/storage/tianmu/handler/ha_tianmu.cpp
@@ -455,7 +455,7 @@ int ha_tianmu::write_row([[maybe_unused]] uchar *buf) {
   int ret = 1;
   DBUG_ENTER(__PRETTY_FUNCTION__);
   try {
-    if (ha_thd()->lex->duplicates == DUP_UPDATE) {
+    if (ha_thd()->lex->duplicates == DUP_UPDATE || ha_thd()->lex->duplicates == DUP_REPLACE) {
       if (auto indextab = ha_rcengine_->GetTableIndex(table_name_)) {
         if (size_t row; has_dup_key(indextab, table, row)) {
           dupkey_pos_ = row;


### PR DESCRIPTION
Solution:
  In the function write_row, return errno HA_ERR_FOUND_DUPP_KEY
when unique key of insert record exisits. And than it will be processed as update(DUP_REPLACE)

<!--

Thank you for contributing to StoneDB!

PR Title Format: <type>(<scope>): description to this pr (#issue_id)
e.g.
fix(util): fix sth..... (#1)

-->

## Summary about this PR
<!--

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".
e.g.:
Issue: close #1

-->

Issue Number: close #1714 


## Tests Check List
<!-- At least one of next options must be included. -->

- [ ] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

## Changelog
<!-- At least one of next options must be included. -->

- [x] New Feature
- [ ] Bug Fix
- [ ] Performance Improvement
- [ ] Build/Testing/CI/CD
- [ ] Documentation
- [ ] Not for changelog (changelog entry is not required)

## Documentation
<!-- At least one of next options must be included. -->

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
