### PR TITLE
fix(tianmu): To fixup the instance crashed if the result of aggregate is out of boundary

### DIFF
--- a/mysql-test/suite/tianmu/r/issue1855.result
+++ b/mysql-test/suite/tianmu/r/issue1855.result
@@ -1,0 +1,6 @@
+SELECT SUM(LENGTH(p_id)) FROM ttt;
+SUM(LENGTH(p_id))
+27
+SELECT SUM(LENGTH(p_id)/2) FROM ttt;
+SUM(LENGTH(p_id)/2)
+13.5000

--- a/mysql-test/suite/tianmu/t/issue1855.test
+++ b/mysql-test/suite/tianmu/t/issue1855.test
@@ -1,0 +1,34 @@
+-- source include/have_tianmu.inc
+
+--disable_warnings
+
+--disable_query_log
+
+DROP DATABASE IF EXISTS issue1855_test_db;
+CREATE DATABASE issue1855_test_db;
+
+USE issue1855_test_db;
+
+DROP TABLE IF EXISTS squence;
+
+CREATE TABLE ttt (
+  p_id varchar(50) NOT NULL
+) ENGINE=TIANMU AUTO_INCREMENT=3000000004910127 DEFAULT CHARSET=utf8mb4;
+
+INSERT INTO `ttt` 
+VALUES("THIS IS"), 
+("A TEST"),
+("FOR SUM LENGTH");
+--enable_query_log
+
+SELECT SUM(LENGTH(p_id)) FROM ttt;
+
+SELECT SUM(LENGTH(p_id)/2) FROM ttt;
+
+--disable_query_log
+DROP TABLE ttt;
+
+DROP DATABASE issue1855_test_db;
+--enable_query_log
+
+--enable_warnings

--- a/storage/tianmu/core/value_or_null.cpp
+++ b/storage/tianmu/core/value_or_null.cpp
@@ -43,6 +43,7 @@ void ValueOrNull::SetBString(const types::BString &tianmu_s) {
 void ValueOrNull::MakeStringOwner() {
   if (!sp || string_owner)
     return;
+
   char *tmp = new char[len + 1];
   std::memcpy(tmp, sp, len);
   tmp[len] = 0;
@@ -74,9 +75,11 @@ void ValueOrNull::GetBString(types::BString &tianmu_s) const {
 ValueOrNull::ValueOrNull(ValueOrNull const &von)
     : x(von.x), len(von.len), string_owner(von.string_owner), null(von.null) {
   if (string_owner) {
-    sp = new char[len + 1];
-    std::memcpy(sp, von.sp, len);
-    sp[len] = 0;
+    sp = new (std::nothrow) char[len + 1];
+    if (sp) {
+      std::memcpy(sp, von.sp, len);
+      sp[len] = 0;
+    }
   } else {
     sp = von.sp;
   }
@@ -87,6 +90,7 @@ ValueOrNull &ValueOrNull::operator=(ValueOrNull const &von) {
     ValueOrNull tmp(von);
     Swap(tmp);
   }
+
   return (*this);
 }
 

--- a/storage/tianmu/core/value_or_null.h
+++ b/storage/tianmu/core/value_or_null.h
@@ -105,10 +105,13 @@ class ValueOrNull final {
 
   void Swap(ValueOrNull &von);
   void Clear() {
-    if (string_owner)
+    if (string_owner && sp) {
       delete[] sp;
-    sp = nullptr;
-    string_owner = false;
+      sp = nullptr;
+
+      string_owner = false;
+    }
+
     null = true;
     x = common::NULL_VALUE_64;
     len = 0;

--- a/storage/tianmu/data/pack_int.cpp
+++ b/storage/tianmu/data/pack_int.cpp
@@ -35,6 +35,8 @@ PackInt::PackInt(DPN *dpn, PackCoordinate pc, ColumnShare *s) : Pack(dpn, pc, s)
   if (dpn_->NotTrivial()) {
     system::TianmuFile f;
     f.OpenReadOnly(s->DataFile());
+
+    ASSERT(dpn_->dataAddress != DPN_INVALID_ADDR);
     f.Seek(dpn_->dataAddress, SEEK_SET);
     LoadDataFromFile(&f);
   }


### PR DESCRIPTION


<!--

Thank you for contributing to StoneDB!

PR Title Format: <type>(<scope>): description to this pr (#issue_id)
e.g.
fix(util): fix sth..... (#1)

-->

## Summary about this PR
<!--

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".
e.g.:
Issue: close #1

-->
To fixup the instance crashed if the result of aggregate is out of boundary function goes out of bounds

To caculate `sum(length())` will lead a corruption in destructor of `ValueOrNull`, frees an array of char. Before the array deletes, the validity of that should be checked, and after that the pointer of that arrary should also be set to nullptr, which make sure it's a safe code piece.
Issue Number: close #issue_number_you_created


## Tests Check List
<!-- At least one of next options must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

## Changelog
<!-- At least one of next options must be included. -->

- [ ] New Feature
- [x] Bug Fix
- [ ] Performance Improvement
- [ ] Build/Testing/CI/CD
- [ ] Documentation
- [ ] Not for changelog (changelog entry is not required)

## Documentation
<!-- At least one of next options must be included. -->

- [x] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
