### PR TITLE
fix(tianmu): hotfix corruption in ValueOrNull under multi-thread

### DIFF
--- a/mysql-test/suite/tianmu/r/issue1855.result
+++ b/mysql-test/suite/tianmu/r/issue1855.result
@@ -10,3 +10,17 @@ SUM(LENGTH(p_val))
 SELECT SUM(LENGTH(p_val)/2) FROM ttt;
 SUM(LENGTH(p_val)/2)
 3.0000
+Variable_name	Value
+tianmu_groupby_parallel_degree	0
+tianmu_groupby_parallel_rows_minimum	655360
+Variable_name	Value
+tianmu_groupby_parallel_degree	4
+tianmu_groupby_parallel_rows_minimum	100
+SUM(LENGTH(p_id))
+158949
+SUM(LENGTH(p_id)/2)
+79474.5000
+SUM(LENGTH(p_val))
+38901
+SUM(LENGTH(p_val)/2)
+19450.5000

--- a/mysql-test/suite/tianmu/t/issue1855.test
+++ b/mysql-test/suite/tianmu/t/issue1855.test
@@ -32,8 +32,56 @@ SELECT SUM(LENGTH(p_val)) FROM ttt;
 SELECT SUM(LENGTH(p_val)/2) FROM ttt;
 
 --disable_query_log
-DROP TABLE ttt;
 
+--DELIMITER //
+CREATE PROCEDURE insert_data()
+wholeblock:BEGIN
+  DECLARE x INT;
+  DECLARE str VARCHAR(50);
+  DECLARE str1 VARCHAR(50);
+  SET x = 0;
+  SET str = 'this is ';
+  SET str1 = '';
+  
+  loop_label: LOOP
+    IF x > 10000 THEN
+      LEAVE loop_label;
+    END IF;
+   
+    SET str1 = substring(md5(rand()), 1, 10);
+    SET str = CONCAT(str,str1,',');
+    SET str = CONCAT(str,x,',');
+     
+    INSERT INTO ttt VALUES (str, x);
+    SET str ='';
+    SET x = x + 1;
+    ITERATE loop_label;
+  END LOOP;
+END//
+
+--DELIMITER ;
+
+CALL insert_data();
+
+DROP PROCEDURE insert_data;
+
+SHOW VARIABLES LIKE "%tianmu_groupby_parallel%";
+
+SET GLOBAL tianmu_groupby_parallel_rows_minimum = 100;
+SET GLOBAL tianmu_groupby_parallel_degree = 4;
+
+SHOW VARIABLES LIKE "%tianmu_groupby_parallel%";
+
+SELECT SUM(LENGTH(p_id)) FROM ttt;
+
+SELECT SUM(LENGTH(p_id)/2) FROM ttt;
+
+SELECT SUM(LENGTH(p_val)) FROM ttt;
+
+SELECT SUM(LENGTH(p_val)/2) FROM ttt;
+
+
+DROP TABLE ttt;
 DROP DATABASE issue1855_test_db;
 --enable_query_log
 

--- a/storage/tianmu/core/value_or_null.cpp
+++ b/storage/tianmu/core/value_or_null.cpp
@@ -23,6 +23,7 @@
 
 namespace Tianmu {
 namespace core {
+
 void ValueOrNull::SetBString(const types::BString &tianmu_s) {
   Clear();
   if (!tianmu_s.IsNull()) {
@@ -44,7 +45,7 @@ void ValueOrNull::SetBString(const types::BString &tianmu_s) {
 }
 
 void ValueOrNull::MakeStringOwner() {
-  if (!sp || string_owner)
+  if (!sp || !len || string_owner)
     return;
 
   char *tmp = new (std::nothrow) char[len + 1];
@@ -70,17 +71,14 @@ void ValueOrNull::GetBString(types::BString &tianmu_s) const {
     tianmu_s = rcs_null;
   } else {
     // copy either from sp or x
-    if (sp)
-      tianmu_s = types::BString(sp, len, true);
-    else
-      tianmu_s = types::TianmuNum(x).ToBString();
+    tianmu_s = (sp) ? types::BString(sp, len, true) : types::TianmuNum(x).ToBString();
     tianmu_s.MakePersistent();
   }
 }
 
 ValueOrNull::ValueOrNull(ValueOrNull const &von)
     : x(von.x), len(von.len), string_owner(von.string_owner), null(von.null) {
-  if (string_owner) {
+  if (string_owner && von.sp && len > 0) {
     sp = new (std::nothrow) char[len + 1];
 
     if (sp) {
@@ -99,7 +97,7 @@ ValueOrNull &ValueOrNull::operator=(ValueOrNull const &von) {
   if (this == &von)
     return *this;
 
-  if (von.string_owner) {
+  if (von.string_owner && von.sp) {
     sp = new (std::nothrow) char[von.len + 1];
     if (sp) {
       std::memset(sp, '\0', von.len + 1);
@@ -140,5 +138,6 @@ void ValueOrNull::Swap(ValueOrNull &von) {
     std::swap(string_owner, von.string_owner);
   }
 }
+
 }  // namespace core
 }  // namespace Tianmu

--- a/storage/tianmu/core/value_or_null.h
+++ b/storage/tianmu/core/value_or_null.h
@@ -102,6 +102,7 @@ class ValueOrNull final {
 
       string_owner = false;
       null = true;
+      len = 0;
     }
   }
 

--- a/storage/tianmu/handler/ha_tianmu.cpp
+++ b/storage/tianmu/handler/ha_tianmu.cpp
@@ -2623,7 +2623,7 @@ static MYSQL_SYSVAR_BOOL(groupby_speedup, tianmu_sysvar_groupby_speedup, PLUGIN_
 static MYSQL_SYSVAR_UINT(groupby_parallel_degree, tianmu_sysvar_groupby_parallel_degree, PLUGIN_VAR_INT,
                          "group by parallel degree, number of worker threads", nullptr, nullptr, 8, 0, INT32_MAX, 0);
 static MYSQL_SYSVAR_ULONGLONG(groupby_parallel_rows_minimum, tianmu_sysvar_groupby_parallel_rows_minimum,
-                              PLUGIN_VAR_LONGLONG, "group by parallel minimum rows", nullptr, nullptr, 655360, 655360,
+                              PLUGIN_VAR_LONGLONG, "group by parallel minimum rows", nullptr, nullptr, 655360, 100,
                               INT64_MAX, 0);
 static MYSQL_SYSVAR_UINT(slow_query_record_interval, tianmu_sysvar_slow_query_record_interval, PLUGIN_VAR_INT,
                          "slow Query Threshold of recording tianmu logs, in seconds", nullptr, nullptr, 0, 0, INT32_MAX,

--- a/storage/tianmu/optimizer/aggregation_algorithm.cpp
+++ b/storage/tianmu/optimizer/aggregation_algorithm.cpp
@@ -1072,6 +1072,7 @@ void AggregationWorkerEnt::DistributeAggreTaskAverage(MIIterator &mit, uint64_t 
   for (uint i = 0; i < vTask.size(); ++i) {
     if (dims.NoDimsUsed() == 0)
       dims.SetAll();
+
     auto &mii = taskIterator.emplace_back(mit, true);
     mii.SetTaskNum(vTask.size());
     mii.SetTaskId(i);

--- a/storage/tianmu/optimizer/aggregator_basic.h
+++ b/storage/tianmu/optimizer/aggregator_basic.h
@@ -18,6 +18,7 @@
 #define TIANMU_CORE_AGGREGATOR_BASIC_H_
 #pragma once
 
+#include <mutex>
 #include "optimizer/aggregator.h"
 
 namespace Tianmu {
@@ -87,6 +88,7 @@ class AggregatorSum64 : public TIANMUAggregator {
   }
 
  private:
+  std::mutex aggr_mtx;
   int64_t pack_sum;
   int64_t pack_min;  // min and max are used to check whether a pack may update
                      // sum (i.e. both 0 means "no change")

--- a/storage/tianmu/optimizer/group_table.cpp
+++ b/storage/tianmu/optimizer/group_table.cpp
@@ -569,9 +569,11 @@ bool GroupTable::PutAggregatedValue(int col, int64_t row, MIIterator &mit, int64
     DEBUG_ASSERT(gdistinct[col]);
     if (vc[col]->IsNull(mit))
       return true;  // omit nulls
+
     GDTResult res = gdistinct[col]->Add(row, mit);
     if (res == GDTResult::GDT_EXISTS)
       return true;  // value found, do not aggregate it again
+
     if (res == GDTResult::GDT_FULL) {
       // if (gdistinct[col]->AlreadyFull())
       // not_full = false;  // disable also the main grouping table (if it is a

--- a/storage/tianmu/vc/column_share.h
+++ b/storage/tianmu/vc/column_share.h
@@ -140,6 +140,7 @@ class ColumnShare final {
   bool has_filter_hist = false;
   bool has_filter_bloom = false;
 };
+
 }  // namespace core
 }  // namespace Tianmu
 

--- a/storage/tianmu/vc/expr_column.cpp
+++ b/storage/tianmu/vc/expr_column.cpp
@@ -16,6 +16,7 @@
 */
 
 #include "expr_column.h"
+#include <mutex>
 #include "core/mysql_expression.h"
 #include "optimizer/compile/compiled_query.h"
 #include "vc/tianmu_attr.h"
@@ -131,6 +132,9 @@ bool ExpressionColumn::FeedArguments(const core::MIIterator &mit) {
 }
 
 int64_t ExpressionColumn::GetValueInt64Impl(const core::MIIterator &mit) {
+  static std::mutex scp_mutex;
+  std::scoped_lock lock(scp_mutex);
+
   if (FeedArguments(mit))
     last_val_ = expr_->Evaluate();
 
@@ -152,6 +156,7 @@ int64_t ExpressionColumn::GetValueInt64Impl(const core::MIIterator &mit) {
         val_it.second->Clear_SP();
     }
   }
+
   return last_val_->Get64();
 }
 


### PR DESCRIPTION
<!--

Thank you for contributing to StoneDB!

PR Title Format: <type>(<scope>): description to this pr (#issue_id)
e.g.
fix(util): fix sth..... (#1)

-->

## Summary about this PR
<!--

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".
e.g.:
Issue: close #1

-->
In multi-thread aggregation, ExpressionColumn will occur double free due to without protection. Thread A will do ValueOrNull::operator ==, but in thread B, it will try to free it. Therefore, it leads to instance crash.

Issue Number: close #1855


## Tests Check List
<!-- At least one of next options must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

## Changelog
<!-- At least one of next options must be included. -->

- [ ] New Feature
- [ ] Bug Fix
- [ ] Performance Improvement
- [ ] Build/Testing/CI/CD
- [ ] Documentation
- [ ] Not for changelog (changelog entry is not required)

## Documentation
<!-- At least one of next options must be included. -->

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
