### PR TITLE
fix(tianmu): incorrect result when using where expr and args > bigint_max #1564

### DIFF
--- a/mysql-test/suite/tianmu/r/issue1564.result
+++ b/mysql-test/suite/tianmu/r/issue1564.result
@@ -1,0 +1,99 @@
+DROP DATABASE IF EXISTS issue1564;
+create database issue1564;
+use issue1564;
+create table t(a bigint not null);
+insert into t values(-222222), (-22), (-15),(-16),(0), (11), (12), (9223372036854775807);
+select * from t;
+a
+-222222
+-22
+-15
+-16
+0
+11
+12
+9223372036854775807
+select * from t where a = 18446744073709551601;
+a
+select * from t where a != 18446744073709551601;
+a
+-222222
+-22
+-15
+-16
+0
+11
+12
+9223372036854775807
+select * from t where a = -22;
+a
+-22
+select * from t where a != -22;
+a
+-222222
+-15
+-16
+0
+11
+12
+9223372036854775807
+select * from t where a in(-16, -15, -11);
+a
+-15
+-16
+select * from t where a > 18446744073709551599;
+a
+select * from t where a >= 18446744073709551599;
+a
+select * from t where a < 18446744073709551599;
+a
+-222222
+-22
+-15
+-16
+0
+11
+12
+9223372036854775807
+select * from t where a <= 18446744073709551599;
+a
+-222222
+-22
+-15
+-16
+0
+11
+12
+9223372036854775807
+select * from t where a between -22 and 18446744073709551599;
+a
+-22
+-15
+-16
+0
+11
+12
+9223372036854775807
+select * from t where a between -22 and 9223372036854775807;
+a
+-22
+-15
+-16
+0
+11
+12
+9223372036854775807
+select * from t where a between -222222 and 9223372036854775807;
+a
+-222222
+-22
+-15
+-16
+0
+11
+12
+9223372036854775807
+select * from t where a between 9223372036854775807 and -22;
+a
+drop table t;
+drop database issue1564;

--- a/mysql-test/suite/tianmu/t/issue1564.test
+++ b/mysql-test/suite/tianmu/t/issue1564.test
@@ -1,0 +1,27 @@
+--source include/have_tianmu.inc
+
+--disable_warnings
+DROP DATABASE IF EXISTS issue1564;
+--enable_warnings
+create database issue1564;
+use issue1564;
+
+create table t(a bigint not null);
+insert into t values(-222222), (-22), (-15),(-16),(0), (11), (12), (9223372036854775807);
+select * from t;
+select * from t where a = 18446744073709551601;
+select * from t where a != 18446744073709551601;
+select * from t where a = -22;
+select * from t where a != -22;
+select * from t where a in(-16, -15, -11);
+select * from t where a > 18446744073709551599;
+select * from t where a >= 18446744073709551599;
+select * from t where a < 18446744073709551599;
+select * from t where a <= 18446744073709551599;
+select * from t where a between -22 and 18446744073709551599;
+select * from t where a between -22 and 9223372036854775807;
+select * from t where a between -222222 and 9223372036854775807;
+select * from t where a between 9223372036854775807 and -22;
+
+drop table t;
+drop database issue1564;

--- a/storage/tianmu/core/mysql_expression.cpp
+++ b/storage/tianmu/core/mysql_expression.cpp
@@ -560,6 +560,9 @@ std::shared_ptr<ValueOrNull> MysqlExpression::ItemInt2ValueOrNull(Item *item) {
   if (v == common::NULL_VALUE_64)
     v++;
   val->SetFixed(v);
+  // add unsigned flag here as item may have unsigned valued, like where a = 18446744073709551601; 18446744073709551601
+  // is an unsigned valued stored in item. Introduced by a bug: https://github.com/stoneatom/stonedb/issues/1564
+  val->SetUnsignedFlag(static_cast<bool>(item->unsigned_flag));
   if (item->null_value)
     return std::make_shared<ValueOrNull>();
   return val;

--- a/storage/tianmu/core/value_or_null.cpp
+++ b/storage/tianmu/core/value_or_null.cpp
@@ -79,7 +79,7 @@ void ValueOrNull::GetBString(types::BString &tianmu_s) const {
 }
 
 ValueOrNull::ValueOrNull(ValueOrNull const &von)
-    : x(von.x), len(von.len), string_owner(von.string_owner), null(von.null) {
+    : x(von.x), len(von.len), string_owner(von.string_owner), null(von.null), unsigned_flag_(von.unsigned_flag_) {
   if (string_owner) {
     sp = new (std::nothrow) char[len + 1];
 
@@ -117,9 +117,11 @@ ValueOrNull &ValueOrNull::operator=(ValueOrNull const &von) {
   return (*this);
 }
 
-ValueOrNull::ValueOrNull(types::TianmuNum const &tianmu_n) : x(tianmu_n.GetValueInt64()), null(tianmu_n.IsNull()) {}
+ValueOrNull::ValueOrNull(types::TianmuNum const &tianmu_n)
+    : x(tianmu_n.GetValueInt64()), null(tianmu_n.IsNull()), unsigned_flag_(tianmu_n.GetUnsignedFlag()) {}
 
-ValueOrNull::ValueOrNull(types::TianmuDateTime const &tianmu_dt) : x(tianmu_dt.GetInt64()), null(tianmu_dt.IsNull()) {}
+ValueOrNull::ValueOrNull(types::TianmuDateTime const &tianmu_dt)
+    : x(tianmu_dt.GetInt64()), null(tianmu_dt.IsNull()), unsigned_flag_(true) {}
 
 ValueOrNull::ValueOrNull(types::BString const &tianmu_s)
     : x(common::NULL_VALUE_64),
@@ -138,6 +140,7 @@ void ValueOrNull::Swap(ValueOrNull &von) {
     std::swap(sp, von.sp);
     std::swap(len, von.len);
     std::swap(string_owner, von.string_owner);
+    std::swap(unsigned_flag_, von.unsigned_flag_);
   }
 }
 }  // namespace core

--- a/storage/tianmu/core/value_or_null.h
+++ b/storage/tianmu/core/value_or_null.h
@@ -58,6 +58,8 @@ class ValueOrNull final {
   bool NotNull() const { return !null; }
   size_t StrLen() const { return len; }
   int64_t Get64() const { return x; }
+  bool GetUnsignedFlag() const { return unsigned_flag_; }
+  void SetUnsignedFlag(bool is_unsigned) { unsigned_flag_ = is_unsigned; }
 
   void SetFixed(int64_t v) {
     Clear();
@@ -118,13 +120,15 @@ class ValueOrNull final {
     null = true;
     x = common::NULL_VALUE_64;
     len = 0;
+    unsigned_flag_ = false;
   }
 
  private:
-  int64_t x;                  // 8-byte value of an expression; interpreted as int64_t or double
-  char *sp = nullptr;         // != 0 if string value assigned
-  uint len = 0;               // string length; used only for ValueType::VT_STRING
-  bool string_owner = false;  // if true, destructor must deallocate sp
+  int64_t x;                    // 8-byte value of an expression; interpreted as int64_t or double
+  bool unsigned_flag_ = false;  // check if x is unsigned or not
+  char *sp = nullptr;           // != 0 if string value assigned
+  uint len = 0;                 // string length; used only for ValueType::VT_STRING
+  bool string_owner = false;    // if true, destructor must deallocate sp
   bool null;
 };
 }  // namespace core

--- a/storage/tianmu/types/tianmu_num.cpp
+++ b/storage/tianmu/types/tianmu_num.cpp
@@ -29,14 +29,16 @@ namespace Tianmu {
 namespace types {
 
 TianmuNum::TianmuNum(common::ColumnType attrt)
-    : value_(0), scale_(0), is_double_(false), is_dot_(false), attr_type_(attrt) {}
+    : value_(0), scale_(0), is_double_(false), is_dot_(false), attr_type_(attrt), unsigned_flag_(false) {}
 
-TianmuNum::TianmuNum(int64_t value, short scale, bool is_double, common::ColumnType attrt) {
-  Assign(value, scale, is_double, attrt);
+TianmuNum::TianmuNum(int64_t value, short scale, bool is_double, common::ColumnType attrt, bool unsigned_flag) {
+  Assign(value, scale, is_double, attrt, unsigned_flag);
 }
 
 TianmuNum::TianmuNum(double value)
     : value_(*(int64_t *)&value), scale_(0), is_double_(true), is_dot_(false), attr_type_(common::ColumnType::REAL) {
+  // In tianmu, real type does not support unsigned well.
+  unsigned_flag_ = false;
   null_ = (value_ == NULL_VALUE_D ? true : false);
 }
 
@@ -46,17 +48,19 @@ TianmuNum::TianmuNum(const TianmuNum &tianmu_n)
       scale_(tianmu_n.scale_),
       is_double_(tianmu_n.is_double_),
       is_dot_(tianmu_n.is_dot_),
-      attr_type_(tianmu_n.attr_type_) {
+      attr_type_(tianmu_n.attr_type_),
+      unsigned_flag_(tianmu_n.unsigned_flag_) {
   null_ = tianmu_n.null_;
 }
 
 TianmuNum::~TianmuNum() {}
 
-TianmuNum &TianmuNum::Assign(int64_t value, short scale, bool is_double, common::ColumnType attrt) {
+TianmuNum &TianmuNum::Assign(int64_t value, short scale, bool is_double, common::ColumnType attrt, bool unsigned_flag) {
   this->value_ = value;
   this->scale_ = scale;
   this->is_double_ = is_double;
   this->attr_type_ = attrt;
+  this->unsigned_flag_ = unsigned_flag;
 
   if (scale != -1 &&
       !is_double_) {  // check if construct decimal, the UNK is used on temp_table.cpp: GetValueString(..)
@@ -84,6 +88,7 @@ TianmuNum &TianmuNum::Assign(double value) {
   this->is_double_ = true;
   this->is_dot_ = false;
   this->attr_type_ = common::ColumnType::REAL;
+  this->unsigned_flag_ = false;
   common::double_int_t v(value_);
   null_ = (v.i == common::NULL_VALUE_64 ? true : false);
   return *this;

--- a/storage/tianmu/types/tianmu_num.h
+++ b/storage/tianmu/types/tianmu_num.h
@@ -31,13 +31,14 @@ class TianmuNum : public ValueBasic<TianmuNum> {
 
  public:
   TianmuNum(common::ColumnType attrt = common::ColumnType::NUM);
-  TianmuNum(int64_t value, short scale = -1, bool dbl = false, common::ColumnType attrt = common::ColumnType::UNK);
+  TianmuNum(int64_t value, short scale = -1, bool dbl = false, common::ColumnType attrt = common::ColumnType::UNK,
+            bool unsigned_flag = false);
   TianmuNum(double value);
   TianmuNum(const TianmuNum &);
   ~TianmuNum();
 
   TianmuNum &Assign(int64_t value, short scale = -1, bool dbl = false,
-                    common::ColumnType attrt = common::ColumnType::UNK);
+                    common::ColumnType attrt = common::ColumnType::UNK, bool unsigned_flag = false);
   TianmuNum &Assign(double value);
 
   static common::ErrorCode Parse(const BString &tianmu_s, TianmuNum &tianmu_n,
@@ -82,6 +83,7 @@ class TianmuNum : public ValueBasic<TianmuNum> {
 
   short Scale() const { return scale_; }
   int64_t ValueInt() const { return value_; }
+  bool GetUnsignedFlag() const { return unsigned_flag_; }
   char *GetDataBytesPointer() const override { return (char *)&value_; }
   int64_t GetIntPart() const {
     return is_double_ ? (int64_t)GetIntPartAsDouble() : value_ / (int64_t)Uint64PowOfTen(scale_);
@@ -105,6 +107,7 @@ class TianmuNum : public ValueBasic<TianmuNum> {
  private:
   static constexpr int MAX_DEC_PRECISION = 18;
   int64_t value_;
+  bool unsigned_flag_ = false;
   ushort scale_;  // means 'scale' actually
   bool is_double_;
   bool is_dot_;

--- a/storage/tianmu/vc/const_column.h
+++ b/storage/tianmu/vc/const_column.h
@@ -58,6 +58,7 @@ class ConstColumn : public VirtualColumn {
   int64_t GetValueInt64Impl([[maybe_unused]] const core::MIIterator &mit) override {
     return value_or_null_.IsNull() ? common::NULL_VALUE_64 : value_or_null_.Get64();
   }
+  bool GetUnsignedFlagImpl() override { return value_or_null_.GetUnsignedFlag(); }
   bool IsNullImpl([[maybe_unused]] const core::MIIterator &mit) override { return value_or_null_.IsNull(); }
   void GetValueStringImpl(types::BString &s, const core::MIIterator &mit) override;
   double GetValueDoubleImpl(const core::MIIterator &mit) override;

--- a/storage/tianmu/vc/const_expr_column.h
+++ b/storage/tianmu/vc/const_expr_column.h
@@ -96,6 +96,8 @@ class ConstExpressionColumn : public ExpressionColumn {
     return last_val_->IsNull() ? common::NULL_VALUE_64 : last_val_->Get64();
   }
 
+  bool GetUnsignedFlagImpl() override { return last_val_->GetUnsignedFlag(); }
+
   double GetValueDoubleImpl(const core::MIIterator &mit) override;
   int64_t GetMinInt64Impl([[maybe_unused]] const core::MIIterator &mit) override {
     return last_val_->IsNull() ? common::MINUS_INF_64 : last_val_->Get64();

--- a/storage/tianmu/vc/expr_column.h
+++ b/storage/tianmu/vc/expr_column.h
@@ -83,6 +83,7 @@ class ExpressionColumn : public VirtualColumn {
   /////////////// Data access //////////////////////
  protected:
   int64_t GetValueInt64Impl(const core::MIIterator &) override;
+  bool GetUnsignedFlagImpl() override { return static_cast<bool>(expr_->GetItem()->unsigned_flag); }
   bool IsNullImpl(const core::MIIterator &) override;
   void GetValueStringImpl(types::BString &, const core::MIIterator &) override;
   double GetValueDoubleImpl(const core::MIIterator &) override;

--- a/storage/tianmu/vc/multi_value_column.h
+++ b/storage/tianmu/vc/multi_value_column.h
@@ -194,6 +194,10 @@ class MultiValColumn : public VirtualColumn {
     DEBUG_ASSERT(!"Invalid call for this type of column.");
     return (0);
   }
+  bool GetUnsignedFlagImpl() override {
+    DEBUG_ASSERT(!"Invalid call for this type of column.");
+    return (false);
+  }
   double GetValueDoubleImpl([[maybe_unused]] const core::MIIterator &mit) override {
     DEBUG_ASSERT(!"Invalid call for this type of column.");
     return (0);

--- a/storage/tianmu/vc/single_column.h
+++ b/storage/tianmu/vc/single_column.h
@@ -73,6 +73,7 @@ class SingleColumn : public VirtualColumn {
 
  protected:
   int64_t GetValueInt64Impl(const core::MIIterator &mit) override { return col_->GetValueInt64(mit[dim_]); }
+  bool GetUnsignedFlagImpl() override { return col_->Type().GetUnsigned(); }
   bool IsNullImpl(const core::MIIterator &mit) override { return col_->IsNull(mit[dim_]); }
   void GetValueStringImpl(types::BString &s, const core::MIIterator &mit) override {
     col_->GetValueString(mit[dim_], s);

--- a/storage/tianmu/vc/tianmu_attr.h
+++ b/storage/tianmu/vc/tianmu_attr.h
@@ -229,6 +229,7 @@ class TianmuAttr final : public mm::TraceableObject, public PhysicalColumn, publ
   void SetMaxInt64(int64_t a_imax) { hdr.max = a_imax; }
   bool GetIfAutoInc() const { return ct.GetAutoInc(); }
   bool GetIfUnsigned() const { return ct.GetUnsigned(); }
+  void SetUnsigned(bool unsigned_flag) { ct.SetUnsigned(unsigned_flag); }
   uint64_t AutoIncNext() {
     backup_auto_inc_next_ = m_share->auto_inc_.fetch_add(1);
     if (backup_auto_inc_next_ >= UINT64_MAX)

--- a/storage/tianmu/vc/type_cast_column.h
+++ b/storage/tianmu/vc/type_cast_column.h
@@ -71,6 +71,7 @@ class TypeCastColumn : public VirtualColumn {
 
  protected:
   int64_t GetValueInt64Impl(const core::MIIterator &mit) override { return vc_->GetValueInt64(mit); }
+  bool GetUnsignedFlagImpl() override { return vc_->GetUnsignedFlag(); }
   bool IsNullImpl(const core::MIIterator &mit) override { return vc_->IsNull(mit); }
   void GetValueStringImpl(types::BString &s, const core::MIIterator &m) override { return vc_->GetValueString(s, m); }
   double GetValueDoubleImpl(const core::MIIterator &m) override { return vc_->GetValueDouble(m); }

--- a/storage/tianmu/vc/virtual_column_base.h
+++ b/storage/tianmu/vc/virtual_column_base.h
@@ -91,6 +91,7 @@ class VirtualColumnBase : public core::Column {
    * - Doubles must be cast e.g. *(double*)&
    */
   inline int64_t GetValueInt64(const core::MIIterator &mit) { return GetValueInt64Impl(mit); }
+  inline bool GetUnsignedFlag() { return GetUnsignedFlagImpl(); }
   virtual int64_t GetNotNullValueInt64(const core::MIIterator &mit) = 0;
 
   /*! \brief get Item
@@ -492,6 +493,7 @@ class VirtualColumnBase : public core::Column {
 
  protected:
   virtual int64_t GetValueInt64Impl(const core::MIIterator &) = 0;
+  virtual bool GetUnsignedFlagImpl() = 0;
   virtual bool IsNullImpl(const core::MIIterator &) = 0;
   virtual void GetValueStringImpl(types::BString &, const core::MIIterator &) = 0;
   virtual double GetValueDoubleImpl(const core::MIIterator &) = 0;


### PR DESCRIPTION

[summary]
1. static_cast<int64_t>(18446744073709551601) = -15
2. Item will set 18446744073709551601 with unsigned flag, but in tianmu transform to ValueOrNot, the value will be set to `-15`.
3. add `unsigned flag` in value_or_null & TianmuNum & tianmu expr.

<!--

Thank you for contributing to StoneDB!

PR Title Format: <type>(<scope>): description to this pr (#issue_id)
e.g.
fix(util): fix sth..... (#1)

-->

## Summary about this PR
<!--

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".
e.g.:
Issue: close #1

-->

Issue Number: close #issue_number_you_created


## Tests Check List
<!-- At least one of next options must be included. -->

- [ ] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

## Changelog
<!-- At least one of next options must be included. -->

- [ ] New Feature
- [x] Bug Fix
- [ ] Performance Improvement
- [ ] Build/Testing/CI/CD
- [ ] Documentation
- [ ] Not for changelog (changelog entry is not required)

## Documentation
<!-- At least one of next options must be included. -->

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
