### PR TITLE
fix(tianmu): fix when using where to filter hexadecimal format data, return incorrect(#1625)

### DIFF
--- a/mysql-test/suite/tianmu/r/insert_update.result
+++ b/mysql-test/suite/tianmu/r/insert_update.result
@@ -126,14 +126,21 @@ Warning	3135	'NO_ZERO_DATE', 'NO_ZERO_IN_DATE' and 'ERROR_FOR_DIVISION_BY_ZERO' 
 Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 INSERT INTO t_latin1 values(x'f242', x'f242', x'f242');
 UPDATE t_latin1 SET a=x'f343' where a=x'f242';
+select * from t_latin1;
+a	b	c
+ÛC	ÚB	ÚB
 INSERT INTO t_gb2312 values(x'e5ac', x'e5ac', x'e5ac');
 UPDATE t_gb2312 SET a=x'e6af' where a=x'e5ac';
+select * from t_gb2312;
+a	b	c
+?	?	?
 INSERT INTO t_utf8 values(x'e4b8ad', x'e4b8ad', x'e4b8ad');
 INSERT INTO t_utf8 values(x'f4b8ad', x'f4b8ad', x'f4b8ad');
 ERROR HY000: Incorrect string value: '\xF4\xB8\xAD' for column 'a' at row 1
 UPDATE t_utf8 SET a=x'e69687' where a=x'e4b8ad';
-UPDATE t_utf8 SET a=x'f69687' where a=x'e69687';
 select * from t_utf8;
 a	b	c
 ?	?	?
+UPDATE t_utf8 SET a=x'f69687' where a=x'e69687';
+ERROR HY000: Incorrect string value: '\xF6\x96\x87' for column 'a' at row 1
 DROP DATABASE insert_update_db;

--- a/mysql-test/suite/tianmu/r/issue1625.result
+++ b/mysql-test/suite/tianmu/r/issue1625.result
@@ -1,0 +1,14 @@
+DROP DATABASE IF EXISTS issue1625_test;
+create database issue1625_test;
+use issue1625_test;
+CREATE TABLE t_latin1(
+a CHAR(20) CHARACTER SET latin1,
+b VARCHAR(20) CHARACTER SET latin1,
+c TEXT(20) CHARACTER SET latin1
+)engine=tianmu;
+INSERT INTO t_latin1 values(x'f242', x'f242', x'f242');
+select * from t_latin1 where a=x'f242';
+a	b	c
+ÚB	ÚB	ÚB
+DROP TABLE t_latin1;
+drop database issue1625_test;

--- a/mysql-test/suite/tianmu/r/update_v1.result
+++ b/mysql-test/suite/tianmu/r/update_v1.result
@@ -259,7 +259,7 @@ id	token
 UPDATE t1 SET token = NULL WHERE token = X'ad';
 SELECT * FROM t1;
 id	token
-1	­
-2	­
+1	NULL
+2	NULL
 DROP TABLE t1;
 DROP DATABASE update_v1_db;

--- a/mysql-test/suite/tianmu/t/insert_update.test
+++ b/mysql-test/suite/tianmu/t/insert_update.test
@@ -126,14 +126,18 @@ CREATE TABLE t_utf8(
 SET SQL_MODE="STRICT_TRANS_TABLES";
 INSERT INTO t_latin1 values(x'f242', x'f242', x'f242');
 UPDATE t_latin1 SET a=x'f343' where a=x'f242';
+select * from t_latin1;
 INSERT INTO t_gb2312 values(x'e5ac', x'e5ac', x'e5ac');
 UPDATE t_gb2312 SET a=x'e6af' where a=x'e5ac';
+select * from t_gb2312;
 INSERT INTO t_utf8 values(x'e4b8ad', x'e4b8ad', x'e4b8ad');
 --disable_abort_on_error
 INSERT INTO t_utf8 values(x'f4b8ad', x'f4b8ad', x'f4b8ad');
 --enable_abort_on_error
 UPDATE t_utf8 SET a=x'e69687' where a=x'e4b8ad';
-UPDATE t_utf8 SET a=x'f69687' where a=x'e69687';
 select * from t_utf8;
+--disable_abort_on_error
+UPDATE t_utf8 SET a=x'f69687' where a=x'e69687';
+--enable_abort_on_error
 # Clean UP
 DROP DATABASE insert_update_db;

--- a/mysql-test/suite/tianmu/t/issue1625.test
+++ b/mysql-test/suite/tianmu/t/issue1625.test
@@ -1,0 +1,21 @@
+--source include/have_tianmu.inc
+
+--disable_warnings
+DROP DATABASE IF EXISTS issue1625_test;
+--enable_warnings
+
+create database issue1625_test;
+use issue1625_test;
+
+CREATE TABLE t_latin1(
+a CHAR(20) CHARACTER SET latin1,
+b VARCHAR(20) CHARACTER SET latin1,
+c TEXT(20) CHARACTER SET latin1
+)engine=tianmu;
+
+INSERT INTO t_latin1 values(x'f242', x'f242', x'f242');
+
+select * from t_latin1 where a=x'f242';
+
+DROP TABLE t_latin1;
+drop database issue1625_test;

--- a/storage/tianmu/core/query.cpp
+++ b/storage/tianmu/core/query.cpp
@@ -1103,7 +1103,6 @@ QueryRouteTo Query::Item2CQTerm(Item *an_arg, CQTerm &term, const TabID &tmp_tab
     return QueryRouteTo::kToTianmu;
   } else {
     // WHERE FILTER
-
     AttrID vc;
     AttrID col;
     TabID tab;
@@ -1117,7 +1116,7 @@ QueryRouteTo Query::Item2CQTerm(Item *an_arg, CQTerm &term, const TabID &tmp_tab
         phys2virt.insert(std::make_pair(std::pair<int, int>(tab.n, col.n), phys_vc));
       }
       vc.n = phys_vc.second;
-    } else if (an_arg->type() == Item::VARBIN_ITEM) {
+    } else if (an_arg->type() == Item::VARBIN_ITEM && an_arg->cmp_context == REAL_RESULT) {
       String str;
       an_arg->val_str(&str);  // sets null_value
       if (!an_arg->null_value) {


### PR DESCRIPTION
<!--

Thank you for contributing to StoneDB!

PR Title Format: <type>(<scope>): description to this pr (#issue_id)
e.g.
fix(util): fix sth..... (#1)

-->

## Summary about this PR
<!--

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".
e.g.:
Issue: close #1

-->

`Item_hex_string` will be transformed to `Item_int` here eventually leading to wrong type of item in evaluation.
Only `Item_hex_string` and Comparison context is `REAL_RESULT` need transformation.

Issue Number: close #1625 


## Tests Check List
<!-- At least one of next options must be included. -->

- [ ] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

## Changelog
<!-- At least one of next options must be included. -->

- [ ] New Feature
- [x] Bug Fix
- [ ] Performance Improvement
- [ ] Build/Testing/CI/CD
- [ ] Documentation
- [ ] Not for changelog (changelog entry is not required)

## Documentation
<!-- At least one of next options must be included. -->

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
