### PR TITLE
fix(sql,tianmu):fix when binlog format is row, the load data statement cannot be recorded(#1876)

### DIFF
--- a/mysql-test/suite/tianmu/r/issue1876.result
+++ b/mysql-test/suite/tianmu/r/issue1876.result
@@ -1,0 +1,57 @@
+include/master-slave.inc
+Warnings:
+Note	####	Sending passwords in plain text without SSL/TLS is extremely insecure.
+Note	####	Storing MySQL user name or password information in the master info repository is not secure and is therefore not recommended. Please consider using the USER and PASSWORD connection options for START SLAVE; see the 'START SLAVE Syntax' in the MySQL Manual for more information.
+[connection master]
+create table t1 (b int not null default 1, c varchar(60) default '\\')engine=tianmu;
+insert into t1 values(1, 'AAAAAAAA');
+insert into t1 values(2, 'BBBBBBBB');
+SELECT * from t1 INTO OUTFILE '1876_tmp_dat';
+create table t2 like t1;
+load data infile '1876_tmp_dat' into table t2;
+CREATE TABLE `column_type_test1` (
+`c_tinyint` tinyint(4) DEFAULT NULL COMMENT 'tinyint',
+`c_smallint` smallint(6) DEFAULT NULL COMMENT 'smallint',
+`c_mediumint` mediumint(9) DEFAULT NULL COMMENT 'mediumint',
+`c_int` int(11) DEFAULT NULL COMMENT 'int',
+`c_bigint` bigint(20) DEFAULT NULL COMMENT 'bigint',
+`c_float` float DEFAULT NULL COMMENT 'float',
+`c_double` double DEFAULT NULL COMMENT 'double',
+`c_decimal` decimal(10,5) DEFAULT NULL COMMENT 'decimal',
+`c_date` date DEFAULT NULL COMMENT 'date',
+`c_datetime` datetime DEFAULT NULL COMMENT 'datetime',
+`c_timestamp` timestamp NULL DEFAULT NULL COMMENT 'timestamp',
+`c_time` time DEFAULT NULL COMMENT 'time',
+`c_char` char(10) DEFAULT NULL COMMENT 'char',
+`c_varchar` varchar(10) DEFAULT NULL COMMENT 'varchar',
+`c_blob` blob COMMENT 'blob',
+`c_text` text COMMENT 'text',
+`c_longblob` longblob COMMENT 'longblob'
+) engine=tianmu;
+insert into column_type_test1 values(100, 100, 100, 100, 100, 5.2, 10.88, 100.08300, '2016-02-25', '2016-02-25 10:20:01', '2007-04-23 08:12:49', '10:20:01', 'stonedb', 'hello', null, 'bcdefghijklmn', null);
+insert into column_type_test1 values(101, 101, 101, 101, 101, 5.2, 10.88, 101.08300, '2016-02-25', '2016-02-25 10:20:01', '1985-08-11 09:10:25', '10:20:01', 'stoneatom', 'hello', null, 'bcdefghijklmn', null);
+SELECT * from column_type_test1 INTO OUTFILE '1876_tmp1_dat';
+create table column_type_test2 like column_type_test1;
+load data infile '1876_tmp1_dat' into table column_type_test2;
+create table user_t1(id int, department varchar(10)) engine=tianmu;
+SELECT * from user_t1 INTO OUTFILE '1876_tmp2_dat';
+create table user_t2 like user_t1;
+load data infile '1876_tmp2_dat' into table user_t2;
+SHOW STATUS LIKE 'Slave_running';
+Variable_name	Value
+Slave_running	ON
+select * from t2;
+b	c
+1	AAAAAAAA
+2	BBBBBBBB
+select * from column_type_test2;
+c_tinyint	c_smallint	c_mediumint	c_int	c_bigint	c_float	c_double	c_decimal	c_date	c_datetime	c_timestamp	c_time	c_char	c_varchar	c_blob	c_text	c_longblob
+100	100	100	100	100	5.2	10.88	100.08300	2016-02-25	2016-02-25 10:20:01	2007-04-23 08:12:49	10:20:01	stonedb	hello	NULL	bcdefghijklmn	NULL
+101	101	101	101	101	5.2	10.88	101.08300	2016-02-25	2016-02-25 10:20:01	1985-08-11 09:10:25	10:20:01	stoneatom	hello	NULL	bcdefghijklmn	NULL
+checksum table user_t2;
+Table	Checksum
+test.user_t2	536836232
+drop table t1, t2;
+drop table column_type_test1, column_type_test2;
+drop table user_t1, user_t2;
+include/rpl_end.inc

--- a/mysql-test/suite/tianmu/t/issue1876-master.opt
+++ b/mysql-test/suite/tianmu/t/issue1876-master.opt
@@ -1,0 +1,5 @@
+--testcase-timeout=40
+--secure-file-priv=""
+--tianmu_insert_delayed=off
+--log-bin=bin
+--binlog_format=row

--- a/mysql-test/suite/tianmu/t/issue1876.test
+++ b/mysql-test/suite/tianmu/t/issue1876.test
@@ -1,0 +1,66 @@
+--source include/have_tianmu.inc
+--source include/master-slave.inc
+
+connection master;
+create table t1 (b int not null default 1, c varchar(60) default '\\')engine=tianmu;
+insert into t1 values(1, 'AAAAAAAA');
+insert into t1 values(2, 'BBBBBBBB');
+SELECT * from t1 INTO OUTFILE '1876_tmp_dat';
+create table t2 like t1;
+load data infile '1876_tmp_dat' into table t2;
+
+CREATE TABLE `column_type_test1` (
+ `c_tinyint` tinyint(4) DEFAULT NULL COMMENT 'tinyint',
+  `c_smallint` smallint(6) DEFAULT NULL COMMENT 'smallint',
+  `c_mediumint` mediumint(9) DEFAULT NULL COMMENT 'mediumint',
+  `c_int` int(11) DEFAULT NULL COMMENT 'int',
+  `c_bigint` bigint(20) DEFAULT NULL COMMENT 'bigint',
+  `c_float` float DEFAULT NULL COMMENT 'float',
+  `c_double` double DEFAULT NULL COMMENT 'double',
+  `c_decimal` decimal(10,5) DEFAULT NULL COMMENT 'decimal',
+  `c_date` date DEFAULT NULL COMMENT 'date',
+  `c_datetime` datetime DEFAULT NULL COMMENT 'datetime',
+  `c_timestamp` timestamp NULL DEFAULT NULL COMMENT 'timestamp',
+  `c_time` time DEFAULT NULL COMMENT 'time',
+  `c_char` char(10) DEFAULT NULL COMMENT 'char',
+  `c_varchar` varchar(10) DEFAULT NULL COMMENT 'varchar',
+  `c_blob` blob COMMENT 'blob',
+  `c_text` text COMMENT 'text',
+  `c_longblob` longblob COMMENT 'longblob'
+) engine=tianmu;
+insert into column_type_test1 values(100, 100, 100, 100, 100, 5.2, 10.88, 100.08300, '2016-02-25', '2016-02-25 10:20:01', '2007-04-23 08:12:49', '10:20:01', 'stonedb', 'hello', null, 'bcdefghijklmn', null);
+insert into column_type_test1 values(101, 101, 101, 101, 101, 5.2, 10.88, 101.08300, '2016-02-25', '2016-02-25 10:20:01', '1985-08-11 09:10:25', '10:20:01', 'stoneatom', 'hello', null, 'bcdefghijklmn', null);
+SELECT * from column_type_test1 INTO OUTFILE '1876_tmp1_dat';
+create table column_type_test2 like column_type_test1;
+load data infile '1876_tmp1_dat' into table column_type_test2;
+
+create table user_t1(id int, department varchar(10)) engine=tianmu;
+--disable_query_log
+let $i = 0;
+while($i < 70000)
+{
+  eval insert into user_t1 values($i, 'stonedb');
+  inc $i;
+}
+--enable_query_log
+SELECT * from user_t1 INTO OUTFILE '1876_tmp2_dat';
+create table user_t2 like user_t1;
+load data infile '1876_tmp2_dat' into table user_t2;
+
+--sync_slave_with_master
+
+connection slave;
+# check the rpl is running normally
+SHOW STATUS LIKE 'Slave_running';
+
+# the data in table t2 in slave is the same to that's in master, means the binlog is written correctly
+select * from t2;
+select * from column_type_test2;
+checksum table user_t2;
+
+connection master;
+drop table t1, t2;
+drop table column_type_test1, column_type_test2;
+drop table user_t1, user_t2;
+--sync_slave_with_master
+--source include/rpl_end.inc

--- a/sql/binlog.cc
+++ b/sql/binlog.cc
@@ -8802,12 +8802,14 @@ TC_LOG::enum_result MYSQL_BIN_LOG::commit(THD *thd, bool all)
         DBUG_RETURN(RESULT_ABORTED);
       }
     }
-    else if (real_trans && xid && trn_ctx->rw_ha_count(trx_scope) > 1 &&
-             !trn_ctx->no_2pc(trx_scope))
+    else if (thd->tianmu_need_xid || (real_trans && xid && trn_ctx->rw_ha_count(trx_scope) > 1 &&
+             !trn_ctx->no_2pc(trx_scope)))
     {
       Xid_log_event end_evt(thd, xid);
       if (cache_mngr->trx_cache.finalize(thd, &end_evt))
         DBUG_RETURN(RESULT_ABORTED);
+      // used for tianmu only
+      thd->tianmu_need_xid= false;
     }
     else
     {

--- a/sql/sql_class.h
+++ b/sql/sql_class.h
@@ -1492,6 +1492,8 @@ private:
   { assert(0); return Query_arena::is_conventional(); }
 
 public:
+  /* Used only for tianmu to wirte xid log event */
+  bool tianmu_need_xid;
   MDL_context mdl_context;
 
   /*

--- a/storage/tianmu/core/tianmu_table.h
+++ b/storage/tianmu/core/tianmu_table.h
@@ -159,6 +159,7 @@ class TianmuTable final : public JustATable {
   uint64_t ProceedNormal(system::IOParameters &iop);
   uint64_t ProcessDelayed(system::IOParameters &iop);
   void Field2VC(Field *f, loader::ValueCache &vc, size_t col);
+  int binlog_flush_pending_rows_event(system::IOParameters &iop, bool stmt_end, bool is_transactional);
   int binlog_load_query_log_event(system::IOParameters &iop);
   int binlog_insert2load_log_event(system::IOParameters &iop);
   int binlog_insert2load_block(std::vector<loader::ValueCache> &vcs, uint load_obj, system::IOParameters &iop);


### PR DESCRIPTION
<!--

Thank you for contributing to StoneDB!

PR Title Format: <type>(<scope>): description to this pr (#issue_id)
e.g.
fix(util): fix sth..... (#1)

-->

## Summary about this PR
<!--

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".
e.g.:
Issue: close #1

-->

1. Actually, tianmu uses its own code to handle load which lacks support of row format of binlog
2. When tianmu parsing rows,  write table map event first
3. Once tianmu constructs a row, just add it to the rows log event, when parsing is done, the rows log event will also be ready, then write it to the binlog

Issue Number: close #1876 


## Tests Check List
<!-- At least one of next options must be included. -->

- [ ] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

## Changelog
<!-- At least one of next options must be included. -->

- [ ] New Feature
- [x] Bug Fix
- [ ] Performance Improvement
- [ ] Build/Testing/CI/CD
- [ ] Documentation
- [ ] Not for changelog (changelog entry is not required)

## Documentation
<!-- At least one of next options must be included. -->

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
