### PR TITLE
bugfix(tianmu): fix aggregation result incorrect when no record #1942

### DIFF
--- a/mysql-test/suite/tianmu/r/issue1784.result
+++ b/mysql-test/suite/tianmu/r/issue1784.result
@@ -81,10 +81,10 @@ age	sum(age)
 NULL	NULL
 select case when age is not null then age else 33 end, sum(age) from t1;
 case when age is not null then age else 33 end	sum(age)
-33	NULL
+NULL	NULL
 select case when age is not null then age else 33 end, sum(age) from (select * from t1) ta;
 case when age is not null then age else 33 end	sum(age)
-33	NULL
+NULL	NULL
 insert into t1 values(1);
 select * from t1;
 age

--- a/mysql-test/suite/tianmu/r/issue1942.result
+++ b/mysql-test/suite/tianmu/r/issue1942.result
@@ -1,0 +1,23 @@
+DROP DATABASE IF EXISTS issue1942_test_db;
+CREATE DATABASE issue1942_test_db;
+USE issue1942_test_db;
+CREATE TABLE t0(c0 INT);
+SELECT * FROM t0 WHERE (t0.c0 IS NULL);
+c0
+SELECT SUM(count) FROM (SELECT (t0.c0 IS NULL) IS TRUE  as count FROM t0) as res;
+SUM(count)
+NULL
+SELECT SUM(count) FROM (SELECT CAST((t0.c0 IS NULL) AS UNSIGNED)  as count FROM t0) as res;
+SUM(count)
+NULL
+INSERT INTO t0 VALUES (NULL), (1);
+SELECT * FROM t0 WHERE (t0.c0 IS NULL);
+c0
+NULL
+SELECT SUM(count) FROM (SELECT (t0.c0 IS NULL) IS TRUE  as count FROM t0) as res;
+SUM(count)
+1
+SELECT SUM(count) FROM (SELECT CAST((t0.c0 IS NULL) AS UNSIGNED)  as count FROM t0) as res;
+SUM(count)
+1
+DROP DATABASE issue1942_test_db;

--- a/mysql-test/suite/tianmu/t/issue1942.test
+++ b/mysql-test/suite/tianmu/t/issue1942.test
@@ -1,0 +1,19 @@
+--source include/have_tianmu.inc
+
+--disable_warnings
+DROP DATABASE IF EXISTS issue1942_test_db;
+--enable_warnings
+CREATE DATABASE issue1942_test_db;
+USE issue1942_test_db;
+
+CREATE TABLE t0(c0 INT);
+SELECT * FROM t0 WHERE (t0.c0 IS NULL); 
+SELECT SUM(count) FROM (SELECT (t0.c0 IS NULL) IS TRUE  as count FROM t0) as res;
+SELECT SUM(count) FROM (SELECT CAST((t0.c0 IS NULL) AS UNSIGNED)  as count FROM t0) as res;
+
+INSERT INTO t0 VALUES (NULL), (1);
+SELECT * FROM t0 WHERE (t0.c0 IS NULL); 
+SELECT SUM(count) FROM (SELECT (t0.c0 IS NULL) IS TRUE  as count FROM t0) as res;
+SELECT SUM(count) FROM (SELECT CAST((t0.c0 IS NULL) AS UNSIGNED)  as count FROM t0) as res;
+
+DROP DATABASE issue1942_test_db;

--- a/storage/tianmu/optimizer/aggregation_algorithm.cpp
+++ b/storage/tianmu/optimizer/aggregation_algorithm.cpp
@@ -167,7 +167,7 @@ void AggregationAlgorithm::Aggregate(bool just_distinct, int64_t &limit, int64_t
     gbw.AddAllCountStar(row, mit, mind->NumOfTuples());
     all_done_in_one_row = true;
 
-    {
+    if (mit.IsValid()) {
       for (int gr_a = gbw.NumOfGroupingAttrs(); gr_a < gbw.NumOfAttrs(); gr_a++) {
         TempTable::Attr &cur_a = *(t->GetAttrP(gr_a));
 


### PR DESCRIPTION
Cause:
  In the function AggregationAlgorithm::Aggregate in aggregation_algorithm.cpp,
it doesn't check validity of mit before PutAggregatedValue. Solution:
  Check validity of mit.

<!--

Thank you for contributing to StoneDB!

PR Title Format: <type>(<scope>): description to this pr (#issue_id)
e.g.
fix(util): fix sth..... (#1)

-->

## Summary about this PR
<!--

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".
e.g.:
Issue: close #1

-->

Issue Number: close #1942 


## Tests Check List
<!-- At least one of next options must be included. -->

- [ ] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

## Changelog
<!-- At least one of next options must be included. -->

- [ ] New Feature
- [x] Bug Fix
- [ ] Performance Improvement
- [ ] Build/Testing/CI/CD
- [ ] Documentation
- [ ] Not for changelog (changelog entry is not required)

## Documentation
<!-- At least one of next options must be included. -->

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
